### PR TITLE
LPS-52186 Defined a basic confirmation dialog for sitemap submission

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -5185,6 +5185,7 @@ send-password-reset-link=Send Password Reset Link
 send-shipping-email=Send Shipping Email
 send-shipping-email-to-users=Send shipping email to users?
 send-sitemap-information-to-preview=Send sitemap information to {0}preview{1}:
+send-sitemap-confirmation=This will send your sitemap information to the selected search engine. Are you sure you want to proceed?
 send-text-message=Send Text Message
 sender=Sender
 sending-message=Sending message...

--- a/portal-web/docroot/html/portlet/sites_admin/site/sitemap.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/sitemap.jsp
@@ -53,15 +53,28 @@ if (!host.equals(privateLayoutSet.getVirtualHostname())) {
 
 <br /><br />
 
+<script language="javascript">
+/* 
+    Provide a simple confirmation dialog to the user. Clicking OK loads the 
+    URL in a new browser window. 
+*/
+function confirmSitemapSubmission(url){
+    var sitemapConfirmationMessage = "<liferay-ui:message key='send-sitemap-confirmation'/>";
+	if(confirm(sitemapConfirmationMessage)){
+		window.open(url);
+	}
+}
+</script>
+
 <aui:fieldset label="public-pages">
 	<%= LanguageUtil.format(request, "send-sitemap-information-to-preview", new Object[] {"<a target=\"_blank\" href=\"" + HtmlUtil.escapeAttribute(publicSitemapUrl) + "\">", "</a>"}, false) %>
 
 	<ul>
 		<li>
-			<aui:a href='<%= "http://www.google.com/webmasters/sitemaps/ping?sitemap=" + HtmlUtil.escapeURL(publicSitemapUrl) %>' target="_blank">Google</aui:a>
+			<a href="#" onclick='javascript:confirmSitemapSubmission("http://www.google.com/webmasters/sitemaps/ping?sitemap=" + "<%=HtmlUtil.escapeURL(publicSitemapUrl)%>");return false;' target="_blank" title='<liferay-ui:message key="opens-new-window" />'>Google<span class="opens-new-window-accessible"/></a>
 		</li>
 		<li>
-			<aui:a href='<%= "https://siteexplorer.search.yahoo.com/submit/ping?sitemap=" + HtmlUtil.escapeURL(publicSitemapUrl) %>' target="_blank">Yahoo!</aui:a> (<liferay-ui:message key="requires-login" />)
+			<a href="#" onclick='javascript:confirmSitemapSubmission("https://siteexplorer.search.yahoo.com/submit/ping?sitemap=" + "<%=HtmlUtil.escapeURL(publicSitemapUrl)%>");return false;' target="_blank" title='<liferay-ui:message key="opens-new-window" />'>Yahoo!<span class="opens-new-window-accessible"/></a> (<liferay-ui:message key="requires-login" />)
 		</li>
 	</ul>
 </aui:fieldset>
@@ -71,10 +84,10 @@ if (!host.equals(privateLayoutSet.getVirtualHostname())) {
 
 	<ul>
 		<li>
-			<aui:a href='<%= "http://www.google.com/webmasters/sitemaps/ping?sitemap=" + HtmlUtil.escapeURL(privateSitemapUrl) %>' target="_blank">Google</aui:a>
+			<a href="#" onclick='javascript:confirmSitemapSubmission("http://www.google.com/webmasters/sitemaps/ping?sitemap=" + "<%=HtmlUtil.escapeURL(privateSitemapUrl)%>");return false;' target="_blank" title='<liferay-ui:message key="opens-new-window" />'>Google<span class="opens-new-window-accessible"/></a>
 		</li>
 		<li>
-			<aui:a href='<%= "https://siteexplorer.search.yahoo.com/submit/ping?sitemap=" + HtmlUtil.escapeURL(privateSitemapUrl) %>' target="_blank">Yahoo!</aui:a> (<liferay-ui:message key="requires-login" />)
+			<a href="#" onclick='javascript:confirmSitemapSubmission("https://siteexplorer.search.yahoo.com/submit/ping?sitemap=" + "<%=HtmlUtil.escapeURL(privateSitemapUrl)%>");return false;' target="_blank" title='<liferay-ui:message key="opens-new-window" />'>Yahoo!<span class="opens-new-window-accessible"/></a> (<liferay-ui:message key="requires-login" />)
 		</li>
 	</ul>
 </aui:fieldset>


### PR DESCRIPTION
My changes in sitemap.jsp started out as a modification of the existing aui:a tag whereby I set its href to a javascript invocation. A quick revealed Firefox doesn't play well with that, so I went with the more proper approach of pinning down the href attribute to "#" and adding an onclick event to the aui:a tag. But then I ran into a problem with aui:a not respecting my javascript's "return false" to prevent the default behavior of the link. So I used a straight html anchor tag and augmented it to do what aui:a was doing for me, namely: added a span to address the "opens in a new window" icon and a title attribute for accessibility.

If there is a way to still use aui:a, please share, and I'll be glad to improve this solution.
