### PR TITLE
Dev

### DIFF
--- a/sql/sql.properties
+++ b/sql/sql.properties
@@ -56,7 +56,7 @@
 ## MySQL
 ##
 
-    mysql.arg.line=-u ${mysql.user} -p ${mysql.password}
+    mysql.arg.line=-u ${mysql.user} -p${mysql.password}
     mysql.executable=mysql
     mysql.input=create${minimal.suffix}/create${minimal.suffix}-mysql.sql
     mysql.log=mysql.log


### PR DESCRIPTION
I removed the extra space in the string argument mysql.arg.line. From man:  --user=user_name, -u user_name ---> but:   --pasword[=password], -p[password] ---> If you use the
                  short option form (-p), you cannot have a space between the option and the password.
