### PR TITLE
LPS-43116

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -248,18 +248,17 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 		else {
 			vocabularies = getGroupVocabularies(groupId, start, end, obc);
 			total = getGroupVocabulariesCount(groupId);
+		}
 
-			if (addDefaultVocabulary && (total == 0) && 
-				(assetVocabularyPersistence.countByGroupId(groupId) == 0)) {
-				
-				vocabularies = new ArrayList<AssetVocabulary>();
+		if (addDefaultVocabulary && (total == 0) &&
+			(assetVocabularyPersistence.countByGroupId(groupId) == 0)) {
 
-				vocabularies.add(
-					assetVocabularyLocalService.addDefaultVocabulary(
-						groupId));
+			vocabularies = new ArrayList<AssetVocabulary>();
 
-				total = 1;
-			}
+			vocabularies.add(
+				assetVocabularyLocalService.addDefaultVocabulary(groupId));
+
+			total = 1;
 		}
 
 		return new AssetVocabularyDisplay(vocabularies, total, start, end);


### PR DESCRIPTION
Hola @juliocamarero,

I think we should mantain the previous behaviour. Although it can work in this case, if we change the inner behaviour we can confuse users using this API. 

Moreover, we shouldn't make a "behaviour" dependency of one parameter (addDefaultVocabulary) from the value of another one (name) . 
