### PR TITLE
[TECHNICAL SUPPORT] LPS-26232

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/search/FileEntryDisplayTerms.java
+++ b/portal-impl/src/com/liferay/portlet/journal/search/FileEntryDisplayTerms.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.journal.search;
+
+import com.liferay.portal.kernel.dao.search.DisplayTerms;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Vilmos Papp
+ */
+public class FileEntryDisplayTerms extends DisplayTerms {
+
+	public static final String DOCUMENT = "document";
+
+	public static final String DOWNLOADS = "downloads";
+
+	public static final String LOCKED = "locked";
+
+	public static final String SELECTED_GROUP_ID = "selectedGroupId";
+
+	public static final String SIZE = "size";
+
+	public FileEntryDisplayTerms(PortletRequest portletRequest) {
+		super(portletRequest);
+
+		document = ParamUtil.getString(portletRequest, DOCUMENT);
+		downloads = ParamUtil.getInteger(portletRequest, DOWNLOADS);
+		selectedGroupId = ParamUtil.getLong(portletRequest, SELECTED_GROUP_ID);
+		locked = ParamUtil.getBoolean(portletRequest, LOCKED);
+		size = ParamUtil.getString(portletRequest, SIZE);
+	}
+
+	public String getDocument() {
+		return document;
+	}
+
+	public int getDownloads() {
+		return downloads;
+	}
+
+	public long getSelectedGroupId() {
+		return selectedGroupId;
+	}
+
+	public String getSize() {
+		return size;
+	}
+
+	public boolean isLocked() {
+		return locked;
+	}
+
+	public void setSelectedGroupId(long selectedGroupId) {
+		this.selectedGroupId = selectedGroupId;
+	}
+
+	protected String document;
+	protected int downloads;
+	protected boolean locked;
+	protected long selectedGroupId;
+	protected String size;
+
+}

--- a/portal-impl/src/com/liferay/portlet/journal/search/FileEntrySearch.java
+++ b/portal-impl/src/com/liferay/portlet/journal/search/FileEntrySearch.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.journal.search;
+
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Vilmos Papp
+ */
+public class FileEntrySearch extends SearchContainer<FileEntry> {
+
+	static List<String> headerNames = new ArrayList<String>();
+
+	static {
+		headerNames.add("document");
+		headerNames.add("size");
+		headerNames.add("downloads");
+		headerNames.add("locked");
+	}
+
+	public static final String EMPTY_RESULTS_MESSAGE = "there-are-no-documents";
+
+	public FileEntrySearch(
+		PortletRequest portletRequest, FileEntryDisplayTerms displayTerms,
+		FileEntrySearchTerms searchTerms, String cur, int delta,
+		PortletURL iteratorURL, List<String> headers,
+		String emptyResultsMessage) {
+
+		super(
+			portletRequest, new FileEntryDisplayTerms(portletRequest),
+			new FileEntrySearchTerms(portletRequest), cur, delta, iteratorURL,
+			headers, emptyResultsMessage);
+
+		iteratorURL.setParameter(
+			FileEntryDisplayTerms.DOCUMENT, displayTerms.getDocument());
+		iteratorURL.setParameter(
+			FileEntryDisplayTerms.SELECTED_GROUP_ID,
+			String.valueOf(displayTerms.getSelectedGroupId()));
+		iteratorURL.setParameter(
+			FileEntryDisplayTerms.SIZE, displayTerms.getSize());
+		iteratorURL.setParameter(
+			FileEntryDisplayTerms.LOCKED,
+			String.valueOf(displayTerms.isLocked()));
+	}
+
+	public FileEntrySearch(
+		PortletRequest portletRequest, int delta, PortletURL iteratorURL) {
+
+		this(
+			portletRequest, new FileEntryDisplayTerms(portletRequest),
+			new FileEntrySearchTerms(portletRequest), DEFAULT_CUR_PARAM, delta,
+			iteratorURL, headerNames, EMPTY_RESULTS_MESSAGE);
+	}
+
+	public FileEntrySearch(
+		PortletRequest portletRequest, PortletURL iteratorURL) {
+
+		this(portletRequest, DEFAULT_DELTA, iteratorURL);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/journal/search/FileEntrySearchTerms.java
+++ b/portal-impl/src/com/liferay/portlet/journal/search/FileEntrySearchTerms.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.journal.search;
+
+import com.liferay.portal.kernel.dao.search.DAOParamUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Vilmos Papp
+ */
+public class FileEntrySearchTerms extends FileEntryDisplayTerms {
+
+	public FileEntrySearchTerms(PortletRequest portletRequest) {
+		super(portletRequest);
+
+		document = DAOParamUtil.getString(portletRequest, DOCUMENT);
+		downloads = ParamUtil.getInteger(portletRequest, DOWNLOADS);
+		selectedGroupId = DAOParamUtil.getLong(
+			portletRequest, SELECTED_GROUP_ID);
+
+		locked = DAOParamUtil.getBoolean(portletRequest, LOCKED);
+		size = DAOParamUtil.getString(portletRequest, SIZE);
+	}
+
+	public void setSelectedGroupId(long selectedGroupId) {
+		this.selectedGroupId = selectedGroupId;
+	}
+
+}

--- a/portal-web/docroot/html/portlet/document_library/init.jsp
+++ b/portal-web/docroot/html/portlet/document_library/init.jsp
@@ -95,6 +95,8 @@ page import="com.liferay.portlet.dynamicdatamapping.storage.Fields" %><%@
 page import="com.liferay.portlet.dynamicdatamapping.storage.StorageEngineUtil" %><%@
 page import="com.liferay.portlet.dynamicdatamapping.util.DDMXSDUtil" %><%@
 page import="com.liferay.portlet.dynamicdatamapping.util.comparator.StructureStructureKeyComparator" %><%@
+page import="com.liferay.portlet.journal.search.FileEntryDisplayTerms" %><%@
+page import="com.liferay.portlet.journal.search.FileEntrySearch" %><%@
 page import="com.liferay.portlet.usersadmin.search.GroupSearch" %>
 
 <%

--- a/portal-web/docroot/html/portlet/document_library_display/init.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/init.jsp
@@ -41,7 +41,10 @@ page import="com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil" 
 page import="com.liferay.portlet.documentlibrary.service.DLAppServiceUtil" %><%@
 page import="com.liferay.portlet.documentlibrary.service.DLFileEntryTypeLocalServiceUtil" %><%@
 page import="com.liferay.portlet.documentlibrary.service.permission.DLFileEntryPermission" %><%@
-page import="com.liferay.portlet.documentlibrary.util.DLUtil" %>
+page import="com.liferay.portlet.documentlibrary.util.DLUtil" %><%@
+page import="com.liferay.portlet.journal.search.FileEntryDisplayTerms" %><%@
+page import="com.liferay.portlet.journal.search.FileEntrySearch" %><%@
+page import="com.liferay.portlet.journal.search.FileEntrySearchTerms" %>
 
 <%
 PortletPreferences preferences = renderRequest.getPreferences();

--- a/portal-web/docroot/html/portlet/journal/file_entry_search.jsp
+++ b/portal-web/docroot/html/portlet/journal/file_entry_search.jsp
@@ -1,0 +1,38 @@
+<%--
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/portlet/document_library/init.jsp" %>
+
+<%
+FileEntrySearch searchContainer = (FileEntrySearch)request.getAttribute("liferay-ui:search:searchContainer");
+
+FileEntryDisplayTerms displayTerms = (FileEntryDisplayTerms)searchContainer.getDisplayTerms();
+%>
+
+<liferay-ui:search-toggle
+	buttonLabel="search"
+	displayTerms="<%= displayTerms %>"
+	id="toggle_id_asset_search"
+>
+	<aui:fieldset>
+		<aui:input name="keywords" size="20" type="text" value="" />
+
+		<aui:select label="scope" name="<%= displayTerms.SELECTED_GROUP_ID %>" showEmptyOption="<%= false %>">
+			<aui:option label="global" selected="<%= displayTerms.getSelectedGroupId() == themeDisplay.getCompanyGroupId() %>" value="<%= themeDisplay.getCompanyGroupId() %>" />
+			<aui:option label="<%= themeDisplay.getScopeGroupName() %>" selected="<%= displayTerms.getSelectedGroupId() == scopeGroupId %>" value="<%= scopeGroupId %>" />
+		</aui:select>
+	</aui:fieldset>
+</liferay-ui:search-toggle>

--- a/portal-web/docroot/html/portlet/journal/select_document_library.jsp
+++ b/portal-web/docroot/html/portlet/journal/select_document_library.jsp
@@ -21,7 +21,32 @@ Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 long folderId = BeanParamUtil.getLong(folder, request, "folderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-long groupId = ParamUtil.getLong(request, "groupId");
+long searchFolderIds = ParamUtil.getLong(request, "searchFolderIds");
+
+long[] folderIdsArray = null;
+
+long groupId = ParamUtil.getLong(request, FileEntryDisplayTerms.SELECTED_GROUP_ID);
+
+if (groupId == 0) {
+	groupId = ParamUtil.getLong(request, "groupId");
+}
+
+if (folderId > 0) {
+	folderIdsArray = new long[] {folderId};
+
+	folder = DLAppServiceUtil.getFolder(folderId);
+}
+else {
+	long defaultFolderId = DLFolderConstants.getFolderId(groupId, DLFolderConstants.getDataRepositoryId(groupId, searchFolderIds));
+
+	List<Long> folderIds = DLAppServiceUtil.getSubfolderIds(groupId, searchFolderIds);
+
+	folderIds.add(0, defaultFolderId);
+
+	folderIdsArray = StringUtil.split(StringUtil.merge(folderIds), 0L);
+}
+
+String keywords = ParamUtil.getString(request, "keywords");
 
 long repositoryId = groupId;
 
@@ -29,18 +54,36 @@ if (folder != null) {
 	repositoryId = folder.getRepositoryId();
 }
 
+int entryStart = ParamUtil.getInteger(request, "entryStart");
+int entryEnd = ParamUtil.getInteger(request, "entryEnd", PropsValues.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA);
+
 PortletURL portletURL = renderResponse.createRenderURL();
 
 portletURL.setParameter("struts_action", "/journal/select_document_library");
 portletURL.setParameter("folderId", String.valueOf(folderId));
 portletURL.setParameter("groupId", String.valueOf(groupId));
-
+_log.info(portletURL.toString());
 if (folder != null) {
 	DLUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 }
+
 %>
 
 <aui:form method="post" name="fm">
+
+	<%
+		FileEntrySearch fileEntrySearchContainer = new FileEntrySearch(renderRequest, portletURL);
+
+		FileEntryDisplayTerms displayTerms = (FileEntryDisplayTerms)fileEntrySearchContainer.getDisplayTerms();
+		FileEntrySearchTerms searchTerms = (FileEntrySearchTerms)fileEntrySearchContainer.getSearchTerms();
+		displayTerms.setSelectedGroupId(groupId);
+	%>
+
+	<liferay-ui:search-form
+		page="/html/portlet/journal/file_entry_search.jsp"
+		searchContainer="<%= fileEntrySearchContainer %>"
+	/>
+
 	<liferay-ui:header
 		title="folders"
 	/>
@@ -129,84 +172,138 @@ if (folder != null) {
 	headerNames.add("locked");
 	headerNames.add(StringPool.BLANK);
 
-	searchContainer = new SearchContainer(renderRequest, null, null, "cur2", SearchContainer.DEFAULT_DELTA, portletURL, headerNames, "there-are-no-documents-in-this-folder");
+	fileEntrySearchContainer = new FileEntrySearch(renderRequest, displayTerms, searchTerms, "cur2", SearchContainer.DEFAULT_DELTA, portletURL, headerNames, "there-are-no-documents-in-this-folder");
 
-	total = DLAppServiceUtil.getFileEntriesCount(groupId, folderId);
+	try {
 
-	searchContainer.setTotal(total);
+		SearchContext searchContext = SearchContextFactory.getInstance(request);
 
-	results = DLAppServiceUtil.getFileEntries(repositoryId, folderId, searchContainer.getStart(), searchContainer.getEnd());
+		searchContext.setAttribute("groupId",groupId);
+		searchContext.setAttribute("paginationType", "regular");
+		searchContext.setEnd(entryEnd);
+		searchContext.setFolderIds(folderIdsArray);
+		searchContext.setGroupIds(new long[] {groupId});
+		searchContext.setKeywords(keywords);
+		searchContext.setStart(entryStart);
 
-	searchContainer.setResults(results);
+		searchContext.setScopeStrict(false);
 
-	resultRows = searchContainer.getResultRows();
+		Hits hits = DLAppServiceUtil.search(repositoryId, searchContext);
 
-	for (int i = 0; i < results.size(); i++) {
-		FileEntry fileEntry = (FileEntry)results.get(i);
+		results = new ArrayList();
 
-		ResultRow row = new ResultRow(fileEntry, fileEntry.getFileEntryId(), i);
+		fileEntrySearchContainer.getResultRows().clear();
 
-		String rowHREF = DLUtil.getPreviewURL(fileEntry, fileEntry.getFileVersion(), themeDisplay, StringPool.BLANK, false, true);
+		resultRows = fileEntrySearchContainer.getResultRows();
 
-		// Title
+		Document[] docs = hits.getDocs();
 
-		StringBundler sb = new StringBundler(10);
+		if (docs != null) {
+			for (Document doc : docs) {
 
-		sb.append("<img alt=\"\" align=\"left\" border=\"0\" src=\"");
+				// Folder and document
 
-		DLFileShortcut fileShortcut = null;
+				long fileEntryId = GetterUtil.getLong(doc.get(Field.ENTRY_CLASS_PK));
 
-		String thumbnailSrc = DLUtil.getThumbnailSrc(fileEntry, fileShortcut, themeDisplay);
+				FileEntry fileEntry = null;
 
-		sb.append(thumbnailSrc);
-		sb.append("\" style=\"");
+				try {
+					fileEntry = DLAppLocalServiceUtil.getFileEntry(fileEntryId);
+				}
+				catch (Exception e) {
+					if (_log.isWarnEnabled()) {
+						_log.warn("Documents and Media search index is stale and contains file entry {" + fileEntryId + "}");
+					}
 
-		String thumbnailStyle = DLUtil.getThumbnailStyle();
+					continue;
+				}
 
-		sb.append(thumbnailStyle);
-		sb.append("\">");
-		sb.append(fileEntry.getTitle());
+				results.add(fileEntry);
+			}
 
-		row.addText(sb.toString(), rowHREF);
-
-		// Statistics
-
-		row.addText(TextFormatter.formatKB(fileEntry.getSize(), locale) + "k", rowHREF);
-
-		if (PropsValues.DL_FILE_ENTRY_READ_COUNT_ENABLED) {
-			row.addText(String.valueOf(fileEntry.getReadCount()), rowHREF);
+			if (docs.length == 0) {
+				request.removeAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
+			}
 		}
 
-		// Locked
+		total = hits.getLength();
 
-		boolean isCheckedOut = fileEntry.isCheckedOut();
+		fileEntrySearchContainer.setResults(results);
+		fileEntrySearchContainer.setTotal(total);
 
-		row.addText(LanguageUtil.get(pageContext, isCheckedOut ? "yes" : "no"), rowHREF);
+		for (int i = 0; i < results.size(); i++) {
+			FileEntry fileEntry = (FileEntry)results.get(i);
 
-		// Action
+			ResultRow row = new ResultRow(fileEntry, fileEntry.getFileEntryId(), i);
 
-		sb.setIndex(0);
+			String rowHREF = DLUtil.getPreviewURL(fileEntry, fileEntry.getFileVersion(), themeDisplay, StringPool.BLANK, false, true);
 
-		sb.append("Liferay.Util.getOpener().");
-		sb.append(renderResponse.getNamespace());
-		sb.append("selectDocumentLibrary('");
-		sb.append(themeDisplay.getPathContext());
-		sb.append(DLUtil.getPreviewURL(fileEntry, fileEntry.getFileVersion(), themeDisplay, StringPool.BLANK, false, false));
-		sb.append("', '");
-		sb.append(fileEntry.getUuid());
-		sb.append("', '");
-		sb.append(fileEntry.getTitle());
-		sb.append("', '");
-		sb.append(fileEntry.getVersion());
-		sb.append("'); Liferay.Util.getWindow().close();");
+			// Title
 
-		row.addButton("right", SearchEntry.DEFAULT_VALIGN, LanguageUtil.get(pageContext, "choose"), sb.toString());
+			StringBundler sb = new StringBundler(10);
 
-		// Add result row
+			sb.append("<img alt=\"\" align=\"left\" border=\"0\" src=\"");
 
-		resultRows.add(row);
+			DLFileShortcut fileShortcut = null;
+
+			String thumbnailSrc = DLUtil.getThumbnailSrc(fileEntry, fileShortcut, themeDisplay);
+
+			sb.append(thumbnailSrc);
+			sb.append("\" style=\"");
+
+			String thumbnailStyle = DLUtil.getThumbnailStyle();
+
+			sb.append(thumbnailStyle);
+			sb.append("\">");
+			sb.append(fileEntry.getTitle());
+
+			row.addText(sb.toString(), rowHREF);
+
+			// Statistics
+
+			row.addText(TextFormatter.formatKB(fileEntry.getSize(), locale) + "k", rowHREF);
+
+			if (PropsValues.DL_FILE_ENTRY_READ_COUNT_ENABLED) {
+				row.addText(String.valueOf(fileEntry.getReadCount()), rowHREF);
+			}
+
+			// Locked
+
+			boolean isCheckedOut = fileEntry.isCheckedOut();
+
+			row.addText(LanguageUtil.get(pageContext, isCheckedOut ? "yes" : "no"), rowHREF);
+
+			// Action
+
+			sb.setIndex(0);
+
+			sb.append("Liferay.Util.getOpener().");
+			sb.append(renderResponse.getNamespace());
+			sb.append("selectDocumentLibrary('");
+			sb.append(themeDisplay.getPathContext());
+			sb.append(DLUtil.getPreviewURL(fileEntry, fileEntry.getFileVersion(), themeDisplay, StringPool.BLANK, false, false));
+			sb.append("', '");
+			sb.append(fileEntry.getUuid());
+			sb.append("', '");
+			sb.append(fileEntry.getTitle());
+			sb.append("', '");
+			sb.append(fileEntry.getVersion());
+			sb.append("'); Liferay.Util.getWindow().close();");
+
+			row.addButton("right", SearchEntry.DEFAULT_VALIGN, LanguageUtil.get(pageContext, "choose"), sb.toString());
+
+			// Add result row
+
+			resultRows.add(row);
+		}
+	}
+	catch (Exception e) {
+		_log.error(e, e);
 	}
 	%>
 
-	<liferay-ui:search-iterator searchContainer="<%= searchContainer %>" />
+	<liferay-ui:search-iterator searchContainer="<%= fileEntrySearchContainer %>" />
 </aui:form>
+<%!
+private static Log _log = LogFactoryUtil.getLog("portal-web.docroot.html.portlet.journal.select_document_library_jsp");
+%>


### PR DESCRIPTION
Hi Máté,

cc-ing Zberentey : @zberentey

When editing a web content which has a structure with a Documents And Media filed, there wasn't an option to select document from the Global scope meanwhile it works through CKEditor if there's no structure defined for the web content.

As we discussed, I implemented the pattern mostly from the asset_search but had to add some logic from document_library's searching as well because there's needed to do some conversion from Hits to ResultRow items.

Regards,
Vilmos
