### PR TITLE
[Technica Support] LPS-60792 Reverting falling back to the previous scope type

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -193,7 +193,6 @@ public class JournalContentExportImportPortletPreferencesProcessor
 		}
 
 		long previousScopeGroupId = portletDataContext.getScopeGroupId();
-		String previousScopeType = portletDataContext.getScopeType();
 
 		Map<Long, Long> groupIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -269,7 +268,6 @@ public class JournalContentExportImportPortletPreferencesProcessor
 		}
 
 		portletDataContext.setScopeGroupId(previousScopeGroupId);
-		portletDataContext.setScopeType(previousScopeType);
 
 		return portletPreferences;
 	}


### PR DESCRIPTION
Hi Máté,

I could not found better solution for this because as I can see, there is no other way to handle different data level scope from the portlet level scope within a portlet.

Because of that, I only reverted the fallback logic.

Please, let me know if you have any better idea.

See the antecedent pull request: https://github.com/matethurzo/liferay-portal/pull/1273#issuecomment-162601686

Thank you,
Zsigmond