### PR TITLE
Fix for LPS-30666 : Problem in Session Sharing between Portlet and Servlet when name of the variable starts with shared session attribute keyword.

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java
+++ b/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java
@@ -184,6 +184,14 @@ public class SharedSessionWrapper implements HttpSession {
 		HttpSession session = getSessionDelegate(name);
 
 		session.setAttribute(name, value);
+		 
+		// @Sushil Saini
+		// Added this code to make the shared session variables
+		// available to http servlet session
+		if (containsSharedAttribute(name)) {
+			HttpSession httpSession = getSessionDelegate();
+			httpSession.setAttribute(name, value);
+		}
 	}
 
 	public void setMaxInactiveInterval(int maxInactiveInterval) {


### PR DESCRIPTION
Hi there,

I have found a bug in a liferay and implemented the solution also. Please review the solution and if you find it suitable. please include it into the liferay source code.

Brief Description: Problem in Session Sharing between Portlet and Servlet when name of the variable starts with shared session attribute keyword.

For seeing the complete detail of the problem, please see the corresponding jira ticket and forum post.

Jira Ticket : http://issues.liferay.com/browse/LPS-30666
Forum Post : http://www.liferay.com/community/forums/-/message_boards/message/17448574

Please let me know if you want any more details from me.

Thanks & Regards
Sushil Saini
