### PR TITLE
LPS-24280 Log appenders not being configured in JBoss

### DIFF
--- a/util-java/src/com/liferay/util/log4j/Log4JUtil.java
+++ b/util-java/src/com/liferay/util/log4j/Log4JUtil.java
@@ -72,14 +72,12 @@ public class Log4JUtil {
 
 		// See LPS-6029 and LPS-8865
 
-		if (!ServerDetector.isJBoss()) {
-			DOMConfigurator domConfigurator = new DOMConfigurator();
+		DOMConfigurator domConfigurator = new DOMConfigurator();
 
-			Reader urlReader = new StringReader(urlContent);
+		Reader urlReader = new StringReader(urlContent);
 
-			domConfigurator.doConfigure(
-				urlReader, LogManager.getLoggerRepository());
-		}
+		domConfigurator.doConfigure(
+			urlReader, LogManager.getLoggerRepository());
 
 		Set<String> currentLoggerNames = new HashSet<String>();
 


### PR DESCRIPTION
Per Dave Rison working on AONHEWITT-15.  Also checked with Doug regarding LPS-8865 and confirmed that full logs are still logged in server.log.
