### PR TITLE
LPS-61962 Fix Facebook's struts action (broke again)

### DIFF
--- a/modules/portal-security/portal-security-sso-facebook-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/test/FacebookConnectCompanySettingsVerifyProcessTest.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/test/FacebookConnectCompanySettingsVerifyProcessTest.java
@@ -80,7 +80,7 @@ public class FacebookConnectCompanySettingsVerifyProcessTest
 				FacebookConnectConfigurationKeys.OAUTH_AUTH_URL,
 				StringPool.BLANK));
 		Assert.assertEquals(
-			"test_oauth_redirect_url",
+			"http://localhost:8080/c/portal/facebook_connect_oauth",
 			settings.getValue(
 				FacebookConnectConfigurationKeys.OAUTH_REDIRECT_URL,
 				StringPool.BLANK));
@@ -119,7 +119,7 @@ public class FacebookConnectCompanySettingsVerifyProcessTest
 			"test_oauth_auth_url");
 		properties.put(
 			LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL,
-			"test_oauth_redirect_url");
+			"http://localhost:8080/c/login/facebook_connect_oauth");
 		properties.put(
 			LegacyFacebookConnectPropsKeys.OAUTH_TOKEN_URL,
 			"test_oauth_token_url");

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/configuration/FacebookConnectConfiguration.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/configuration/FacebookConnectConfiguration.java
@@ -47,7 +47,7 @@ public interface FacebookConnectConfiguration {
 	public String oauthAuthURL();
 
 	@Meta.AD(
-		deflt = "http://localhost:8080/c/facebook_connect/facebook_connect_oauth",
+		deflt = "http://localhost:8080/c/portal/facebook_connect_oauth",
 		required = false
 	)
 	public String oauthRedirectURL();

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/portlet/action/FacebookConnectAction.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/portlet/action/FacebookConnectAction.java
@@ -66,7 +66,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"/common/referer_jsp.jsp=/common/referer_jsp.jsp",
-		"path=/facebook_connect/facebook_connect_oauth",
+		"path=/portal/facebook_connect_oauth",
 		"portlet.login.login=portlet.login.login",
 		"portlet.login.update_account=portlet.login.update_account"
 	},

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConfigurationKeys;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants;
 import com.liferay.portal.security.sso.facebook.connect.constants.LegacyFacebookConnectPropsKeys;
@@ -85,9 +86,11 @@ public class FacebookConnectCompanySettingsVerifyProcess
 				StringPool.BLANK));
 		dictionary.put(
 			FacebookConnectConfigurationKeys.OAUTH_REDIRECT_URL,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL,
-				StringPool.BLANK));
+			upgradeOAuthRedirectURI(
+				_prefsProps.getString(
+						companyId,
+						LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL,
+						StringPool.BLANK)));
 		dictionary.put(
 			FacebookConnectConfigurationKeys.OAUTH_TOKEN_URL,
 			_prefsProps.getString(
@@ -128,6 +131,15 @@ public class FacebookConnectCompanySettingsVerifyProcess
 	@Reference(unbind = "-")
 	protected void setSettingsFactory(SettingsFactory settingsFactory) {
 		_settingsFactory = settingsFactory;
+	}
+
+	private String upgradeOAuthRedirectURI(String redirectURIFromLiferay62) {
+		if (Validator.isNull(redirectURIFromLiferay62))
+			return redirectURIFromLiferay62;
+
+		return redirectURIFromLiferay62.replaceFirst(
+			"/c/login/facebook_connect_oauth",
+			"/c/portal/facebook_connect_oauth");
 	}
 
 	private CompanyLocalService _companyLocalService;

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/web/portlet/path/AuthPublicPath.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/web/portlet/path/AuthPublicPath.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	immediate = true,
-	property = {"auth.public.path=/facebook_connect/facebook_connect_oauth"},
+	property = {"auth.public.path=/portal/facebook_connect_oauth"},
 	service = Object.class
 )
 public class AuthPublicPath {


### PR DESCRIPTION
Hi Tomas. The Facebook integration needs a slight tweak since LPS-61464 (the original Struts fix) because the Struts action needs to be associate with a portlet. I've now set it to "/portal" which is what Google SSO is also using.

There must have been a core bug that previously allowed the Facebook Struts action to work without a portlet being associated!