### PR TITLE
LPS-53769 - Content saved using TinyMCE does not save the formatting of content

### DIFF
--- a/portal-web/docroot/html/js/editor/tinymce.jsp
+++ b/portal-web/docroot/html/js/editor/tinymce.jsp
@@ -141,7 +141,7 @@ String toolbarSet = (String)request.getAttribute("liferay-ui:input-editor:toolba
 				}
 			}
 			else {
-				data = tinyMCE.editors['<%= name %>'].getBody().textContent;
+				data = tinyMCE.editors['<%= name %>'].getContent();
 			}
 
 			return data;


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-53769.

This one was caused by ba3676b301a8826d5507fb95571c1ff655d2d490 in https://issues.liferay.com/browse/LPS-53162.  I don't think the ```getBody().textContent``` change was intended for tinymce, only tinymce_simple.

Please let me know if there are any issues.

Thanks!