### PR TITLE
[Technical support] LPS-34764 Fixed _totalSize setting for large file sizes 

### DIFF
--- a/portal-impl/src/com/liferay/portal/upload/LiferayInputStream.java
+++ b/portal-impl/src/com/liferay/portal/upload/LiferayInputStream.java
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpSession;
  */
 public class LiferayInputStream extends ServletInputStreamAdapter {
 
-	public static final long THRESHOLD_SIZE = GetterUtil.getInteger(
+	public static final long THRESHOLD_SIZE = GetterUtil.getLong(
 		PropsUtil.get(LiferayInputStream.class.getName() + ".threshold.size"));
 
 	public LiferayInputStream(HttpServletRequest request) throws IOException {


### PR DESCRIPTION
Hi Sergío,

this modification is necessary to create a fix for the LPS for a previous version for the upload progress bar. However, the progress bar problem is not on master, this file size related problem can be a problem on master also. That is why we're sending this separately here.

I found the Document & Media Library component to be the closest one to this and I found you on that, this is why I'm sending this to you.

Regards
Zsigmond
