### PR TITLE
LPS-39170 Update DLFileEntryIndexer.java

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -430,6 +430,8 @@ public class DLFileEntryIndexer extends BaseIndexer {
 			document.addKeyword("path", dlFileEntry.getTitle());
 			document.addKeyword("readCount", dlFileEntry.getReadCount());
 			document.addKeyword("size", dlFileEntry.getSize());
+			document.addDate("modified", dlFileEntry.getModifiedDate());
+			document.addDate("createDate", dlFileEntry.getCreateDate());
 
 			ExpandoBridge expandoBridge =
 				ExpandoBridgeFactoryUtil.getExpandoBridge(


### PR DESCRIPTION
DLIndexer.java used to index the modified date, but not the creation date, which is a basic search filter, the new indexer does neither, so I'm including the attributes to be indexed.
