### PR TITLE
LPS-49956 Upload URLs are incorrect

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view.jsp
@@ -99,7 +99,11 @@ request.setAttribute("view.jsp-orderByCol", orderByCol);
 request.setAttribute("view.jsp-orderByType", orderByType);
 %>
 
-<liferay-util:buffer var="uploadURL"><liferay-portlet:actionURL><portlet:param name="struts_action" value="/document_library/view_file_entry" /><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.ADD_DYNAMIC %>" /><portlet:param name="folderId" value="{folderId}" /><portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" /></liferay-portlet:actionURL><liferay-ui:input-permissions-params modelName="<%= DLFileEntryConstants.getClassName() %>" /></liferay-util:buffer>
+<liferay-util:buffer var="uploadURL"><liferay-portlet:actionURL><portlet:param name="struts_action" value="/document_library/view_file_entry" /><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.ADD_DYNAMIC %>" /><portlet:param name="folderId" value="{folderId}" /><portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" /></liferay-portlet:actionURL></liferay-util:buffer>
+
+<liferay-util:buffer var="inputPermissions">
+	<liferay-ui:input-permissions-params modelName="<%= DLFileEntryConstants.getClassName() %>" />
+</liferay-util:buffer>
 
 <liferay-ui:trash-undo />
 


### PR DESCRIPTION
Divide uploadURL into two parts in order to delete class name from url.

This bug is caused by reconstruction in LPS-49821 and a source formatting in LPS-29543.
