### PR TITLE
https://issues.liferay.com/browse/LRDOCS-1266

### DIFF
--- a/modules/util/markdown-converter/src/com/liferay/markdown/converter/internal/pegdown/serializer/LiferayToHtmlSerializer.java
+++ b/modules/util/markdown-converter/src/com/liferay/markdown/converter/internal/pegdown/serializer/LiferayToHtmlSerializer.java
@@ -19,7 +19,13 @@ import com.liferay.markdown.converter.internal.pegdown.ast.SidebarNode;
 
 import org.pegdown.LinkRenderer;
 import org.pegdown.ToHtmlSerializer;
+import org.pegdown.ast.HeaderNode;
+import org.pegdown.ast.HtmlBlockNode;
+import org.pegdown.ast.Node;
 import org.pegdown.ast.SuperNode;
+import org.pegdown.ast.TextNode;
+
+import java.util.List;
 
 /**
  * Provides a visitor implementation for printing HTML for pictures with
@@ -40,6 +46,21 @@ public class LiferayToHtmlSerializer extends ToHtmlSerializer {
 	public void visit(SidebarNode sidebarNode) {
 		print(sidebarNode);
 	}
+	
+	@Override
+    public void visit(HeaderNode node) {
+    	int headerLevel = node.getLevel();
+    	if (headerLevel != 1) {
+    		List<Node> children = node.getChildren();
+    		if (!children.isEmpty()) {
+    			TextNode childNode = (TextNode) children.get(0);
+				String text = childNode.getText().replace(' ', '-')
+						.toLowerCase().replaceAll("[^a-z0-9 ]", "");
+    			printer.print("<a name=\"" + text + "\" />");
+    		}
+    	}
+        printTag(node, "h" + headerLevel);
+    }
 
 	@Override
 	public void visit(SuperNode superNode) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-1266

Updated Markdown converter so that anchors are generated for headers (h2 through h6) in the resulting HTML
