### PR TITLE
LPS-22139 - Update portlet-configuration icons/links to use inline Javacript

### DIFF
--- a/portal-web/docroot/html/portal/portlet_not_setup.jsp
+++ b/portal-web/docroot/html/portal/portlet_not_setup.jsp
@@ -21,7 +21,7 @@ renderRequest.setAttribute(WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE
 %>
 
 <div class="portlet-configuration portlet-msg-info">
-	<a href="<%= portletDisplay.getURLConfiguration() %>">
+	<a href="<%= portletDisplay.getURLConfiguration() %>" onClick="<%= portletDisplay.getURLConfigurationJS() %>">
 		<liferay-ui:message key="please-configure-this-portlet-to-make-it-visible-to-all-users" />
 	</a>
 </div>

--- a/portal-web/docroot/html/portlet/dynamic_data_list_display/view.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_list_display/view.jsp
@@ -149,6 +149,7 @@ boolean showSelectListIcon = PortletPermissionUtil.contains(permissionChecker, l
 					image="configuration"
 					message="select-list"
 					method="get"
+					onClick="<%= portletDisplay.getURLConfigurationJS() %>"
 					url="<%= portletDisplay.getURLConfiguration() %>"
 				/>
 			</c:if>

--- a/portal-web/docroot/html/portlet/polls_display/view.jsp
+++ b/portal-web/docroot/html/portlet/polls_display/view.jsp
@@ -28,7 +28,7 @@ PollsQuestion question = (PollsQuestion)request.getAttribute(WebKeys.POLLS_QUEST
 		%>
 
 		<div class="portlet-configuration portlet-msg-info">
-			<a href="<%= portletDisplay.getURLConfiguration() %>">
+			<a href="<%= portletDisplay.getURLConfiguration() %>" onClick="<%= portletDisplay.getURLConfigurationJS() %>">
 				<liferay-ui:message key="please-configure-this-portlet-to-make-it-visible-to-all-users" />
 			</a>
 		</div>
@@ -171,6 +171,7 @@ boolean showIconsActions = themeDisplay.isSignedIn() && (showEditPollIcon || sho
 					image="configuration"
 					message="select-web-content"
 					method="get"
+					onClick="<%= portletDisplay.getURLConfigurationJS() %>"
 					url="<%= portletDisplay.getURLConfiguration() %>"
 				/>
 			</c:if>


### PR DESCRIPTION
Hey Nate,

Attached are the changes for the plugins to use inline Javascript for portlet-configuration icons/links. The ticket is associated to:

http://issues.liferay.com/browse/LPS-22139

Please let me know if you have any questions. Thanks!
- Jon Mak
