### PR TITLE
[TECHNICAL SUPPORT] LPS-63922 User-specific portlet preferences are not cleaned up when the portlet is removed and portlet can not be re-added 

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -217,15 +217,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 			companyId, rootPortletId, ResourceConstants.SCOPE_INDIVIDUAL,
 			PortletPermissionUtil.getPrimaryKey(plid, portletId));
 
-		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
-
-		if (PortletConstants.hasUserId(portletId)) {
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-		}
-
 		List<PortletPreferences> portletPreferencesList =
 			portletPreferencesLocalService.getPortletPreferences(
-				ownerType, plid, portletId);
+				plid, portletId);
 
 		Portlet portlet = getPortletById(companyId, portletId);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-63922

Hi Ray,

See Norbert's comment:
>Use cases to consider:
1. Preferences-unique-per-layout=true preferences-owned-by-group=true
plid+portletId will be unique in this case and that record should be removed.
2. Preferences-unique-per-layout=true preferences-owned-by-group=false
This is what the issue is about. In this case there will be one record for the layout owned by the group, and one owned by each user who configures the portlet. Every one of those needs to be removed.
3. The column is customizable.
plid+portletId will be unique (portletId + userId separator + userId) in this case and that record has to be romoved

>In other cases the preferences won't be related to the layout so they won't be removed.

I've asked him to create a test for this. We'll submit if you agree with his changes.

Thanks,
Tibor

/cc @NorbertKocsis