### PR TITLE
LPS-29119 SQLException Webcontent Control Panel

### DIFF
--- a/portal-impl/src/custom-sql/journal.xml
+++ b/portal-impl/src/custom-sql/journal.xml
@@ -221,7 +221,7 @@
 	<sql id="com.liferay.portlet.journal.service.persistence.JournalFolderFinder.findF_ByG_F">
 		<![CDATA[
 			SELECT
-				DISTINCT folderId AS modelFolderId, JournalFolder.createDate as createDate, JournalFolder.createDate as displayDate, JournalFolder.modifiedDate as modifiedDate, 0 AS articleId, 0 AS version, JournalFolder.name AS title, 1 AS modelFolder
+				DISTINCT folderId AS modelFolderId, JournalFolder.createDate as createDate, JournalFolder.modifiedDate as modifiedDate, 0 AS articleId, 0 AS version, JournalFolder.name AS title, JournalFolder.createDate as displayDate, 1 AS modelFolder
 			FROM
 				JournalFolder
 			WHERE


### PR DESCRIPTION
The source formatting at 3ca4ee3cd77b9d226bc0e5a5bf40160ae3a8a046 was applied to findA_ByG_F, but not to findF_ByG_F, leaving the UNION ALL at JournalFolderFinderImpl.doFindF_AByG_F unbalanced.
