### PR TITLE
LPS-24057 JavadocFormatter --update option

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -360,7 +360,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 			newenvironment="true"
 		>
 			<jvmarg value="-Xmx128m" />
-			<arg line="--limit ${limit} --init ${init}" />
+			<arg line="--limit ${limit} --init ${init} --update ${update}" />
 		</java>
 	</target>
 

--- a/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
+++ b/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
@@ -83,14 +83,21 @@ public class JavadocFormatter {
 			"limit");
 		CmdLineParser.Option initOption = cmdLineParser.addStringOption(
 			"init");
+		CmdLineParser.Option updateOption = cmdLineParser.addStringOption(
+			"update");
 
 		cmdLineParser.parse(args);
 
 		String limit = (String)cmdLineParser.getOptionValue(limitOption);
 		String init = (String)cmdLineParser.getOptionValue(initOption);
+		String update = (String)cmdLineParser.getOptionValue(updateOption);
 
 		if (Validator.isNotNull(init) && !init.startsWith("$")) {
 			_initializeMissingJavadocs = GetterUtil.getBoolean(init);
+		}
+
+		if (Validator.isNotNull(update) && !update.startsWith("$")) {
+			_updateJavadocs = GetterUtil.getBoolean(update);
 		}
 
 		DirectoryScanner ds = new DirectoryScanner();
@@ -255,6 +262,15 @@ public class JavadocFormatter {
 		if (_initializeMissingJavadocs) {
 			maxTagNameLengthTags.addAll(allTagNames);
 		}
+		else if (_updateJavadocs) {
+			if (!commonTagNamesWithComments.isEmpty()) {
+				maxTagNameLengthTags.addAll(allTagNames);
+			}
+			else {
+				maxTagNameLengthTags.addAll(commonTagNamesWithComments);
+				maxTagNameLengthTags.addAll(customTagNames);
+			}
+		}
 		else {
 			maxTagNameLengthTags.addAll(commonTagNamesWithComments);
 			maxTagNameLengthTags.addAll(customTagNames);
@@ -311,6 +327,35 @@ public class JavadocFormatter {
 							tagNameIndent);
 
 						sb.append(comment);
+					}
+					else if (_updateJavadocs && publicAccess) {
+						if (!tagName.equals("param") &&
+							!tagName.equals("return") &&
+							!tagName.equals("throws")) {
+
+							// Write out custom tag name
+
+							comment = _assembleTagComment(
+								tagName, elementName, comment, indent,
+								tagNameIndent);
+
+							sb.append(comment);
+						}
+						else if (!commonTagNamesWithComments.isEmpty()) {
+
+							// Write out all tags
+
+							comment = _assembleTagComment(
+								tagName, elementName, comment, indent,
+								tagNameIndent);
+
+							sb.append(comment);
+						}
+						else {
+
+							// Skip empty common tag name
+
+						}
 					}
 					else {
 						if (!tagName.equals("param") &&
@@ -1457,5 +1502,6 @@ public class JavadocFormatter {
 	private boolean _initializeMissingJavadocs;
 	private Map<String, Tuple> _javadocxXmlTuples =
 		new HashMap<String, Tuple>();
+	private boolean _updateJavadocs;
 
 }


### PR DESCRIPTION
Adds option to "update" Javadocs for a method. In other words, if a method has some but not all of its signature elements (i.e. params, return, or exceptions) represented in its Javadoc, then the JavadocFormatter will insert the missing Javadoc tags. This should be especially helpful for an engineer to run after modifying signatures of existing methods.

To run, execute ... ant format-javadoc -Dlimit=SomeClass -Dupdate=true
