### PR TITLE
LPS-29743 Users can still view portlet in private pages even through view permission is unchecked

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_javaterm_alphabetize_exclusions.properties
+++ b/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_javaterm_alphabetize_exclusions.properties
@@ -2,7 +2,7 @@
 # Files that are allowed to have unalphabetized Java terms. In addition these
 # files are allowed to have non-final variables that are capitalized.
 #
-portal-impl/src/com/liferay/portal/util/PortalImpl.java@6252=true
+portal-impl/src/com/liferay/portal/util/PortalImpl.java@6259=true
 portal-impl/src/com/liferay/portal/webdav/methods/Method.java@54=true
 portal-impl/test/integration/com/liferay/portal/test/TestContext.java@54=true
 portal-impl/test/integration/com/liferay/portal/util/DiffImplTest.java

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5671,9 +5671,16 @@ public class PortalImpl implements Portal {
 				primaryKey);
 
 		if (count == 0) {
-			ResourceLocalServiceUtil.addResources(
-				companyId, groupId, 0, name, primaryKey, portletActions, true,
-				true);
+			if (layout.isPrivateLayout()) {
+				ResourceLocalServiceUtil.addResources(
+					companyId, groupId, 0, name, primaryKey, portletActions,
+					true, false);
+			}
+			else {
+				ResourceLocalServiceUtil.addResources(
+					companyId, groupId, 0, name, primaryKey, portletActions,
+					true, true);
+			}
 		}
 	}
 


### PR DESCRIPTION
Should not add guest action's permissions if the portlet is in the private site
