### PR TITLE
LPS-48904 Categories not forwarded to editor

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/view.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/view.jsp
@@ -84,7 +84,7 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 <c:if test="<%= showAddContentButton && (scopeGroup != null) && (!scopeGroup.hasStagingGroup() || scopeGroup.isStagingGroup()) && !portletName.equals(PortletKeys.HIGHEST_RATED_ASSETS) && !portletName.equals(PortletKeys.MOST_VIEWED_ASSETS) && !portletName.equals(PortletKeys.RELATED_ASSETS) %>">
 
 	<%
-	addPortletURLs = AssetUtil.getAddPortletURLs(liferayPortletRequest, liferayPortletResponse, classNameIds, classTypeIds, allAssetCategoryIds, allAssetTagNames, null);
+	addPortletURLs = AssetUtil.getAddPortletURLs(liferayPortletRequest, liferayPortletResponse, classNameIds, classTypeIds, assetEntryQuery.getAllCategoryIds(), allAssetTagNames, null);
 
 	for (long groupId : groupIds) {
 	%>


### PR DESCRIPTION
If you select categories in the query (contains ALL categories), these
categories do not get forwarded to the editor and thus the newly
created content is not visible in the asset publisher
