### PR TITLE
LPS-32028 - Add page permission control in JSP

### DIFF
--- a/portal-web/docroot/html/portlet/dockbar/view.jsp
+++ b/portal-web/docroot/html/portlet/dockbar/view.jsp
@@ -37,6 +37,14 @@ for (String portletId : PropsValues.DOCKBAR_ADD_PORTLETS) {
 
 boolean hasLayoutCustomizePermission = LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE);
 boolean hasLayoutUpdatePermission = LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE);
+boolean hasLayoutAddPagePermission = GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT) && !group.isLayoutPrototype();
+
+if (hasLayoutAddPagePermission && layout != null && layout.getParentLayoutId() > 0) {
+    Layout parentLayout =  LayoutLocalServiceUtil.getLayout(layout.getGroupId(), layout.isPrivateLayout(), layout.getParentLayoutId());
+    hasLayoutAddPagePermission = LayoutPermissionUtil.contains(permissionChecker, parentLayout, ActionKeys.UPDATE);
+}
+
+boolean hasAddPermission = hasLayoutAddPagePermission && !group.isControlPanel() && (!group.hasStagingGroup() || group.isStagingGroup()) && (GroupPermissionUtil.contains(permissionChecker, group.getGroupId(), ActionKeys.ADD_LAYOUT) || hasLayoutUpdatePermission || (layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && hasLayoutCustomizePermission));
 %>
 
 <div class="dockbar" data-namespace="<portlet:namespace />" id="dockbar">
@@ -45,7 +53,7 @@ boolean hasLayoutUpdatePermission = LayoutPermissionUtil.contains(permissionChec
 			<a href="javascript:;"><img alt='<liferay-ui:message key="pin-the-dockbar" />' src="<%= HtmlUtil.escape(themeDisplay.getPathThemeImages()) %>/spacer.png" /></a>
 		</li>
 
-		<c:if test="<%= !group.isControlPanel() && (!group.hasStagingGroup() || group.isStagingGroup()) && (GroupPermissionUtil.contains(permissionChecker, group.getGroupId(), ActionKeys.ADD_LAYOUT) || hasLayoutUpdatePermission || (layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && hasLayoutCustomizePermission)) %>">
+        <c:if test="<%= hasAddPermission %>">
 			<li class="add-content has-submenu" id="<portlet:namespace />addContent">
 				<a class="menu-button" href="javascript:;">
 					<span>


### PR DESCRIPTION
This ticket is caused because there is a java permission checking that is not done in the JSP file.

Because of this problem, the page enables sending the request to the server. Then, the server checks the permission and returns a null response, causing an error in the client.

All the behabiour is reported in jira ticket.

The solution I propose is to add permission check in jsp file. Maybe it would be interesting to include logging in the java class.

The permission control in java side is in the class  com.liferay.portlet.layoutsadmin.action.UpdateLayoutAction.java (line 90):

if ((layout != null) &&
            !LayoutPermissionUtil.contains(
                permissionChecker, layout, ActionKeys.UPDATE)) {

```
        return null;
```

}
