### PR TITLE
LPS-62457

### DIFF
--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingService.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingService.java
@@ -151,7 +151,16 @@ public interface CalendarBookingService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public boolean hasChildCalendarBookings(long parentCalendarBookingId);
 
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link #invokeTransition(long, int,
+	long, boolean, boolean, ServiceContext)}
+	*/
+	@java.lang.Deprecated
 	public void invokeTransition(long calendarBookingId, int status,
+		ServiceContext serviceContext) throws PortalException;
+
+	public CalendarBooking invokeTransition(long calendarBookingId, int status,
+		long startTime, boolean updateInstance, boolean allFollowing,
 		ServiceContext serviceContext) throws PortalException;
 
 	public CalendarBooking moveCalendarBookingToTrash(long calendarBookingId)

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingServiceUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingServiceUtil.java
@@ -199,10 +199,25 @@ public class CalendarBookingServiceUtil {
 		return getService().hasChildCalendarBookings(parentCalendarBookingId);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link #invokeTransition(long, int,
+	long, boolean, boolean, ServiceContext)}
+	*/
+	@Deprecated
 	public static void invokeTransition(long calendarBookingId, int status,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService().invokeTransition(calendarBookingId, status, serviceContext);
+	}
+
+	public static com.liferay.calendar.model.CalendarBooking invokeTransition(
+		long calendarBookingId, int status, long startTime,
+		boolean updateInstance, boolean allFollowing,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .invokeTransition(calendarBookingId, status, startTime,
+			updateInstance, allFollowing, serviceContext);
 	}
 
 	public static com.liferay.calendar.model.CalendarBooking moveCalendarBookingToTrash(

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingServiceWrapper.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingServiceWrapper.java
@@ -205,12 +205,27 @@ public class CalendarBookingServiceWrapper implements CalendarBookingService,
 		return _calendarBookingService.hasChildCalendarBookings(parentCalendarBookingId);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link #invokeTransition(long, int,
+	long, boolean, boolean, ServiceContext)}
+	*/
+	@Deprecated
 	@Override
 	public void invokeTransition(long calendarBookingId, int status,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		_calendarBookingService.invokeTransition(calendarBookingId, status,
 			serviceContext);
+	}
+
+	@Override
+	public com.liferay.calendar.model.CalendarBooking invokeTransition(
+		long calendarBookingId, int status, long startTime,
+		boolean updateInstance, boolean allFollowing,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _calendarBookingService.invokeTransition(calendarBookingId,
+			status, startTime, updateInstance, allFollowing, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/http/CalendarBookingServiceHttp.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/http/CalendarBookingServiceHttp.java
@@ -666,13 +666,48 @@ public class CalendarBookingServiceHttp {
 		}
 	}
 
+	public static com.liferay.calendar.model.CalendarBooking invokeTransition(
+		HttpPrincipal httpPrincipal, long calendarBookingId, int status,
+		long startTime, boolean updateInstance, boolean allFollowing,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
+					"invokeTransition", _invokeTransitionParameterTypes18);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					calendarBookingId, status, startTime, updateInstance,
+					allFollowing, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.calendar.model.CalendarBooking)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static void invokeTransition(HttpPrincipal httpPrincipal,
 		long calendarBookingId, int status,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
-					"invokeTransition", _invokeTransitionParameterTypes18);
+					"invokeTransition", _invokeTransitionParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, status, serviceContext);
@@ -701,7 +736,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"moveCalendarBookingToTrash",
-					_moveCalendarBookingToTrashParameterTypes19);
+					_moveCalendarBookingToTrashParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId);
@@ -734,7 +769,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"restoreCalendarBookingFromTrash",
-					_restoreCalendarBookingFromTrashParameterTypes20);
+					_restoreCalendarBookingFromTrashParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId);
@@ -771,7 +806,7 @@ public class CalendarBookingServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
-					"search", _searchParameterTypes21);
+					"search", _searchParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupIds, calendarIds, calendarResourceIds,
@@ -811,7 +846,7 @@ public class CalendarBookingServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
-					"search", _searchParameterTypes22);
+					"search", _searchParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupIds, calendarIds, calendarResourceIds,
@@ -848,7 +883,7 @@ public class CalendarBookingServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
-					"searchCount", _searchCountParameterTypes23);
+					"searchCount", _searchCountParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupIds, calendarIds, calendarResourceIds,
@@ -886,7 +921,7 @@ public class CalendarBookingServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
-					"searchCount", _searchCountParameterTypes24);
+					"searchCount", _searchCountParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupIds, calendarIds, calendarResourceIds,
@@ -929,7 +964,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"updateCalendarBooking",
-					_updateCalendarBookingParameterTypes25);
+					_updateCalendarBookingParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, calendarId, childCalendarIds, titleMap,
@@ -972,7 +1007,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"updateCalendarBooking",
-					_updateCalendarBookingParameterTypes26);
+					_updateCalendarBookingParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, calendarId, titleMap, descriptionMap,
@@ -1016,7 +1051,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"updateCalendarBookingInstance",
-					_updateCalendarBookingInstanceParameterTypes27);
+					_updateCalendarBookingInstanceParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, instanceIndex, calendarId,
@@ -1064,7 +1099,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"updateCalendarBookingInstance",
-					_updateCalendarBookingInstanceParameterTypes28);
+					_updateCalendarBookingInstanceParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, instanceIndex, calendarId, titleMap,
@@ -1111,7 +1146,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"updateCalendarBookingInstance",
-					_updateCalendarBookingInstanceParameterTypes29);
+					_updateCalendarBookingInstanceParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, instanceIndex, calendarId, titleMap,
@@ -1155,7 +1190,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"updateOffsetAndDuration",
-					_updateOffsetAndDurationParameterTypes30);
+					_updateOffsetAndDurationParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, calendarId, childCalendarIds, titleMap,
@@ -1198,7 +1233,7 @@ public class CalendarBookingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(CalendarBookingServiceUtil.class,
 					"updateOffsetAndDuration",
-					_updateOffsetAndDurationParameterTypes31);
+					_updateOffsetAndDurationParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					calendarBookingId, calendarId, titleMap, descriptionMap,
@@ -1293,53 +1328,57 @@ public class CalendarBookingServiceHttp {
 			long.class
 		};
 	private static final Class<?>[] _invokeTransitionParameterTypes18 = new Class[] {
+			long.class, int.class, long.class, boolean.class, boolean.class,
+			com.liferay.portal.service.ServiceContext.class
+		};
+	private static final Class<?>[] _invokeTransitionParameterTypes19 = new Class[] {
 			long.class, int.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveCalendarBookingToTrashParameterTypes19 = new Class[] {
+	private static final Class<?>[] _moveCalendarBookingToTrashParameterTypes20 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _restoreCalendarBookingFromTrashParameterTypes20 =
+	private static final Class<?>[] _restoreCalendarBookingFromTrashParameterTypes21 =
 		new Class[] { long.class };
-	private static final Class<?>[] _searchParameterTypes21 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes22 = new Class[] {
 			long.class, long[].class, long[].class, long[].class, long.class,
 			java.lang.String.class, long.class, long.class, boolean.class,
 			int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _searchParameterTypes22 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes23 = new Class[] {
 			long.class, long[].class, long[].class, long[].class, long.class,
 			java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, long.class, long.class, boolean.class,
 			int[].class, boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _searchCountParameterTypes23 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes24 = new Class[] {
 			long.class, long[].class, long[].class, long[].class, long.class,
 			java.lang.String.class, long.class, long.class, boolean.class,
 			int[].class
 		};
-	private static final Class<?>[] _searchCountParameterTypes24 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes25 = new Class[] {
 			long.class, long[].class, long[].class, long[].class, long.class,
 			java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, long.class, long.class, boolean.class,
 			int[].class, boolean.class
 		};
-	private static final Class<?>[] _updateCalendarBookingParameterTypes25 = new Class[] {
+	private static final Class<?>[] _updateCalendarBookingParameterTypes26 = new Class[] {
 			long.class, long.class, long[].class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class, long.class, long.class,
 			boolean.class, java.lang.String.class, long.class,
 			java.lang.String.class, long.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateCalendarBookingParameterTypes26 = new Class[] {
+	private static final Class<?>[] _updateCalendarBookingParameterTypes27 = new Class[] {
 			long.class, long.class, java.util.Map.class, java.util.Map.class,
 			java.lang.String.class, long.class, long.class, boolean.class,
 			java.lang.String.class, long.class, java.lang.String.class,
 			long.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateCalendarBookingInstanceParameterTypes27 =
+	private static final Class<?>[] _updateCalendarBookingInstanceParameterTypes28 =
 		new Class[] {
 			long.class, int.class, long.class, long[].class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class, long.class, long.class,
@@ -1347,7 +1386,7 @@ public class CalendarBookingServiceHttp {
 			java.lang.String.class, long.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateCalendarBookingInstanceParameterTypes28 =
+	private static final Class<?>[] _updateCalendarBookingInstanceParameterTypes29 =
 		new Class[] {
 			long.class, int.class, long.class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class, int.class, int.class,
@@ -1357,7 +1396,7 @@ public class CalendarBookingServiceHttp {
 			java.lang.String.class, long.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateCalendarBookingInstanceParameterTypes29 =
+	private static final Class<?>[] _updateCalendarBookingInstanceParameterTypes30 =
 		new Class[] {
 			long.class, int.class, long.class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class, long.class, long.class,
@@ -1365,14 +1404,14 @@ public class CalendarBookingServiceHttp {
 			java.lang.String.class, long.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateOffsetAndDurationParameterTypes30 = new Class[] {
+	private static final Class<?>[] _updateOffsetAndDurationParameterTypes31 = new Class[] {
 			long.class, long.class, long[].class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class, long.class, long.class,
 			boolean.class, java.lang.String.class, long.class,
 			java.lang.String.class, long.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateOffsetAndDurationParameterTypes31 = new Class[] {
+	private static final Class<?>[] _updateOffsetAndDurationParameterTypes32 = new Class[] {
 			long.class, long.class, java.util.Map.class, java.util.Map.class,
 			java.lang.String.class, long.class, long.class, boolean.class,
 			java.lang.String.class, long.class, java.lang.String.class,

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/http/CalendarBookingServiceSoap.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/http/CalendarBookingServiceSoap.java
@@ -367,6 +367,30 @@ public class CalendarBookingServiceSoap {
 		}
 	}
 
+	public static com.liferay.calendar.model.CalendarBookingSoap invokeTransition(
+		long calendarBookingId, int status, long startTime,
+		boolean updateInstance, boolean allFollowing,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.calendar.model.CalendarBooking returnValue = CalendarBookingServiceUtil.invokeTransition(calendarBookingId,
+					status, startTime, updateInstance, allFollowing,
+					serviceContext);
+
+			return com.liferay.calendar.model.CalendarBookingSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link #invokeTransition(long, int,
+	long, boolean, boolean, ServiceContext)}
+	*/
+	@Deprecated
 	public static void invokeTransition(long calendarBookingId, int status,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws RemoteException {

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
@@ -17,11 +17,14 @@ package com.liferay.calendar.service.impl;
 import com.liferay.calendar.constants.CalendarActionKeys;
 import com.liferay.calendar.model.Calendar;
 import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.calendar.recurrence.Recurrence;
+import com.liferay.calendar.recurrence.RecurrenceSerializer;
 import com.liferay.calendar.service.base.CalendarBookingServiceBaseImpl;
 import com.liferay.calendar.service.permission.CalendarPermission;
 import com.liferay.calendar.util.CalendarUtil;
 import com.liferay.calendar.util.JCalendarUtil;
 import com.liferay.calendar.util.RSSUtil;
+import com.liferay.calendar.util.RecurrenceUtil;
 import com.liferay.calendar.workflow.CalendarBookingWorkflowConstants;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -358,12 +361,57 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 	}
 
 	@Override
-	public void invokeTransition(
-			long calendarBookingId, int status, ServiceContext serviceContext)
+	public CalendarBooking invokeTransition(
+			long calendarBookingId, int status, long startTime,
+			boolean updateInstance, boolean allFollowing,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		CalendarBooking calendarBooking =
 			calendarBookingPersistence.findByPrimaryKey(calendarBookingId);
+
+		if (updateInstance) {
+			long calendarId = calendarBooking.getCalendarId();
+			long[] childCalendarIds =
+				calendarBookingLocalService.getChildCalendarIds(
+					calendarBookingId, calendarId);
+
+			long duration =
+				calendarBooking.getEndTime() - calendarBooking.getStartTime();
+
+			long endTime = startTime + duration;
+
+			String recurrence = null;
+
+			if (allFollowing) {
+				Recurrence recurrenceObj = calendarBooking.getRecurrenceObj();
+
+				int count = recurrenceObj.getCount();
+
+				if (count > 0) {
+					int instanceIndex = RecurrenceUtil.getIndexOfInstance(
+						calendarBooking.getRecurrence(),
+						calendarBooking.getStartTime(), startTime);
+
+					recurrenceObj.setCount(count - instanceIndex);
+				}
+
+				recurrence = RecurrenceSerializer.serialize(recurrenceObj);
+			}
+
+			deleteCalendarBookingInstance(
+				calendarBookingId, startTime, allFollowing);
+
+			calendarBooking = addCalendarBooking(
+				calendarId, childCalendarIds, 0, calendarBooking.getTitleMap(),
+				calendarBooking.getDescriptionMap(),
+				calendarBooking.getLocation(), startTime, endTime,
+				calendarBooking.isAllDay(), recurrence,
+				calendarBooking.getFirstReminder(),
+				calendarBooking.getFirstReminderType(),
+				calendarBooking.getSecondReminder(),
+				calendarBooking.getSecondReminderType(), serviceContext);
+		}
 
 		CalendarPermission.check(
 			getPermissionChecker(), calendarBooking.getCalendarId(),
@@ -371,6 +419,22 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 
 		calendarBookingLocalService.updateStatus(
 			getUserId(), calendarBooking, status, serviceContext);
+
+		return calendarBooking;
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #invokeTransition(long, int,
+	 *             long, boolean, boolean, ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public void invokeTransition(
+			long calendarBookingId, int status, ServiceContext serviceContext)
+		throws PortalException {
+
+		invokeTransition(
+			calendarBookingId, status, 0, false, false, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/portlet/CalendarPortlet.java
@@ -203,11 +203,34 @@ public class CalendarPortlet extends MVCPortlet {
 
 		int status = ParamUtil.getInteger(actionRequest, "status");
 
+		long startTime = ParamUtil.getLong(actionRequest, "startTime");
+
+		boolean updateInstance = ParamUtil.getBoolean(
+			actionRequest, "updateInstance");
+
+		boolean allFollowing = ParamUtil.getBoolean(
+			actionRequest, "allFollowing");
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			CalendarBooking.class.getName(), actionRequest);
 
-		_calendarBookingService.invokeTransition(
-			calendarBookingId, status, serviceContext);
+		CalendarBooking calendarBooking =
+			_calendarBookingService.invokeTransition(
+				calendarBookingId, status, startTime, updateInstance,
+				allFollowing, serviceContext);
+
+		String redirect = getRedirect(actionRequest, actionResponse);
+
+		if (calendarBooking.getCalendarBookingId() != calendarBookingId) {
+			redirect = StringUtil.replace(
+				redirect, "/-/calendar/event/" + calendarBookingId,
+				"/-/calendar/event/" + calendarBooking.getCalendarBookingId());
+
+			redirect = HttpUtil.removeParameter(
+				redirect, actionResponse.getNamespace() + "instanceIndex");
+		}
+
+		actionRequest.setAttribute(WebKeys.REDIRECT, redirect);
 	}
 
 	public void moveCalendarBookingToTrash(

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/javascript.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/javascript.js
@@ -770,14 +770,19 @@ AUI.add(
 				A.each(
 					schedulerEvents,
 					function(schedulerEvent) {
-						if (calendarBooking.status === CalendarWorkflow.STATUS_DENIED) {
+						if (schedulerEvent.isRecurring() || calendarBooking.status === CalendarWorkflow.STATUS_DENIED) {
 							var scheduler = schedulerEvent.get('scheduler');
 
 							var eventRecorder = scheduler.get('eventRecorder');
 
 							eventRecorder.hidePopover();
 
-							CalendarUtil.destroyEvent(schedulerEvent);
+							if schedulerEvent.isRecurring() {
+								scheduler.load();
+							}
+							if calendarBooking.status === CalendarWorkflow.STATUS_DENIED {
+								CalendarUtil.destroyEvent(schedulerEvent);
+							}
 						}
 						else {
 							schedulerEvent.set('status', calendarBooking.status);

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_booking.jsp
@@ -169,6 +169,9 @@ AssetEntry layoutAssetEntry = AssetEntryLocalServiceUtil.getEntry(CalendarBookin
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 	<aui:input name="calendarBookingId" type="hidden" value="<%= calendarBooking.getCalendarBookingId() %>" />
 	<aui:input name="status" type="hidden" />
+	<aui:input name="startTime" type="hidden" value = "<%= calendarBooking.getStartTime() %>" />
+	<aui:input name="updateInstance" type="hidden" value="false" />
+	<aui:input name="allFollowing" type="hidden" value="false" />
 
 	<aui:fieldset>
 		<aui:button-row>
@@ -199,7 +202,27 @@ AssetEntry layoutAssetEntry = AssetEntryLocalServiceUtil.getEntry(CalendarBookin
 	function <portlet:namespace />invokeTransition(status) {
 		document.<portlet:namespace />fm.<portlet:namespace />status.value = status;
 
-		submitForm(document.<portlet:namespace />fm);
+		if (<%= calendarBooking.isRecurring() %>) {
+			Liferay.RecurrenceUtil.openConfirmationPanel(
+				'invokeTransition',
+				function() {
+					document.<portlet:namespace />fm.<portlet:namespace />updateInstance.value = 'true';
+					submitForm(document.<portlet:namespace />fm);
+				},
+				function() {
+					document.<portlet:namespace />fm.<portlet:namespace />updateInstance.value = 'true';
+					document.<portlet:namespace />fm.<portlet:namespace />allFollowing.value = 'true';
+					submitForm(document.<portlet:namespace />fm);
+				},
+				function() {
+					submitForm(document.<portlet:namespace />fm);
+				}
+			);
+		}
+
+		else {
+			submitForm(document.<portlet:namespace />fm);
+		}
 	}
 </aui:script>
 

--- a/portal-service/src/com/liferay/portal/kernel/cal/Recurrence.java
+++ b/portal-service/src/com/liferay/portal/kernel/cal/Recurrence.java
@@ -1134,7 +1134,7 @@ public class Recurrence implements Serializable {
 	protected int interval;
 
 	/**
-	 * Field interval
+	 * Field occurrence
 	 */
 	protected int occurrence = 0;
 


### PR DESCRIPTION
Hey Bryan,

To answer question 4 on [your previous comment](https://github.com/BryanEngler/liferay-portal/pull/143#issuecomment-178185302), we don't delete the booking. We call deleteCalendarBookingInstance, which only deletes a single instance of a recurring event. The booking still remains in the table. We do this so that we can create two separate bookings:

1. The original booking with the original status, now with an exception date for the booking that the user modified
2. The new booking with the new status, which occurs on the date that the user modified.