### PR TITLE
LPS-30444 Expanding a node in the manage pages tree results in the edit ...

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/view.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/view.jsp
@@ -215,7 +215,7 @@ SitesUtil.addPortletBreadcrumbEntries(group, pagesName, redirectURL, request, re
 			function(event) {
 				event.preventDefault();
 
-				var href = event.currentTarget.one('a').attr('href');
+				var href = event.currentTarget.ancestor().one('a').attr('href');
 
 				if (href) {
 					var hash = location.hash;
@@ -243,7 +243,7 @@ SitesUtil.addPortletBreadcrumbEntries(group, pagesName, redirectURL, request, re
 					layoutsContainer.io.start();
 				}
 			},
-			'.aui-tree-node-content'
+			'.aui-tree-label, .aui-tree-icon'
 		);
 	</aui:script>
 </c:if>


### PR DESCRIPTION
Hi Djalma,

As mentioned on the thread, I think we should only delegate the event to the icon and the label itself.

I don't find it exactly pretty, to be honest... but it serves the purpose ;)

Thanks!
Daniel
