### PR TITLE
Update open_document.jspf

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/action/open_document.jspf
+++ b/portal-web/docroot/html/portlet/document_library/action/open_document.jspf
@@ -17,7 +17,7 @@
 <c:if test="<%= DLFileEntryPermission.contains(permissionChecker, fileEntry, ActionKeys.VIEW) %>">
 
 	<%
-	if (DLUtil.isOfficeExtension(fileEntry.getExtension()) && portletDisplay.isWebDAVEnabled() && BrowserSnifferUtil.isIeOnWin32(request)) {
+	if (DLUtil.isOfficeExtension(fileEntry.getExtension()) && portletDisplay.isWebDAVEnabled() && BrowserSnifferUtil.isIe(request)) {
 		String webDavUrl = DLUtil.getWebDavURL(themeDisplay, fileEntry.getFolder(), fileEntry, PropsValues.DL_FILE_ENTRY_OPEN_IN_MS_OFFICE_MANUAL_CHECK_IN_REQUIRED, true);
 
 		String taglibOnClick = "javascript:" + liferayPortletResponse.getNamespace() + "openDocument('" + webDavUrl + "');";


### PR DESCRIPTION
Fixes issue where 64 bit OS will not show open document link.  Author has mistaken 64 bit OS as a problem for Office/SharePoint ActiveX control.  64 Bit OS will work with control, but 64 bit office installs will not.  There is no way to detect what office install is loaded on client machine.
