### PR TITLE
[TECHNICAL SUPPORT]

### DIFF
--- a/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
@@ -234,7 +234,8 @@ public class FlagsRequestMessageListener extends BaseMessageListener {
 			"[$REPORTED_USER_ADDRESS$]", reportedEmailAddress,
 			"[$REPORTED_USER_NAME$]", reportedUserName, "[$REPORTED_USER_URL$]",
 			reportedUserURL, "[$REPORTER_USER_ADDRESS$]", reporterEmailAddress,
-			"[$REPORTER_USER_NAME$]", reporterUserName);
+			"[$REPORTER_USER_NAME$]", reporterUserName, "[$SITE_NAME$]",
+			groupName);
 		subscriptionSender.setFrom(fromAddress, fromName);
 		subscriptionSender.setHtmlFormat(true);
 		subscriptionSender.setMailId("flags_request", contentId);


### PR DESCRIPTION
LPS-26383 When user add a blog entry on the Blog porlet and "Flag" it on the UI then the email will use the default template and the [$SITE_NAME$] parameter does not fill with any value

cc-ing ZBerentey: @zberentey
