### PR TITLE
LPS-34437

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLContentLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLContentLocalServiceImpl.java
@@ -118,10 +118,6 @@ public class DLContentLocalServiceImpl extends DLContentLocalServiceBaseImpl {
 			long companyId, long repositoryId, String dirName)
 		throws SystemException {
 
-		if (!dirName.endsWith(StringPool.SLASH)) {
-			dirName = dirName.concat(StringPool.SLASH);
-		}
-
 		dirName = dirName.concat(StringPool.PERCENT);
 
 		dlContentPersistence.removeByC_R_LikeP(


### PR DESCRIPTION
Hi Sergio,

I've refactored this fix as we discussed.

I have tested it with the following scenarios

Case 1 (folder delete behavior)
- Install and enable Xuggler, restart portal
- Place Documents and Media portlet on home page
- Add folders: Audio, Image, PDF, Video
- Upload related content into each directory
- Verify that each thumbnail/preview is generated properly
- Add Message Board and Wiki portlet to home page
- Add Thread and Wiki Page with attachment image files
- Verify the content of dlContent table (in case of DBStore) and in ${PORTAL_DIR}/data/document_library folder for other Stores
- Move folders to Recycle Bin then delete them
- Verify again dlContent table or  ${PORTAL_DIR}/data/document_library folder 

Case 2 (export/import site template with thumbnails and previews)
- Install and enable Xuggler, restart portal
- Create a Site Template called ST
- Open ST's home page to customize
- Place Documents and Media portlet on home page
- Add folders: Audio, Image, PDF, Video
- Upload related content into each directory
- Verify that each thumbnail/preview is generated properly
- Export ST
- Import the exported LAR file into ST again
- Verify that the process completes without error

Tested Stores:
- DBStore
- FileSystemStore

Please note, that for DBStore max_allowed_packet should be set properly with higher limit in MySQL.
