### PR TITLE
Lps 55084 Move HibernatePortalCacheManger out of LiferayEhcacheRegionFactory, prepare for extracting portal cache

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/HibernatePortalCacheManager.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/HibernatePortalCacheManager.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.region;
+
+import com.liferay.portal.cache.ehcache.EhcachePortalCacheManager;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.io.Serializable;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.config.CacheConfiguration;
+
+/**
+ * @author Tina Tian
+ */
+public class HibernatePortalCacheManager
+	extends EhcachePortalCacheManager<Serializable, Serializable> {
+
+	@Override
+	protected Ehcache createEhcache(
+		String portalCacheName, CacheConfiguration cacheConfiguration) {
+
+		reconfigureCache(new Cache(cacheConfiguration));
+
+		CacheManager cacheManager = getEhcacheManager();
+
+		return cacheManager.getCache(portalCacheName);
+	}
+
+	protected void reconfigureCache(Ehcache replacementCache) {
+		CacheManager cacheManager = getEhcacheManager();
+
+		String cacheName = replacementCache.getName();
+
+		Ehcache ehcache = cacheManager.getEhcache(cacheName);
+
+		if ((ehcache != null) &&
+			(ehcache instanceof ModifiableEhcacheWrapper)) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Reconfiguring Hibernate cache " + cacheName);
+			}
+
+			ModifiableEhcacheWrapper modifiableEhcacheWrapper =
+				(ModifiableEhcacheWrapper)ehcache;
+
+			cacheManager.replaceCacheWithDecoratedCache(
+				ehcache, modifiableEhcacheWrapper.getWrappedCache());
+
+			cacheManager.removeCache(cacheName);
+
+			cacheManager.addCache(replacementCache);
+
+			modifiableEhcacheWrapper.setWrappedCache(replacementCache);
+
+			cacheManager.replaceCacheWithDecoratedCache(
+				replacementCache, modifiableEhcacheWrapper);
+		}
+		else {
+			if (_log.isInfoEnabled()) {
+				_log.info("Configuring Hibernate cache " + cacheName);
+			}
+
+			if (ehcache != null) {
+				cacheManager.removeCache(cacheName);
+			}
+
+			ehcache = new ModifiableEhcacheWrapper(replacementCache);
+
+			cacheManager.addCache(replacementCache);
+
+			cacheManager.replaceCacheWithDecoratedCache(
+				replacementCache, ehcache);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		HibernatePortalCacheManager.class);
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/LiferayEhcacheRegionFactory.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/LiferayEhcacheRegionFactory.java
@@ -14,13 +14,10 @@
 
 package com.liferay.portal.dao.orm.hibernate.region;
 
-import com.liferay.portal.cache.ehcache.EhcachePortalCacheManager;
 import com.liferay.portal.cache.ehcache.EhcacheUnwrapUtil;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheManager;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 
@@ -28,10 +25,7 @@ import java.io.Serializable;
 
 import java.util.Properties;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
-import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.hibernate.EhCacheRegionFactory;
 import net.sf.ehcache.hibernate.regions.EhcacheCollectionRegion;
 import net.sf.ehcache.hibernate.regions.EhcacheEntityRegion;
@@ -178,73 +172,7 @@ public class LiferayEhcacheRegionFactory extends EhCacheRegionFactory {
 	private static final String _DEFAULT_CLUSTERED_EHCACHE_CONFIG_FILE =
 		"/ehcache/hibernate-clustered.xml";
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		LiferayEhcacheRegionFactory.class);
-
 	private volatile PortalCacheManager<Serializable, Serializable>
 		_hibernatePortalCacheManager;
-
-	private class HibernatePortalCacheManager
-		extends EhcachePortalCacheManager<Serializable, Serializable> {
-
-		@Override
-		protected Ehcache createEhcache(
-			String portalCacheName, CacheConfiguration cacheConfiguration) {
-
-			reconfigureCache(new Cache(cacheConfiguration));
-
-			CacheManager cacheManager = getEhcacheManager();
-
-			return cacheManager.getCache(portalCacheName);
-		}
-
-		protected void reconfigureCache(Ehcache replacementCache) {
-			CacheManager cacheManager = getEhcacheManager();
-
-			String cacheName = replacementCache.getName();
-
-			Ehcache ehcache = cacheManager.getEhcache(cacheName);
-
-			if ((ehcache != null) &&
-				(ehcache instanceof ModifiableEhcacheWrapper)) {
-
-				if (_log.isInfoEnabled()) {
-					_log.info("Reconfiguring Hibernate cache " + cacheName);
-				}
-
-				ModifiableEhcacheWrapper modifiableEhcacheWrapper =
-					(ModifiableEhcacheWrapper)ehcache;
-
-				cacheManager.replaceCacheWithDecoratedCache(
-					ehcache, modifiableEhcacheWrapper.getWrappedCache());
-
-				cacheManager.removeCache(cacheName);
-
-				cacheManager.addCache(replacementCache);
-
-				modifiableEhcacheWrapper.setWrappedCache(replacementCache);
-
-				cacheManager.replaceCacheWithDecoratedCache(
-					replacementCache, modifiableEhcacheWrapper);
-			}
-			else {
-				if (_log.isInfoEnabled()) {
-					_log.info("Configuring Hibernate cache " + cacheName);
-				}
-
-				if (ehcache != null) {
-					cacheManager.removeCache(cacheName);
-				}
-
-				ehcache = new ModifiableEhcacheWrapper(replacementCache);
-
-				cacheManager.addCache(replacementCache);
-
-				cacheManager.replaceCacheWithDecoratedCache(
-					replacementCache, ehcache);
-			}
-		}
-
-	}
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/LiferayEhcacheRegionFactory.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/LiferayEhcacheRegionFactory.java
@@ -175,50 +175,6 @@ public class LiferayEhcacheRegionFactory extends EhCacheRegionFactory {
 		}
 	}
 
-	protected void reconfigureCache(Ehcache replacementCache) {
-		String cacheName = replacementCache.getName();
-
-		Ehcache ehcache = manager.getEhcache(cacheName);
-
-		if ((ehcache != null) &&
-			(ehcache instanceof ModifiableEhcacheWrapper)) {
-
-			if (_log.isInfoEnabled()) {
-				_log.info("Reconfiguring Hibernate cache " + cacheName);
-			}
-
-			ModifiableEhcacheWrapper modifiableEhcacheWrapper =
-				(ModifiableEhcacheWrapper)ehcache;
-
-			manager.replaceCacheWithDecoratedCache(
-				ehcache, modifiableEhcacheWrapper.getWrappedCache());
-
-			manager.removeCache(cacheName);
-
-			manager.addCache(replacementCache);
-
-			modifiableEhcacheWrapper.setWrappedCache(replacementCache);
-
-			manager.replaceCacheWithDecoratedCache(
-				replacementCache, modifiableEhcacheWrapper);
-		}
-		else {
-			if (_log.isInfoEnabled()) {
-				_log.info("Configuring Hibernate cache " + cacheName);
-			}
-
-			if (ehcache != null) {
-				manager.removeCache(cacheName);
-			}
-
-			ehcache = new ModifiableEhcacheWrapper(replacementCache);
-
-			manager.addCache(replacementCache);
-
-			manager.replaceCacheWithDecoratedCache(replacementCache, ehcache);
-		}
-	}
-
 	private static final String _DEFAULT_CLUSTERED_EHCACHE_CONFIG_FILE =
 		"/ehcache/hibernate-clustered.xml";
 
@@ -240,6 +196,53 @@ public class LiferayEhcacheRegionFactory extends EhCacheRegionFactory {
 			CacheManager cacheManager = getEhcacheManager();
 
 			return cacheManager.getCache(portalCacheName);
+		}
+
+		protected void reconfigureCache(Ehcache replacementCache) {
+			CacheManager cacheManager = getEhcacheManager();
+
+			String cacheName = replacementCache.getName();
+
+			Ehcache ehcache = cacheManager.getEhcache(cacheName);
+
+			if ((ehcache != null) &&
+				(ehcache instanceof ModifiableEhcacheWrapper)) {
+
+				if (_log.isInfoEnabled()) {
+					_log.info("Reconfiguring Hibernate cache " + cacheName);
+				}
+
+				ModifiableEhcacheWrapper modifiableEhcacheWrapper =
+					(ModifiableEhcacheWrapper)ehcache;
+
+				cacheManager.replaceCacheWithDecoratedCache(
+					ehcache, modifiableEhcacheWrapper.getWrappedCache());
+
+				cacheManager.removeCache(cacheName);
+
+				cacheManager.addCache(replacementCache);
+
+				modifiableEhcacheWrapper.setWrappedCache(replacementCache);
+
+				cacheManager.replaceCacheWithDecoratedCache(
+					replacementCache, modifiableEhcacheWrapper);
+			}
+			else {
+				if (_log.isInfoEnabled()) {
+					_log.info("Configuring Hibernate cache " + cacheName);
+				}
+
+				if (ehcache != null) {
+					cacheManager.removeCache(cacheName);
+				}
+
+				ehcache = new ModifiableEhcacheWrapper(replacementCache);
+
+				cacheManager.addCache(replacementCache);
+
+				cacheManager.replaceCacheWithDecoratedCache(
+					replacementCache, ehcache);
+			}
 		}
 
 	}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/LiferayEhcacheRegionFactory.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/region/LiferayEhcacheRegionFactory.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.Properties;
 
 import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.hibernate.EhCacheRegionFactory;
@@ -236,7 +237,9 @@ public class LiferayEhcacheRegionFactory extends EhCacheRegionFactory {
 
 			reconfigureCache(new Cache(cacheConfiguration));
 
-			return manager.getCache(portalCacheName);
+			CacheManager cacheManager = getEhcacheManager();
+
+			return cacheManager.getCache(portalCacheName);
 		}
 
 	}


### PR DESCRIPTION
@shuyangzhou 
Hi Michael,

This is the first group of changes for cleaning before extracting portal cache as a bundle. 

I made these changes because I want to move HibernatePortalCacheManager into portal-cache-ehcache bundle instead of portal-hibernate-ehcache, and make portal-hibernate-ehcache a client of HibernatePortalCacheManager service.  
The benefits are 1) do not need to export implementation details(for example EhcachePortalCacheManager) 2) make HibernatePortalCacheManager consistent with other portal cache manager services

In case you want to see the whole picture, please see https://github.com/mhan810/liferay-portal/pull/349


Thanks.
Tina.
 

