### PR TITLE
LPS-52043 - When staging and an embedded asset is in the recycle bin, the name of the document failing validation is ambigious.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryStagedModelDataHandler.java
@@ -64,6 +64,8 @@ import com.liferay.portlet.documentlibrary.util.DLUtil;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
 import com.liferay.portlet.dynamicdatamapping.storage.Fields;
 import com.liferay.portlet.dynamicdatamapping.storage.StorageEngineUtil;
+import com.liferay.portlet.trash.model.TrashEntry;
+import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -130,6 +132,20 @@ public class FileEntryStagedModelDataHandler
 
 	@Override
 	public String getDisplayName(FileEntry fileEntry) {
+		if (fileEntry.isInTrash()) {
+			try {
+				String name = fileEntry.getTitle().replace("/","");
+				long fileEntryId = Long.valueOf(name).longValue();
+
+				TrashEntry tempEntry = TrashEntryLocalServiceUtil.getEntry(
+					fileEntryId);
+				return tempEntry.getTypeSettingsProperty("title");
+			}
+			catch (Exception e) {
+				return fileEntry.getTitle();
+			}
+		}
+
 		return fileEntry.getTitle();
 	}
 


### PR DESCRIPTION
Get the title from the TrashEntry table, typeSettings property rather than the ambiguous title in the FileEntry table. 
