### PR TITLE
LPS-18282

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -669,7 +669,12 @@ public class ServicePreAction extends Action {
 
 			guestLayouts = (List<Layout>)viewableLayouts[1];
 
-			layouts.addAll(0, guestLayouts);
+			if (layouts == null) {
+				layouts = guestLayouts;
+			}
+			else {
+				layouts.addAll(0, guestLayouts);
+			}
 		}
 		else {
 			HttpSession session = request.getSession();
@@ -715,7 +720,9 @@ public class ServicePreAction extends Action {
 
 				previousLayouts = (List<Layout>)viewableLayouts[1];
 
-				layouts.addAll(previousLayouts);
+				if (previousLayouts != null) {
+					layouts.addAll(previousLayouts);
+				}
 			}
 		}
 


### PR DESCRIPTION
When mergeGuestPublicPages is enabled for site or organization, layouts can be null when there is no viewable layouts which throws an exception. In this case we should still merge by setting layouts as guestLayouts.

Also, if the user was on hidden layout and move to different layout, previousLayouts can be null. In this case we do not add to layouts to prevent null point exception.
