### PR TITLE
LPS-35805: PortalUtil.generateRandomKey does't generate random keys

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -844,8 +844,8 @@ public class PortalImpl implements Portal {
 
 		if (themeDisplay.isAjax() || themeDisplay.isIsolated() ||
 			themeDisplay.isLifecycleResource() ||
-			themeDisplay.isStateExclusive()) {
-
+			themeDisplay.isStateExclusive() || themeDisplay.isLifecycleRender()) {
+			
 			return StringUtil.randomId();
 		}
 		else {

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -1969,7 +1969,7 @@ public class StringUtil {
 	}
 
 	public static String randomId() {
-		Random random = new Random();
+		Random random = new Random((Double.doubleToLongBits(Math.random())));
 
 		char[] chars = new char[4];
 


### PR DESCRIPTION
The bug has been corrected by adding a seed in random number generator of the generateRandomKey method in the StringUtil class.
Now two instances of the same portlet generate different keys.
