### PR TITLE
Workaround for LPS-43917.

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/JSONServiceAction.java
+++ b/portal-impl/src/com/liferay/portal/action/JSONServiceAction.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -40,8 +41,8 @@ import com.liferay.portal.util.PropsValues;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -208,6 +209,11 @@ public class JSONServiceAction extends JSONAction {
 		}
 		else if (typeNameOrClassDescriptor.equals(Date.class.getName())) {
 			return new Date(ParamUtil.getLong(request, parameter));
+		}
+		else if (typeNameOrClassDescriptor.equals(Calendar.class.getName())) {
+			Calendar cal = Calendar.getInstance(LocaleUtil.getDefault());
+			cal.setTime(new Date(ParamUtil.getLong(request, parameter)));
+			return cal;
 		}
 		else if (typeNameOrClassDescriptor.equals(
 					ServiceContext.class.getName())) {


### PR DESCRIPTION
Bug is described with details in LPS-43917. I called this a workaround because I don't know how to represent java.util.Calendar in javascript. As a parameter I pass only timestamp from my javascript, and then directly in Java code, I create Calendar object with default locale. Anyway, I don't know if there is even a possibility and will to utilize date objects with timezone at javascript level.

Regards,
Krzysztof Gołębiowski
