### PR TITLE
LPS-42559: Enabled generic URI path parameter stripping

### DIFF
--- a/portal-service/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/FilterMappingTest.java
@@ -64,6 +64,61 @@ public class FilterMappingTest extends PowerMockito {
 		);
 	}
 
+        /*
+         * Reading 
+         * <a href='http://cdivilly.wordpress.com/2011/04/22/java-servlets-uri-parameters/'>this article</a>
+         * points to information that URI's may contain path parameters for
+         * each path segment and further that filter mapping URI patterns
+         * should match the path without the parameters.
+         * 
+         * From <a href='http://tools.ietf.org/html/rfc2396'>RFC2396</a> (URI):
+         * <pre>
+         *   The path component contains data, specific to the authority (or the
+         *   scheme if there is no authority component), identifying the resource
+         *   within the scope of that scheme and authority.
+         *
+         *      path          = [ abs_path | opaque_part ]
+         *
+         *      path_segments = segment *( "/" segment )
+         *      segment       = *pchar *( ";" param )
+         *      param         = *pchar
+         *
+         *      pchar         = unreserved | escaped |
+         *                      ":" | "@" | "&" | "=" | "+" | "$" | ","
+         *
+         *   The path may consist of a sequence of path segments separated by a
+         *   single slash "/" character.  Within a path segment, the characters
+         *   "/", ";", "=", and "?" are reserved.  Each path segment may include a
+         *   sequence of parameters, indicated by the semicolon ";" character.
+         *   The parameters are not significant to the parsing of relative
+         *   references.
+         * </pre>
+         * From the <a href='http://jcp.org/aboutJava/communityprocess/final/jsr315/index.html'>servlet spec</a>:
+         * <pre>
+         *   The path used for mapping to a servlet is the request URL from 
+         *   the request object minus the context path and the path parameters.
+         * </pre>
+         */
+	@Test
+        public void testIsMatchWithUriPathParameters() {
+                List<String> urlPatterns = new ArrayList<String>();
+
+                urlPatterns.add("/c/portal/login");
+
+                FilterMapping filterMapping = new FilterMapping(
+                        _filter, _filterConfig, urlPatterns, _dispatchers);
+
+                String uri = "/c;foo=bar,d,you=win/portal;a=b,true=false/login;jsessionid=ACD311312312323BF.worker1";
+
+                MockHttpServletRequest mockHttpServletRequest =
+                        new MockHttpServletRequest(HttpMethods.GET, uri);
+
+                Assert.assertEquals(
+                        true,
+                        filterMapping.isMatch(
+                                mockHttpServletRequest, Dispatcher.REQUEST, uri));
+        }
+
 	@Test
 	public void testIsMatchWithJSessionId() {
 		List<String> urlPatterns = new ArrayList<String>();


### PR DESCRIPTION
The current code just removed jsessionid, however, that is just on example of path parameter.  Further the regex replace assumed that anything after jsessionid was throw away.  While that may be the case in the current Tomcat implementation, path parameters are allowed on any path segment, and not just jsessionid.  In order to be more compliant with the servlet spec, I updated the FilterMapping to strip all uri parameters.  

I would actually suggest doing this before getting into FilterMapping, like in InvokerFilterHelper before the loop, so that it could be done once per request rather than once per filter per request, but not sure if you guys had any other reason for doing it this way.  If you comment back, i can move the code so it happens in InvokerFilter before merging.

https://issues.liferay.com/browse/LPS-42559
