### PR TITLE
LPS-30374 NullPointerException when Accessing Legacy URLs to Document Li...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/GetFileAction.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/GetFileAction.java
@@ -171,6 +171,12 @@ public class GetFileAction extends PortletAction {
 			HttpServletResponse response)
 		throws Exception {
 
+		if (name.startsWith("DLFE-")) {
+			name = name.substring("DLFE-".length());
+		}
+
+		name = FileUtil.stripExtension(name);
+
 		FileEntry fileEntry = null;
 
 		if (Validator.isNotNull(uuid) && (groupId > 0)) {


### PR DESCRIPTION
The issue fixed in 6.0.x by LPS-5400 and broken by LPS-14028
