### PR TITLE
LPS-64621 Copying modules to $LIFERAY_HOME/deploy assumes they should…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -244,7 +244,8 @@
 
     #
     # Set the directory to scan for layout templates, portlets, and themes to
-    # auto deploy.
+    # auto deploy. Modules will be automatically copied to the first directory
+    # that appears in the "module.framework.auto.deploy.dirs" property. 
     #
     auto.deploy.deploy.dir=${liferay.home}/deploy
 
@@ -6403,7 +6404,7 @@
     # Set a comma delimited list of directories to scan for modules and
     # configurations to auto deploy.
     #
-    module.framework.auto.deploy.dirs=${module.framework.base.dir}/configs,${module.framework.base.dir}/modules
+    module.framework.auto.deploy.dirs=${module.framework.base.dir}/modules,${module.framework.base.dir}/configs
 
     #
     # Set the interval in milliseconds on how often to scan the directories for


### PR DESCRIPTION
… be in osgi/configs instead of osgi/modules