### PR TITLE
LPS-27098 Extract the localized summary in the asset publisher RSS feed

### DIFF
--- a/portal-impl/src/com/liferay/portlet/assetpublisher/action/RSSAction.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/action/RSSAction.java
@@ -113,20 +113,20 @@ public class RSSAction extends PortletAction {
 				PortalUtil.getUserName(
 					assetEntry.getUserId(), assetEntry.getUserName()));
 
+			String languageId = LanguageUtil.getLanguageId(portletRequest);
+
 			String value = null;
 
 			if (displayStyle.equals(RSSUtil.DISPLAY_STYLE_TITLE)) {
 				value = StringPool.BLANK;
 			}
 			else {
-				value = assetEntry.getSummary();
+				value = assetEntry.getSummary(languageId, true);
 			}
 
 			SyndEntry syndEntry = new SyndEntryImpl();
 
 			syndEntry.setAuthor(author);
-
-			String languageId = LanguageUtil.getLanguageId(portletRequest);
 
 			syndEntry.setTitle(assetEntry.getTitle(languageId, true));
 


### PR DESCRIPTION
Fixes the RSS feed's entry summary to have the localized summary for
asset entries instead of the XML-formatted string Liferay uses for
persisting localized values.
