### PR TITLE
Misuse of <hgroup> when site title and page title contribute to the outli

### DIFF
--- a/portal-web/docroot/html/themes/_unstyled/templates/portal_normal.vm
+++ b/portal-web/docroot/html/themes/_unstyled/templates/portal_normal.vm
@@ -22,7 +22,7 @@ $theme.include($body_top_include)
 	<a href="#main-content" id="skip-to-content">#language("skip-to-content")</a>
 
 	<header id="banner" role="banner">
-		<hgroup id="heading">
+		<div id="heading">
 			<h1 class="company-title">
 				<a class="$logo_css_class" href="$company_url" title="#language("go-to") $company_name">
 					<span>$company_name</span>
@@ -38,7 +38,7 @@ $theme.include($body_top_include)
 			<h3 class="page-title">
 				<span>$the_title</span>
 			</h3>
-		</hgroup>
+		</div>
 
 		#if (!$is_signed_in)
 			<a href="$sign_in_url" id="sign-in" rel="nofollow">$sign_in_text</a>


### PR DESCRIPTION
Misuse of <hgroup> when site title and page title contribute to the outline.
