### PR TITLE
LPP-6359

### DIFF
--- a/util-taglib/src/com/liferay/taglib/security/DoAsURLTag.java
+++ b/util-taglib/src/com/liferay/taglib/security/DoAsURLTag.java
@@ -55,22 +55,8 @@ public class DoAsURLTag extends TagSupport {
 		String doAsURL = company.getHomeURL();
 
 		if (Validator.isNull(doAsURL)) {
-			Layout layout = null;
-
-			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-				themeDisplay.getScopeGroupId(), false,
-				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-
-			if (!layouts.isEmpty()) {
-				layout = layouts.get(0);
-
-				doAsURL = PortalUtil.getLayoutFriendlyURL(layout, themeDisplay);
-			}
-
-			if (Validator.isNull(doAsURL)) {
-				doAsURL =
-					themeDisplay.getPathContext() + _COMPANY_DEFAULT_HOME_URL;
-			}
+			doAsURL =
+				themeDisplay.getPathContext() + _COMPANY_DEFAULT_HOME_URL;
 		}
 		else {
 			doAsURL = themeDisplay.getPathContext() + doAsURL;


### PR DESCRIPTION
The taglib assumes that the first item will always be one of the user's public or private pages.  SO 2.0.4 breaks this assumption by adding a profile page, microblogging page, etc.   Other future plugins might also break this assumption as well.

My fix is to make it more general since there does not seem to be an easy way to determine which of the pages returned is valid as a start page.  (I suppose we could add that as a database column in the future if needed).
