### PR TITLE
LPS-52283 : Asset Publisher scope group lost while publishing from remot...

### DIFF
--- a/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisher.java
+++ b/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisher.java
@@ -41,6 +41,8 @@ public interface AssetPublisher {
 
 	public static final String SCOPE_ID_GROUP_PREFIX = "Group_";
 
+	public static final String SCOPE_ID_GROUP_URL_PREFIX = "GroupUrl_";
+	
 	public static final String SCOPE_ID_LAYOUT_PREFIX = "Layout_";
 
 	public static final String SCOPE_ID_LAYOUT_UUID_PREFIX = "LayoutUuid_";


### PR DESCRIPTION
Here is a proposed solution for this problem :
- During lar export, scope group ids are converted to friendlyURLs
- During lar import, frienlyURLs are converted back to scope group ids

Hence, the asset publisher will keep its original configuration as long as exists a site withe the same friendlyURL.
