### PR TITLE
LPS-18953 The "organization roles" column should not be shown for users t

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/user/search_columns.jspf
+++ b/portal-web/docroot/html/portlet/users_admin/user/search_columns.jspf
@@ -43,7 +43,7 @@
 />
 
 <c:choose>
-	<c:when test="<%= organizationContextView %>">
+	<c:when test="<%= organizationContextView && (organizationGroupId > 0) %>">
 		<liferay-ui:search-container-column-text
 			buffer="buffer"
 			href="<%= rowURL %>"


### PR DESCRIPTION
LPS-18953 The "organization roles" column should not be shown for users that don't belong to an organization
