### PR TITLE
add extension for file name to pass the check.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/EditFileEntryAction.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/EditFileEntryAction.java
@@ -452,7 +452,7 @@ public class EditFileEntryAction extends PortletAction {
 		String title = sourceFileName;
 
 		sourceFileName = sourceFileName.concat(
-			TEMP_RANDOM_SUFFIX).concat(StringUtil.randomString());
+			TEMP_RANDOM_SUFFIX).concat(StringUtil.randomString()).concat(StringPool.PERIOD).concat(FileUtil.getExtension(sourceFileName));
 
 		InputStream inputStream = null;
 


### PR DESCRIPTION
I realized that the sourceFileName is appended with TEMP_RANDOM_SUFFIX and random string to make it unique. However, in this way, it doesn't end with a valid extension. So I append its extension after the random string. As when this file is going to be deleted, its original name is retrieved from soureceFileName (the string after TEMP_RANDOM_SUFFIX will be discarded), the appended extension will not affect the performance. 
I not sure if it is the correct answer.
