### PR TITLE
LRQA-17470 Double click to expand lines in poshi logger

### DIFF
--- a/modules/test/poshi-runner/src/META-INF/resources/js/component.js
+++ b/modules/test/poshi-runner/src/META-INF/resources/js/component.js
@@ -164,6 +164,10 @@ YUI.add(
 
 						var currentTargetAncestor = event.currentTarget.ancestor();
 
+						if (!currentTargetAncestor.hasClass('current-scope')) {
+							event.halt(true);
+						}
+
 						if (currentTargetAncestor) {
 							instance._parseCommandLog(currentTargetAncestor);
 
@@ -180,13 +184,15 @@ YUI.add(
 					handleCurrentScopeSelect: function(event) {
 						var instance = this;
 
-						var currentTarget = event.currentTarget.ancestor();
+						var currentTargetAncestor = event.currentTarget.ancestor();
 
-						event.stopPropagation();
+						if (!currentTargetAncestor.hasClass('current-scope')) {
+							event.halt(true);
+						}
 
-						instance._displayNode(currentTarget);
+						instance._displayNode(currentTargetAncestor);
 
-						instance._selectCurrentScope(currentTarget);
+						instance._selectCurrentScope(currentTargetAncestor);
 					},
 
 					handleErrorBtns: function(event) {
@@ -271,6 +277,18 @@ YUI.add(
 
 						var currentTarget = event.currentTarget;
 
+						if (!currentTarget.hasClass('btn')) {
+							currentTarget = currentTarget.previous();
+
+							if (!inSidebar) {
+								currentTarget = currentTarget.one('.btn-collapse');
+							}
+
+							if (!currentTarget) {
+								return;
+							}
+						}
+
 						var lookUpScope = instance.get(STR_XML_LOG);
 
 						if (inSidebar) {
@@ -305,6 +323,12 @@ YUI.add(
 							'click',
 							A.bind('handleCurrentCommandSelect', instance),
 							'.linkable .line-container'
+						);
+
+						sidebar.delegate(
+							'click',
+							A.rbind('handleToggleCollapseBtn', instance, true),
+							'.linkable.current-scope .line-container'
 						);
 
 						sidebar.delegate(
@@ -360,6 +384,12 @@ YUI.add(
 							'click',
 							A.rbind('handleToggleCollapseBtn', instance, false),
 							'.btn-collapse, .btn-var'
+						);
+
+						xmlLog.delegate(
+							'click',
+							A.rbind('handleToggleCollapseBtn', instance, false),
+							'.current-scope > .line-container'
 						);
 
 						xmlLog.delegate(


### PR DESCRIPTION
Hey @jonmak08,

This fix allows the lines of the logger to expand on double click.
https://issues.liferay.com/browse/LRQA-17470
