### PR TITLE
LPS-18014 aui:input supports non boolean values

### DIFF
--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -1538,7 +1538,17 @@
 		Util,
 		'updateCheckboxValue',
 		function(checkbox) {
-			A.one(checkbox).previous().val(checkbox.checked);
+			checkbox = A.one(checkbox);
+
+			if (checkbox) {
+				var value = '';
+
+				if (checkbox.attr('checked')) {
+					value = checkbox.val();
+				}
+
+				checkbox.previous().val(value);
+			}
 		},
 		['aui-base']
 	);

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -76,44 +76,54 @@
 	<c:when test='<%= type.equals("checkbox") %>'>
 
 		<%
-		boolean valueBoolean = checked;
+		String valueString = String.valueOf(checked);
 
 		if (value != null) {
-			String valueString = value.toString();
+			valueString = value.toString();
+		}
 
-			valueBoolean = GetterUtil.getBoolean(valueString);
+		if (valueString.equalsIgnoreCase("false") || valueString.equalsIgnoreCase("true")) {
+			checked = GetterUtil.getBoolean(valueString);
 		}
 
 		if (!ignoreRequestValue) {
-			valueBoolean = ParamUtil.getBoolean(request, name, valueBoolean);
+			String[] requestValues = request.getParameterValues(name);
+
+			if ((requestValues != null) && !(requestValues.length > 0)) {
+				checked = requestValues[0].equalsIgnoreCase("true") || ArrayUtil.contains(requestValues, valueString);
+			}
+		}
+
+		String defaultValueString = Boolean.TRUE.toString();
+
+		if (Validator.isNotNull(valueString) && !valueString.equalsIgnoreCase("false") && !valueString.equalsIgnoreCase("true")) {
+			defaultValueString = valueString;
 		}
 		%>
 
-		<input id="<%= id %>" name="<%= namespace + name %>" type="hidden" value="<%= valueBoolean %>" />
+		<input id="<%= id %>" name="<%= namespace + name %>" type="hidden" value="<%= valueString %>" />
 
-		<input <%= valueBoolean ? "checked" : StringPool.BLANK %> class="<%= inputCss %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= id %>Checkbox" name="<%= namespace + name %>Checkbox" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> onClick="Liferay.Util.updateCheckboxValue(this); <%= onClick %>" <%= Validator.isNotNull(title) ? "title=\"" + title + "\"" : StringPool.BLANK %> type="checkbox" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= inputCss %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= id %>Checkbox" name="<%= namespace + name %>Checkbox" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> onClick="Liferay.Util.updateCheckboxValue(this); <%= onClick %>" <%= Validator.isNotNull(title) ? "title=\"" + title + "\"" : StringPool.BLANK %> type="checkbox" value="<%= defaultValueString %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
 	</c:when>
 	<c:when test='<%= type.equals("radio") %>'>
 
 		<%
-		boolean valueBoolean = checked;
-
-		String valueString = StringPool.BLANK;
+		String valueString = String.valueOf(checked);
 
 		if (value != null) {
 			valueString = value.toString();
+		}
 
-			if (!ignoreRequestValue) {
-				String requestValue = ParamUtil.getString(request, name);
+		if (!ignoreRequestValue) {
+			String requestValue = ParamUtil.getString(request, name);
 
-				if (Validator.isNotNull(requestValue)) {
-					valueBoolean = valueString.equals(requestValue);
-				}
+			if (Validator.isNotNull(requestValue)) {
+				checked = valueString.equals(requestValue);
 			}
 		}
 		%>
 
-		<input <%= valueBoolean ? "checked" : StringPool.BLANK %> class="<%= inputCss %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + title + "\"" : StringPool.BLANK %> type="radio" value="<%= valueString %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= inputCss %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + title + "\"" : StringPool.BLANK %> type="radio" value="<%= valueString %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
 	</c:when>
 	<c:when test='<%= type.equals("timeZone") %>'>
 		<span class="<%= fieldCss %>">


### PR DESCRIPTION
Hey Brian,

This is to support non boolean values in aui:input checkbox and radio. I tested it in configuration of Asset Publiser, Posting a anonymous message in message boards and following the steps described by Hashi in the ticket publishing in Staging.

This ticket should be intensively tested by automatic tests because this taglib is used in multiple places in the portal and there might be some case we haven't considered.

Thanks!
