### PR TITLE
LPS-26665 (master - 6.2.x) User Group Site Pages: VirtualLayout.injectVi...

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/VirtualLayout.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/VirtualLayout.java
@@ -128,6 +128,11 @@ public class VirtualLayout extends LayoutWrapper {
 	}
 
 	protected String injectVirtualGroupURL(String layoutURL) {
+
+		if (_sourceLayout.isTypeURL()) {
+			return layoutURL;
+		}
+
 		try {
 			Group group = _sourceLayout.getGroup();
 


### PR DESCRIPTION
...rtualGroupURL is called, even when the layout is of type URL

Proposed 6.2.x (master) fix for this issue - see https://github.com/liferay/liferay-portal/pull/318 for the corresponding 6.1.x branch pull request.
