### PR TITLE
LPS-27097 Fix the Secure RSS Filter URL regex pattern for the asset publisher

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -338,7 +338,7 @@
 		</init-param>
 		<init-param>
 			<param-name>url-regex-pattern</param-name>
-			<param-value>.+/(activities|asset_publisher/\p{Alnum}{4}|blogs|journal|message_boards|wiki)/rss.*</param-value>
+			<param-value>.+/(activities|asset_publisher/\p{Alnum}{4,12}|blogs|journal|message_boards|wiki)/rss.*</param-value>
 		</init-param>
 	</filter>
 	<filter>


### PR DESCRIPTION
The instance IDs were increased from 4 to 12. Fix the pattern to match
instance IDs that are 4-12 characters long.
