### PR TITLE
LPS-25793 The call back methods from jgroups should always be invoked after ClusterExecutor is fully initialized.

### DIFF
--- a/portal-impl/src/com/liferay/portal/cluster/ClusterExecutorImpl.java
+++ b/portal-impl/src/com/liferay/portal/cluster/ClusterExecutorImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.cluster.ClusterNodeResponse;
 import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.cluster.FutureClusterResponses;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.executor.PortalExecutorManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InetAddressUtil;
@@ -50,6 +51,7 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 
 import org.jgroups.ChannelException;
 import org.jgroups.JChannel;
@@ -91,6 +93,8 @@ public class ClusterExecutorImpl
 		}
 
 		_controlChannel.close();
+		_parallelExecutorService.shutdownNow();
+		_clusterRequestReceiver.destroy();
 	}
 
 	public FutureClusterResponses execute(ClusterRequest clusterRequest)
@@ -189,6 +193,12 @@ public class ClusterExecutorImpl
 			_log.error("Unable to determine local network address", se);
 		}
 
+		_clusterRequestReceiver.initialize();
+
+		_parallelExecutorService =
+			PortalExecutorManagerUtil.getPortalExecutor(
+				ClusterExecutorImpl.class.getName() + "_parallel");
+
 		memberJoined(_localAddress, _localClusterNode);
 
 		sendNotifyRequest();
@@ -272,7 +282,8 @@ public class ClusterExecutorImpl
 
 	protected void fireClusterEvent(ClusterEvent clusterEvent) {
 		for (ClusterEventListener listener : _clusterEventListeners) {
-			listener.processClusterEvent(clusterEvent);
+			_parallelExecutorService.submit(
+				new ClusterEventTask(listener, clusterEvent));
 		}
 	}
 
@@ -292,12 +303,12 @@ public class ClusterExecutorImpl
 		String controlProperty = controlProperties.getProperty(
 			PropsKeys.CLUSTER_LINK_CHANNEL_PROPERTIES_CONTROL);
 
-		ClusterRequestReceiver clusterRequestReceiver =
-			new ClusterRequestReceiver(this);
+		 _clusterRequestReceiver = new ClusterRequestReceiver(this);
 
 		try {
 			_controlChannel = createJChannel(
-				controlProperty, clusterRequestReceiver, _DEFAULT_CLUSTER_NAME);
+				controlProperty, _clusterRequestReceiver, 
+				_DEFAULT_CLUSTER_NAME);
 		}
 		catch (ChannelException ce) {
 			_log.error(ce, ce);
@@ -503,6 +514,7 @@ public class ClusterExecutorImpl
 		new CopyOnWriteArrayList<ClusterEventListener>();
 	private Map<String, Address> _clusterNodeAddresses =
 		new ConcurrentHashMap<String, Address>();
+	private ClusterRequestReceiver _clusterRequestReceiver;
 	private volatile JChannel _controlChannel;
 	private CountDownLatch _countDownLatch = new CountDownLatch(1);
 	private Map<String, FutureClusterResponses> _futureClusterResponses =
@@ -511,6 +523,26 @@ public class ClusterExecutorImpl
 		new ConcurrentHashMap<Address, ClusterNode>();
 	private volatile Address _localAddress;
 	private volatile ClusterNode _localClusterNode;
+	private ExecutorService _parallelExecutorService;
 	private volatile boolean _shortcutLocalMethod;
+
+	private class ClusterEventTask implements Runnable {
+
+		public ClusterEventTask(
+			ClusterEventListener clusterEventListener, 
+			ClusterEvent clusterEvent) {
+
+			_clusterEvent = clusterEvent;
+			_clusterEventListener = clusterEventListener;
+		}
+
+		public void run() {
+			_clusterEventListener.processClusterEvent(_clusterEvent);
+		}
+
+		private ClusterEvent _clusterEvent;
+		private ClusterEventListener _clusterEventListener;
+
+	}
 
 }

--- a/portal-impl/src/com/liferay/portal/cluster/ClusterRequestReceiver.java
+++ b/portal-impl/src/com/liferay/portal/cluster/ClusterRequestReceiver.java
@@ -26,6 +26,8 @@ import com.liferay.portal.kernel.cluster.FutureClusterResponses;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.NamedThreadFactory;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
@@ -33,6 +35,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.jgroups.Channel;
 import org.jgroups.ChannelException;
@@ -47,6 +51,17 @@ public class ClusterRequestReceiver extends BaseReceiver {
 
 	public ClusterRequestReceiver(ClusterExecutorImpl clusterExecutorImpl) {
 		_clusterExecutorImpl = clusterExecutorImpl;
+	}
+
+	public void destroy() {
+		_executorService.shutdownNow();
+	}
+
+	public void initialize() {
+		_executorService = Executors.newSingleThreadExecutor(
+			new NamedThreadFactory(
+				ClusterRequestReceiver.class.getName() + "_serial", 
+				Thread.NORM_PRIORITY, PortalClassLoaderUtil.getClassLoader()));
 	}
 
 	@Override
@@ -82,7 +97,10 @@ public class ClusterRequestReceiver extends BaseReceiver {
 		if (obj instanceof ClusterRequest) {
 			ClusterRequest clusterRequest = (ClusterRequest)obj;
 
-			processClusterRequest(clusterRequest, sourceAddress, localAddress);
+			ClusterRequestReceiver.RequestTask requestTask = new RequestTask(
+				clusterRequest, sourceAddress, localAddress);
+
+			_executorService.execute(requestTask);
 		}
 		else if (obj instanceof ClusterNodeResponse) {
 			ClusterNodeResponse clusterNodeResponse = (ClusterNodeResponse)obj;
@@ -389,6 +407,29 @@ public class ClusterRequestReceiver extends BaseReceiver {
 		ClusterRequestReceiver.class);
 
 	private ClusterExecutorImpl _clusterExecutorImpl;
+	private volatile ExecutorService _executorService;
 	private volatile View _lastView;
+
+	private class RequestTask implements Runnable {
+
+		public RequestTask(
+			ClusterRequest clusterRequest, org.jgroups.Address sourceAddress,
+			org.jgroups.Address localAddress) {
+
+			_clusterRequest = clusterRequest;
+			_sourceAddress = sourceAddress;
+			_localAddress = localAddress;
+		}
+
+		public void run() {
+			processClusterRequest(
+				_clusterRequest, _sourceAddress, _localAddress);
+		}
+
+		private ClusterRequest _clusterRequest;
+		private org.jgroups.Address _localAddress;
+		private org.jgroups.Address _sourceAddress;
+
+	}
 
 }


### PR DESCRIPTION
The call back methods from jgroups in ClusterRequestReceiver are using variables that initialized in ClusterExecutor.initialize(), they may be invoked before or during ClusterExecutor.initialize().
