### PR TITLE
LPS-42819 - fixed displaying layout controls on staged environments for pages without prototypes

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
@@ -147,7 +147,7 @@ StringBuilder friendlyURLBase = new StringBuilder();
 		</div>
 	</c:if>
 
-	<div class="<%= selLayout.isLayoutPrototypeLinkEnabled() ? "hide" : StringPool.BLANK %>" id="<portlet:namespace />typeOptions">
+	<div class="<%= (Validator.isNotNull(selLayout.getLayoutPrototypeUuid()) && selLayout.isLayoutPrototypeLinkEnabled()) ? "hide" : StringPool.BLANK %>" id="<portlet:namespace />typeOptions">
 		<aui:select name="type">
 
 			<%


### PR DESCRIPTION
LPS-42819 - fixed displaying layout controls on staged environments for pages without prototypes
