### PR TITLE
LPS-54266 available_languages.jsp has wrong content type on Wildfly 8.2

### DIFF
--- a/portal-web/docroot/html/js/liferay/available_languages.jsp
+++ b/portal-web/docroot/html/js/liferay/available_languages.jsp
@@ -18,11 +18,10 @@
 <%@ page import="com.liferay.portal.kernel.servlet.HttpHeaders" %>
 <%@ page import="com.liferay.portal.kernel.util.ContentTypes" %>
 <%@ page import="com.liferay.portal.kernel.util.LocaleUtil" %>
-
+<%@ page language="java" contentType="text/javascript;charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ page import="java.util.Locale" %>
 
 <%
-response.addHeader(HttpHeaders.CONTENT_TYPE, ContentTypes.TEXT_JAVASCRIPT);
 
 String languageId = LanguageUtil.getLanguageId(request);
 


### PR DESCRIPTION
Using response header manipulation doesn't work on Wildfly 8.2 with Java 8: Content-type is text/hrml.

```
response.addHeader(HttpHeaders.CONTENT_TYPE, ContentTypes.TEXT_JAVASCRIPT);
```

The header is overridden and then Chrome doesn't accept to execute the javascript.
Use this will fixe the content type and wildly respond with "text/javascript".

It is better to set the JSP page setting instead of manipulating directly the response header.
