### PR TITLE
LPS-43097 The choose button displays incomplete when the document title ...

### DIFF
--- a/portal-web/docroot/html/css/taglib/button.css
+++ b/portal-web/docroot/html/css/taglib/button.css
@@ -16,6 +16,10 @@
 		}
 
 		.btn {
+			&.selector-button {
+				min-width: 70px;
+			}
+
 			padding: 11px 19px;
 			font-size: 17.5px;
 


### PR DESCRIPTION
...is too long.
