### PR TITLE
LPS-44052 Do not leave file handles open

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletContextUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletContextUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import java.io.File;
 import java.io.IOException;
 
 import java.net.MalformedURLException;
@@ -112,12 +113,14 @@ public class ServletContextUtil {
 						_log.error("Resource URL for " + curPath + " is null");
 					}
 					else {
-						URLConnection urlConnection = url.openConnection();
-
-						if (urlConnection.getLastModified() > lastModified) {
-							lastModified = urlConnection.getLastModified();
-						}
-					}
+							long lm =  new File(url.toURI()).lastModified();
+							if (lm > lastModified) {
+								lastModified = lm;
+							}
+                    }
+				}
+				catch (URISyntaxException ioe) {
+					_log.error(ioe, ioe);
 				}
 				catch (IOException ioe) {
 					_log.error(ioe, ioe);


### PR DESCRIPTION
We ware evaluating problems with deployment of LifeRay to WildFly 8 described in 
https://issues.jboss.org/browse/WFLY-2862
Problem was traced to the way LifeRay gets timestamps which leaves files handles open until GC cleans them up.
With this fix applied users are not seeing problems with "too many open files" anymore.
