### PR TITLE
LPS-40891 Fix result count

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
@@ -817,8 +817,12 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 			userSiteGroups.add(0, controlPanelGroup);
 		}
 
+		if (start == QueryUtil.ALL_POS) {
+			start = 0;
+		}
+
 		return Collections.unmodifiableList(
-			ListUtil.subList(userSiteGroups, start, end));
+			ListUtil.subList(userSiteGroups, 0, end - start));
 	}
 
 	/**


### PR DESCRIPTION
This was broken before your change but your change exposed it.

We already limit the results when we do the search. Since we add more results to it afterwards, we just want to grab the first delta number of results.
