### PR TITLE
LPS-19328 Drag&Drop doesn't work for borderless portlet without title 

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/portlet.css
+++ b/portal-web/docroot/html/themes/_styled/css/portlet.css
@@ -105,6 +105,8 @@ body.portlet {
 
 	.portlet-title-default, .portlet-actions {
 		vertical-align: top;
+        min-height: 20px;
+        min-width: 20px;
 	}
 
 	.portlet-action-separator {


### PR DESCRIPTION
Hi Nate,

Although I'm no CSS / JS guru I tried to fix http://issues.liferay.com/browse/LPS-19328 :) Is it OK?

Thank you.

-- tom
