### PR TITLE
When an Action method raises an exception, forward that exception rather...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -179,7 +179,7 @@ public class LiferayPortlet extends GenericPortlet {
 				return true;
 			}
 			catch (Exception e) {
-				throw new PortletException(nsme);
+				throw new PortletException(e);
 			}
 		}
 		catch (InvocationTargetException ite) {


### PR DESCRIPTION
... than an irrelevant NoSuchMethodException.

When developing a portal contained in Liferay, we had some hard time debugging our portal because the logged exception was a NSME whereas the action method was actually called and the actual exception thrown by the action method was trashed.