### PR TITLE
LPS-46587 Fix JavaScript syntax errors

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/view.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/view.jsp
@@ -134,12 +134,12 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 				var count = parseInt(responseData);
 
 				if (count > 0) {
-					status = <%= WorkflowConstants.STATUS_APPROVED %>
+					status = <%= WorkflowConstants.STATUS_APPROVED %>;
 
 					<portlet:namespace />getUsersCount(
 						className, ids, status,
 						function(event, id, obj) {
-							responseData = this.get('responseData')
+							responseData = this.get('responseData');
 							count = parseInt(responseData);
 
 							if (count > 0) {


### PR DESCRIPTION
The syntax errors can cause the MinifierUtil to fail and the JavaScript
not to load.
