### PR TITLE
Lps 57877

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -120,7 +120,15 @@
 jdbc.default.driverClassName=${database.driver}
 jdbc.default.url=${database.url}
 jdbc.default.username=${database.username}
-jdbc.default.password=${database.password}]]></echo>
+jdbc.default.password=${database.password}
+
+counter.jdbc.prefix=jdbc.counter.
+
+jdbc.counter.maximumPoolSize=5
+jdbc.counter.minimumIdle=0
+
+jdbc.default.maximumPoolSize=20
+jdbc.default.minimumIdle=0]]></echo>
 
 			<post-action />
 		</sequential>

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -456,8 +456,9 @@ public abstract class BaseDB implements DB {
 			String template, boolean evaluate, boolean failOnError)
 		throws IOException, NamingException, SQLException {
 
-		runSQLTemplateString(
-			DataAccess.getConnection(), template, evaluate, failOnError);
+		try (Connection connection = DataAccess.getConnection()) {
+			runSQLTemplateString(connection, template, evaluate, failOnError);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
@migue this is caused by your change at https://github.com/liferay/liferay-portal/commit/48830515ffd9661a9fac2831efd9a239dbec11ac

It creates a massive jdbc connection leak during module DB populating.

We found this during the Sybase integration on CI, sybase is very mean only allow 25 max connections, and portal is choking on this because of it is leaking way more than 25 connections. Other DBs are just too generous to cover up this issue until now.

@brianchandotcom I added in the 2nd commit to simulate the Sybase limitation, so that if anything like this happens again in the future, all DB tests on CI will caught it as running out of connection timeout errors, not just Sybase.