### PR TITLE
LPS-27983 fix for DLPortletDataHandler

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandlerImpl.java
@@ -1669,10 +1669,13 @@ public class DLPortletDataHandlerImpl extends BasePortletDataHandler {
 		List<DDMStructure> ddmStructures = dlFileEntryType.getDDMStructures();
 
 		for (DDMStructure ddmStructure : ddmStructures) {
-			Element structureFieldsElement =
-				(Element)fileEntryElement.selectSingleNode(
-					"//structure-fields[@structureUuid='".concat(
-						ddmStructure.getUuid()).concat("']"));
+			Document currentFileEntrydocument = SAXReaderUtil
+					.read(fileEntryElement.asXML());
+
+			Element structureFieldsElement = (Element) currentFileEntrydocument
+					.getRootElement().selectSingleNode(
+							"//structure-fields[@structureUuid='".concat(
+									ddmStructure.getUuid()).concat("']"));
 
 			if (structureFieldsElement == null) {
 				continue;


### PR DESCRIPTION
Changed the logic for obtaining the structureFieldsElement in the importMetatData method.  The xPath Expression used in the previous logic was always finding the first structure field for a given structureUuid which meant that all documents were getting the same metaData.  
