### PR TITLE
LPS-26352: Adding defensive code to prevent NPEs in case of strange creole source

### DIFF
--- a/portal-impl/src/com/liferay/portal/parsers/creole/visitor/impl/XhtmlTranslationVisitor.java
+++ b/portal-impl/src/com/liferay/portal/parsers/creole/visitor/impl/XhtmlTranslationVisitor.java
@@ -264,7 +264,9 @@ public class XhtmlTranslationVisitor implements ASTVisitor {
 	protected void traverse(List<ASTNode> astNodes) {
 		if (astNodes != null) {
 			for (ASTNode astNode : astNodes) {
-				astNode.accept(this);
+				if (astNode != null) {
+					astNode.accept(this);
+				}
 			}
 		}
 	}
@@ -283,7 +285,9 @@ public class XhtmlTranslationVisitor implements ASTVisitor {
 		for (ASTNode curNode : astNodes) {
 			append(open);
 
-			curNode.accept(this);
+			if (curNode != null) {
+				curNode.accept(this);
+			}
 
 			append(close);
 		}


### PR DESCRIPTION
Added a check for null values to prevent NullPointerExceptions in cases of Creole table cells with only '**' in them
