### PR TITLE
LPS-23297

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/dao/orm/FinderPath.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/orm/FinderPath.java
@@ -65,7 +65,7 @@ public class FinderPath {
 
 		for (Object arg : args) {
 			sb.append(StringPool.PERIOD);
-			sb.append(StringUtil.toHexString(arg));
+			sb.append(String.valueOf(arg));
 		}
 
 		CacheKeyGenerator cacheKeyGenerator =
@@ -84,7 +84,7 @@ public class FinderPath {
 
 		for (Object arg : args) {
 			sb.append(StringPool.PERIOD);
-			sb.append(StringUtil.toHexString(arg));
+			sb.append(String.valueOf(arg));
 		}
 
 		CacheKeyGenerator cacheKeyGenerator =


### PR DESCRIPTION
StringUtil.toHexString(String) != StringUtil.toHexString(Long)
can not get correct cache by using StringUtil.merge(ids) in parameter is "long[] ids" method.
