### PR TITLE
LPS-40360 Fix, doAsGroupId was not read correctly at control panel and was causing Document and media work incorrectly

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4505,6 +4505,13 @@ public class PortalImpl implements Portal {
 			if (group.isControlPanel()) {
 				long doAsGroupId = ParamUtil.getLong(request, "doAsGroupId");
 
+				if (doAsGroupId <= 0) {
+					HttpServletRequest originalRequest =
+						getOriginalServletRequest(request);
+					doAsGroupId = ParamUtil.getLong(
+						originalRequest, "doAsGroupId");
+				}
+
 				Group doAsGroup = GroupLocalServiceUtil.fetchGroup(doAsGroupId);
 
 				if ((doAsGroupId <= 0) || (doAsGroup == null)) {


### PR DESCRIPTION
Hi Ray,

This bug is at PortalImpl even though it is came visible at Document and Media so I send this to you.

See the issue

https://issues.liferay.com/browse/LPS-40360

The problem was that DLImpl.getDefaultFolderId(HttpServletRequest request) was reading the "rootFolderId" value from DM portlet preferences, but it was not able to find it.

To root fault was that PortalImpl.getScopeGroupId(..) was trying to read scopeAndGroup id at control panel, but this case it unable to read doAsGroupId as it should. So this fix add another try to fetch correct scopeGroupId from "doAsGroupId" url parameter.

I have tested this and it seems be ok and working.
