### PR TITLE
[TECHNICAL-SUPPORT] LPS-62480 Do not call flushInits without actual deployment

### DIFF
--- a/portal-impl/src/com/liferay/portal/deploy/hot/HotDeployImpl.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/HotDeployImpl.java
@@ -258,7 +258,9 @@ public class HotDeployImpl implements HotDeploy {
 
 					doFireDeployEvent(dependentEvent);
 
-					dependentEvent.flushInits();
+					if (!_dependentHotDeployEvents.contains(dependentEvent)) {
+						dependentEvent.flushInits();
+					}
 				}
 			}
 			finally {


### PR DESCRIPTION
[LPS-62480](https://issues.liferay.com/browse/LPS-62480)

**Problem:**
Using PortalDelegateServlet can cause deployment/initialization problems. The cause is that we call flushInits even if the plugin have been put into the deployment queue due to missing dependencies. Through flushInits the initialization of the servlet defined in PortalDelegateServlet's servlet-class init-param will be started attempting to access object prepared only later in the context initialization false.

**Solution:**
Doesn't call flushInits if the plugin is queued for later deployment.

**Note:** As Tomcat's FAQ says: "There is no expected startup order." (http://wiki.apache.org/tomcat/FAQ/Miscellaneous#Q27) Due to this fact it may be possible that you won't be able to reproduce the issue with the steps on the LPS ticket.