### PR TITLE
LPS-44990 Provide ability to deploy Faceted search implementations as a hook

### DIFF
--- a/portal-impl/src/com/liferay/portlet/search/dependencies/facet_configuration.json
+++ b/portal-impl/src/com/liferay/portlet/search/dependencies/facet_configuration.json
@@ -2,6 +2,7 @@
 	facets: [
 		{
 			className: 'com.liferay.portal.kernel.search.facet.ScopeFacet',
+			pluginContext: '',
 			data: {
 				frequencyThreshold: 1,
 				maxTerms: 10,
@@ -16,6 +17,7 @@
 		},
 		{
 			className: 'com.liferay.portal.kernel.search.facet.AssetEntriesFacet',
+			pluginContext: '',
 			data: {
 				frequencyThreshold: 1,
 				values: [
@@ -40,6 +42,7 @@
 		},
 		{
 			className: 'com.liferay.portal.kernel.search.facet.MultiValueFacet',
+			pluginContext: '',
 			data: {
 				displayStyle: 'list',
 				frequencyThreshold: 1,
@@ -55,6 +58,7 @@
 		},
 		{
 			className: 'com.liferay.portal.kernel.search.facet.MultiValueFacet',
+			pluginContext: '',
 			data: {
 				displayStyle: 'list',
 				frequencyThreshold: 1,
@@ -70,6 +74,7 @@
 		},
 		{
 			className: 'com.liferay.portal.kernel.search.facet.MultiValueFacet',
+			pluginContext: '',
 			data: {
 				frequencyThreshold: 1,
 				maxTerms: 10,
@@ -84,6 +89,7 @@
 		},
 		{
 			className: 'com.liferay.portal.kernel.search.facet.MultiValueFacet',
+			pluginContext: '',
 			data: {
 				frequencyThreshold: 1,
 				maxTerms: 10,
@@ -98,6 +104,7 @@
 		},
 		{
 			className: 'com.liferay.portal.kernel.search.facet.ModifiedFacet',
+			pluginContext: '',
 			data: {
 				frequencyThreshold: 0,
 				ranges: [

--- a/portal-service/src/com/liferay/portal/kernel/search/facet/config/FacetConfiguration.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/facet/config/FacetConfiguration.java
@@ -94,7 +94,16 @@ public class FacetConfiguration {
 		_weight = weight;
 	}
 
+	public String getPluginContext() {
+		return _pluginContext;
+	}
+
+	public void setPluginContext(String pluginContext) {
+		_pluginContext = pluginContext;
+	}
+
 	private String _className;
+	private String _pluginContext;
 	private JSONObject _dataJSONObject;
 	private String _displayStyle;
 	private String _fieldName;

--- a/portal-service/src/com/liferay/portal/kernel/search/facet/config/FacetConfigurationUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/facet/config/FacetConfigurationUtil.java
@@ -70,6 +70,7 @@ public class FacetConfigurationUtil {
 		FacetConfiguration facetConfiguration = new FacetConfiguration();
 
 		facetConfiguration.setClassName(facetJSONObject.getString("className"));
+		facetConfiguration.setPluginContext(facetJSONObject.getString("pluginContext"));
 
 		if (facetJSONObject.has("data")) {
 			facetConfiguration.setDataJSONObject(


### PR DESCRIPTION
Implement the solution suggested by Ray Auge :
- A new facet configuration parameter is read from the facet's JSON string : pluginContext.
- If plugin context is not empty, we look for the facet implementation in the plugin's classLoader.
