### PR TITLE
LPS-36191

### DIFF
--- a/portal-web/docroot/html/portlet/message_boards/css/main.css
+++ b/portal-web/docroot/html/portlet/message_boards/css/main.css
@@ -389,6 +389,12 @@
 	}
 }
 
+.ie8 {
+	.question-details {
+		float: none;
+	}
+}
+
 .trash-restore-popup {
 	.form {
 		fieldset {


### PR DESCRIPTION
 the Answer graphic would be in the Qustion column in IE8 when viewing a Question thread in Message Board with display stype set to HTML
