### PR TITLE
LPS-37204 SearchContainer tag emptyResultsMessage attribute value is not applied if searchContainer attribute is also specified

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerTag.java
@@ -124,6 +124,10 @@ public class SearchContainerTag<R> extends ParamAndPropertyAncestorTagImpl {
 				_searchContainer.setTotal(_total);
 			}
 
+			if (Validator.isNotNull(_emptyResultsMessage)) {
+				_searchContainer.setEmptyResultsMessage(_emptyResultsMessage);
+			}
+			
 			pageContext.setAttribute(_var, _searchContainer);
 
 			return EVAL_BODY_INCLUDE;


### PR DESCRIPTION
This change fix the LPS-37204.
If a emptyResultMessage is specified to the liferay-ui:search-container tag, the emptyResultMessage value will be applied to the SearchContainer instance, no matter it is passed in by tag attribute, or instanced by the tag itself.
