### PR TITLE
LPS-17128: Non-instanceable portlets are able to add to page when same portlet is embedded in the theme

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -180,3 +180,11 @@ if (layout != null) {
 		);
 	</c:if>
 </aui:script>
+
+<script type="text/javascript">
+	// <![CDATA[
+		<c:if test="<%= runtimePortletIds != null && !runtimePortletIds.isEmpty() && !layoutTypePortlet.hasStateMax() %>">
+			Liferay.Portlet.runtimeList = ['<%= ListUtil.toString(portlets, Portlet.PORTLET_ID_ACCESSOR, "','") %>'];
+		</c:if>
+	// ]]>
+</script>

--- a/portal-web/docroot/html/js/liferay/dockbar.js
+++ b/portal-web/docroot/html/js/liferay/dockbar.js
@@ -591,6 +591,16 @@ AUI.add(
 									BODY.toggleClass('lfr-has-sidebar', visible);
 								};
 
+								var j, runtimePortletIds = '';
+
+								for (j = 0; j < Liferay.Portlet.runtimeList.length; j++) {
+									runtimePortletIds += Liferay.Portlet.runtimeList[j];
+
+									if (j < Liferay.Portlet.runtimeList.length) {
+										runtimePortletIds += ',';
+									}
+							    }
+
 								addApplication = instance._addUnderlay(
 									{
 										after: {
@@ -605,6 +615,7 @@ AUI.add(
 											},
 											data: {
 												doAsUserId: themeDisplay.getDoAsUserIdEncoded(),
+												runtimePortletIds: runtimePortletIds,
 												p_l_id: themeDisplay.getPlid(),
 												p_p_id: 87,
 												p_p_state: 'exclusive'

--- a/portal-web/docroot/html/js/liferay/portlet.js
+++ b/portal-web/docroot/html/js/liferay/portlet.js
@@ -7,6 +7,7 @@
 
 	var Portlet = {
 		list: [],
+		runtimeList: [],
 
 		isStatic: function(portletId) {
 			var instance = this;

--- a/portal-web/docroot/html/portlet/dockbar/view.jsp
+++ b/portal-web/docroot/html/portlet/dockbar/view.jsp
@@ -34,6 +34,8 @@ for (String portletId : PropsValues.DOCKBAR_ADD_PORTLETS) {
 		portlets.add(portlet);
 	}
 }
+
+Set<String> runtimePortletIds = (Set<String>)request.getAttribute(com.liferay.portal.kernel.util.WebKeys.RUNTIME_PORTLET_IDS);
 %>
 
 <div class="dockbar" data-namespace="<portlet:namespace />" id="dockbar">
@@ -78,6 +80,16 @@ for (String portletId : PropsValues.DOCKBAR_ADD_PORTLETS) {
 
 														boolean portletInstanceable = portlet.isInstanceable();
 														boolean portletUsed = layoutTypePortlet.hasPortletId(portlet.getPortletId());
+
+														for (String runtimePortletId : runtimePortletIds) {
+															if (runtimePortletId.equals(portlet.getPortletId()) ||
+																runtimePortletId.startsWith(
+																	portlet.getPortletId().concat(PortletConstants.INSTANCE_SEPARATOR))) {
+												
+																portletUsed = true;
+															}
+														}
+
 														boolean portletLocked = (!portletInstanceable && portletUsed);
 
 													if (!PortletPermissionUtil.contains(permissionChecker, layout, portlet.getPortletId(), ActionKeys.ADD_TO_PAGE)) {

--- a/portal-web/docroot/html/portlet/layout_configuration/view_category.jsp
+++ b/portal-web/docroot/html/portlet/layout_configuration/view_category.jsp
@@ -73,6 +73,8 @@ while (itr.hasNext()) {
 
 portlets = ListUtil.sort(portlets, new PortletTitleComparator(application, locale));
 
+String[] runtimePortletIds = request.getParameter("runtimePortletIds").split(",");
+
 if (!categories.isEmpty() || !portlets.isEmpty()) {
 %>
 
@@ -118,6 +120,16 @@ if (!categories.isEmpty() || !portlets.isEmpty()) {
 
 				boolean portletInstanceable = portlet.isInstanceable();
 				boolean portletUsed = layoutTypePortlet.hasPortletId(portlet.getPortletId());
+
+				for (String runtimePortletId : runtimePortletIds) {
+					if (runtimePortletId.equals(portlet.getPortletId()) ||
+						runtimePortletId.startsWith(
+							portlet.getPortletId().concat(PortletConstants.INSTANCE_SEPARATOR))) {
+
+						portletUsed = true;
+					}
+				}
+
 				boolean portletLocked = (!portletInstanceable && portletUsed);
 
 				if (portletInstanceable && layout.isTypePanel()) {


### PR DESCRIPTION
Hi Juan,
this is an improved handling that is considering Nate's suggestions. One note, I am putting in the separate list runtim portlets because if they arein the same list with normal portlets, then you don't know if the portlet is runtim or not. Handling on the server side is the same, you hav separete lists, so I don't see the reason why not have the same behavior on the client.
