### PR TITLE
[TECHNICAL-SUPPORT] LPS-56374 Set staging life cycle

### DIFF
--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -408,6 +408,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 
 		try {
 			ExportImportThreadLocal.setLayoutImportInProcess(true);
+			ExportImportThreadLocal.setLayoutStagingInProcess(true);
 
 			Folder folder = PortletFileRepositoryUtil.getPortletFolder(
 				stagingRequestId);
@@ -441,6 +442,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 		}
 		finally {
 			ExportImportThreadLocal.setLayoutImportInProcess(false);
+			ExportImportThreadLocal.setLayoutStagingInProcess(false);
 		}
 	}
 


### PR DESCRIPTION
Hey Máté,

even though in **LayoutRemoteStagingBackgroundTaskExecutor** the **ExportImportThreadLocal.setLayoutStagingInProcess(true);** is called, but it affects only the export side, and in case of remote staging, the import side is unaware of this flag.

Actually, this is a separate bug from [LPS-56374](https://issues.liferay.com/browse/LPS-56374), however the fix for LPS-56374 depends on it, so I think the best solution would be to commit this fix under LPS-56374 as well, so we will have a complete solution.

Thanks,
Tamás