### PR TITLE
LPS-31000 Asset count is not displayed when cloud style is selected, even if the Show Asset Count box is checked

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/application.css
+++ b/portal-web/docroot/html/themes/_styled/css/application.css
@@ -287,11 +287,6 @@
 
 .tag-cloud {
 	line-height: 2.5em;
-
-	.tag-asset-count {
-		clip: rect(0 0 0 0);
-		position: absolute;
-	}
 }
 
 .tag-selected {
@@ -302,11 +297,6 @@
 
 .tag-cloud {
 	line-height: 2.5em;
-
-	.tag-asset-count {
-		clip: rect(0 0 0 0);
-		position: absolute;
-	}
 
 	$tag-popularity-font-size: 0.7em;
 


### PR DESCRIPTION
With these changes, the asset count is displayed if the "show asset count" box is checked, regardless of the style selected. 

The name "number" for the alternative style to "cloud" is confussing (displaying the number depends no longer from the style) so it should be changed to something like "simple". However, since the style selector (taglib ddm-template-menu) assigns  the same for label and value, this change will affect to the value of the portlet preference and thus it'd require an upgrade process. 
