### PR TITLE
Update GroupLocalServiceImpl.java

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -276,7 +276,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		else if (className.equals(Organization.class.getName())) {
 			name = getOrgGroupName(name);
 		}
-		else if (!GroupConstants.USER_PERSONAL_SITE.equals(name)) {
+		else if (GroupConstants.USER_PERSONAL_SITE.equals(name)||Validator.isNull(name)) {
 			name = String.valueOf(classPK);
 		}
 


### PR DESCRIPTION
In case of create  LayoutSetPrototype or LayoutPrototype why do we set group's name = classPK and then when updating we set group's name = layoutSetPrototype's name???
