### PR TITLE
LPS-28640 (master - 6.2.x) Performance improvement for importing from LD...

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/ldap/PortalLDAPImporterImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/ldap/PortalLDAPImporterImpl.java
@@ -306,6 +306,8 @@ public class PortalLDAPImporterImpl implements PortalLDAPImporter {
 
 				Binding binding = enu.nextElement();
 
+				enu.close();
+
 				Attributes attributes = PortalLDAPUtil.getUserAttributes(
 					ldapServerId, companyId, ldapContext,
 					PortalLDAPUtil.getNameInNamespace(
@@ -943,9 +945,20 @@ public class PortalLDAPImporterImpl implements PortalLDAPImporter {
 			userGroup = UserGroupLocalServiceUtil.getUserGroup(
 				companyId, ldapGroup.getGroupName());
 
-			UserGroupLocalServiceUtil.updateUserGroup(
-				companyId, userGroup.getUserGroupId(), ldapGroup.getGroupName(),
-				ldapGroup.getDescription(), null);
+			boolean newGroupName = !userGroup.getName()
+					.equalsIgnoreCase(ldapGroup.getGroupName());
+			
+			boolean newGroupDescription = (userGroup.getDescription() != null
+					&& !userGroup.getDescription()
+						.equalsIgnoreCase(ldapGroup.getDescription()))
+						|| (userGroup.getDescription() == null
+							&& ldapGroup.getDescription() != null);
+
+			if (newGroupName || newGroupDescription) {
+				UserGroupLocalServiceUtil.updateUserGroup(
+					companyId, userGroup.getUserGroupId(), ldapGroup.getGroupName(),
+					ldapGroup.getDescription(), null);
+			}
 		}
 		catch (NoSuchUserGroupException nsuge) {
 			if (_log.isDebugEnabled()) {


### PR DESCRIPTION
...AP when using open.sso.ldap.import.enabled=true

This change does not include all the changes made for the 6.1.x branch.  The 6.2.x (master) already had an overlapping set of improvements made to the following method (line 864).

```
protected void importGroups(
        long ldapServerId, long companyId, LdapContext ldapContext,
        Attributes attributes, User user, Properties userMappings,
        Properties groupMappings)
    throws Exception
```

This pull request contains only the following changes that were provided for the 6.1.x branch.
- Early closure of enu to release the LDAP pool resource sooner.
- Logic for checking the group name and description before calling an update.  This prevents the update being called if no change has occurred.
