### PR TITLE
LPS-52685 Liferay.NavigationInteraction plugin (touch only) unmet dependency

### DIFF
--- a/portal-web/docroot/html/js/liferay/navigation_interaction_touch.js
+++ b/portal-web/docroot/html/js/liferay/navigation_interaction_touch.js
@@ -100,6 +100,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['event-tap', 'event-touch', 'liferay-navigation-interaction']
+		requires: ['event-outside', 'event-tap', 'event-touch', 'liferay-navigation-interaction']
 	}
 );


### PR DESCRIPTION
`liferay-navigation-interaction-touch` subtly depended on the presence in the shared sandbox of `event-outside` without explicitly setting it in the required modules. With this change we now ensure it is present.