### PR TITLE
LPS-64931 Return record and journal information when querying a list of assets

### DIFF
--- a/modules/apps/screens/screens-service/build.gradle
+++ b/modules/apps/screens/screens-service/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.lists.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.lists.service", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.0.0"
+	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.service", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.journal.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.journal.service", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"

--- a/modules/apps/screens/screens-service/service.xml
+++ b/modules/apps/screens/screens-service/service.xml
@@ -5,6 +5,9 @@
 	<author>José Manuel Navarro</author>
 	<namespace>Screens</namespace>
 	<entity name="ScreensAssetEntry" local-service="false" remote-service="true">
+		<reference package-path="com.liferay.dynamic.data.lists" entity="DDLRecord" />
+		<reference package-path="com.liferay.dynamic.data.lists" entity="DDLRecordSet" />
+		<reference package-path="com.liferay.dynamic.data.mapping" entity="DDMStructure" />
 		<reference package-path="com.liferay.journal" entity="JournalArticle" />
 		<reference package-path="com.liferay.journal" entity="JournalArticleResource" />
 		<reference package-path="com.liferay.portal" entity="PortletItem" />

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/base/ScreensAssetEntryServiceBaseImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/base/ScreensAssetEntryServiceBaseImpl.java
@@ -18,6 +18,10 @@ import com.liferay.asset.kernel.service.persistence.AssetEntryPersistence;
 
 import com.liferay.document.library.kernel.service.persistence.DLFileEntryPersistence;
 
+import com.liferay.dynamic.data.lists.service.persistence.DDLRecordPersistence;
+import com.liferay.dynamic.data.lists.service.persistence.DDLRecordSetPersistence;
+import com.liferay.dynamic.data.mapping.service.persistence.DDMStructurePersistence;
+
 import com.liferay.journal.service.persistence.JournalArticlePersistence;
 import com.liferay.journal.service.persistence.JournalArticleResourcePersistence;
 
@@ -135,6 +139,177 @@ public abstract class ScreensAssetEntryServiceBaseImpl extends BaseServiceImpl
 	public void setCounterLocalService(
 		com.liferay.counter.kernel.service.CounterLocalService counterLocalService) {
 		this.counterLocalService = counterLocalService;
+	}
+
+	/**
+	 * Returns the d d l record local service.
+	 *
+	 * @return the d d l record local service
+	 */
+	public com.liferay.dynamic.data.lists.service.DDLRecordLocalService getDDLRecordLocalService() {
+		return ddlRecordLocalService;
+	}
+
+	/**
+	 * Sets the d d l record local service.
+	 *
+	 * @param ddlRecordLocalService the d d l record local service
+	 */
+	public void setDDLRecordLocalService(
+		com.liferay.dynamic.data.lists.service.DDLRecordLocalService ddlRecordLocalService) {
+		this.ddlRecordLocalService = ddlRecordLocalService;
+	}
+
+	/**
+	 * Returns the d d l record remote service.
+	 *
+	 * @return the d d l record remote service
+	 */
+	public com.liferay.dynamic.data.lists.service.DDLRecordService getDDLRecordService() {
+		return ddlRecordService;
+	}
+
+	/**
+	 * Sets the d d l record remote service.
+	 *
+	 * @param ddlRecordService the d d l record remote service
+	 */
+	public void setDDLRecordService(
+		com.liferay.dynamic.data.lists.service.DDLRecordService ddlRecordService) {
+		this.ddlRecordService = ddlRecordService;
+	}
+
+	/**
+	 * Returns the d d l record persistence.
+	 *
+	 * @return the d d l record persistence
+	 */
+	public DDLRecordPersistence getDDLRecordPersistence() {
+		return ddlRecordPersistence;
+	}
+
+	/**
+	 * Sets the d d l record persistence.
+	 *
+	 * @param ddlRecordPersistence the d d l record persistence
+	 */
+	public void setDDLRecordPersistence(
+		DDLRecordPersistence ddlRecordPersistence) {
+		this.ddlRecordPersistence = ddlRecordPersistence;
+	}
+
+	/**
+	 * Returns the d d l record set local service.
+	 *
+	 * @return the d d l record set local service
+	 */
+	public com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService getDDLRecordSetLocalService() {
+		return ddlRecordSetLocalService;
+	}
+
+	/**
+	 * Sets the d d l record set local service.
+	 *
+	 * @param ddlRecordSetLocalService the d d l record set local service
+	 */
+	public void setDDLRecordSetLocalService(
+		com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService ddlRecordSetLocalService) {
+		this.ddlRecordSetLocalService = ddlRecordSetLocalService;
+	}
+
+	/**
+	 * Returns the d d l record set remote service.
+	 *
+	 * @return the d d l record set remote service
+	 */
+	public com.liferay.dynamic.data.lists.service.DDLRecordSetService getDDLRecordSetService() {
+		return ddlRecordSetService;
+	}
+
+	/**
+	 * Sets the d d l record set remote service.
+	 *
+	 * @param ddlRecordSetService the d d l record set remote service
+	 */
+	public void setDDLRecordSetService(
+		com.liferay.dynamic.data.lists.service.DDLRecordSetService ddlRecordSetService) {
+		this.ddlRecordSetService = ddlRecordSetService;
+	}
+
+	/**
+	 * Returns the d d l record set persistence.
+	 *
+	 * @return the d d l record set persistence
+	 */
+	public DDLRecordSetPersistence getDDLRecordSetPersistence() {
+		return ddlRecordSetPersistence;
+	}
+
+	/**
+	 * Sets the d d l record set persistence.
+	 *
+	 * @param ddlRecordSetPersistence the d d l record set persistence
+	 */
+	public void setDDLRecordSetPersistence(
+		DDLRecordSetPersistence ddlRecordSetPersistence) {
+		this.ddlRecordSetPersistence = ddlRecordSetPersistence;
+	}
+
+	/**
+	 * Returns the d d m structure local service.
+	 *
+	 * @return the d d m structure local service
+	 */
+	public com.liferay.dynamic.data.mapping.service.DDMStructureLocalService getDDMStructureLocalService() {
+		return ddmStructureLocalService;
+	}
+
+	/**
+	 * Sets the d d m structure local service.
+	 *
+	 * @param ddmStructureLocalService the d d m structure local service
+	 */
+	public void setDDMStructureLocalService(
+		com.liferay.dynamic.data.mapping.service.DDMStructureLocalService ddmStructureLocalService) {
+		this.ddmStructureLocalService = ddmStructureLocalService;
+	}
+
+	/**
+	 * Returns the d d m structure remote service.
+	 *
+	 * @return the d d m structure remote service
+	 */
+	public com.liferay.dynamic.data.mapping.service.DDMStructureService getDDMStructureService() {
+		return ddmStructureService;
+	}
+
+	/**
+	 * Sets the d d m structure remote service.
+	 *
+	 * @param ddmStructureService the d d m structure remote service
+	 */
+	public void setDDMStructureService(
+		com.liferay.dynamic.data.mapping.service.DDMStructureService ddmStructureService) {
+		this.ddmStructureService = ddmStructureService;
+	}
+
+	/**
+	 * Returns the d d m structure persistence.
+	 *
+	 * @return the d d m structure persistence
+	 */
+	public DDMStructurePersistence getDDMStructurePersistence() {
+		return ddmStructurePersistence;
+	}
+
+	/**
+	 * Sets the d d m structure persistence.
+	 *
+	 * @param ddmStructurePersistence the d d m structure persistence
+	 */
+	public void setDDMStructurePersistence(
+		DDMStructurePersistence ddmStructurePersistence) {
+		this.ddmStructurePersistence = ddmStructurePersistence;
 	}
 
 	/**
@@ -659,6 +834,24 @@ public abstract class ScreensAssetEntryServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.screens.service.ScreensJournalArticleService screensJournalArticleService;
 	@ServiceReference(type = com.liferay.counter.kernel.service.CounterLocalService.class)
 	protected com.liferay.counter.kernel.service.CounterLocalService counterLocalService;
+	@ServiceReference(type = com.liferay.dynamic.data.lists.service.DDLRecordLocalService.class)
+	protected com.liferay.dynamic.data.lists.service.DDLRecordLocalService ddlRecordLocalService;
+	@ServiceReference(type = com.liferay.dynamic.data.lists.service.DDLRecordService.class)
+	protected com.liferay.dynamic.data.lists.service.DDLRecordService ddlRecordService;
+	@ServiceReference(type = DDLRecordPersistence.class)
+	protected DDLRecordPersistence ddlRecordPersistence;
+	@ServiceReference(type = com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService.class)
+	protected com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService ddlRecordSetLocalService;
+	@ServiceReference(type = com.liferay.dynamic.data.lists.service.DDLRecordSetService.class)
+	protected com.liferay.dynamic.data.lists.service.DDLRecordSetService ddlRecordSetService;
+	@ServiceReference(type = DDLRecordSetPersistence.class)
+	protected DDLRecordSetPersistence ddlRecordSetPersistence;
+	@ServiceReference(type = com.liferay.dynamic.data.mapping.service.DDMStructureLocalService.class)
+	protected com.liferay.dynamic.data.mapping.service.DDMStructureLocalService ddmStructureLocalService;
+	@ServiceReference(type = com.liferay.dynamic.data.mapping.service.DDMStructureService.class)
+	protected com.liferay.dynamic.data.mapping.service.DDMStructureService ddmStructureService;
+	@ServiceReference(type = DDMStructurePersistence.class)
+	protected DDMStructurePersistence ddmStructurePersistence;
 	@ServiceReference(type = com.liferay.journal.service.JournalArticleLocalService.class)
 	protected com.liferay.journal.service.JournalArticleLocalService journalArticleLocalService;
 	@ServiceReference(type = com.liferay.journal.service.JournalArticleService.class)

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -177,8 +177,8 @@ public class ScreensAssetEntryServiceImpl
 			return getFileEntryJSONObject(assetEntry);
 		}
 		else if (className.equals(
-					"com.liferay.portlet.journal.model.JournalArticle")) {
 
+					"com.liferay.journal.model.JournalArticle")) {
 			return getJournalArticleJSONObject(assetEntry);
 		}
 

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -177,9 +177,7 @@ public class ScreensAssetEntryServiceImpl
 
 			return getFileEntryJSONObject(assetEntry);
 		}
-		else if (className.equals(
-					"com.liferay.journal.model.JournalArticle")) {
-
+		else if (className.equals("com.liferay.journal.model.JournalArticle")) {
 			return getJournalArticleJSONObject(assetEntry);
 		}
 		else if (className.equals(
@@ -277,9 +275,9 @@ public class ScreensAssetEntryServiceImpl
 				JSONFactoryUtil.looseSerialize(assetEntry));
 
 			jsonObject.put("description", assetEntry.getDescription(locale));
+			jsonObject.put("locale", String.valueOf(locale));
 			jsonObject.put(
 				"object", getAssetObjectJSONObject(assetEntry, locale));
-			jsonObject.put("locale", String.valueOf(locale));
 			jsonObject.put("summary", assetEntry.getSummary(locale));
 			jsonObject.put("title", assetEntry.getTitle(locale));
 			jsonArray.put(jsonObject);

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -277,10 +277,11 @@ public class ScreensAssetEntryServiceImpl
 				JSONFactoryUtil.looseSerialize(assetEntry));
 
 			jsonObject.put("description", assetEntry.getDescription(locale));
-			jsonObject.put("object", getAssetObjectJSONObject(assetEntry));
+			jsonObject.put(
+				"object", getAssetObjectJSONObject(assetEntry, locale));
+			jsonObject.put("locale", String.valueOf(locale));
 			jsonObject.put("summary", assetEntry.getSummary(locale));
 			jsonObject.put("title", assetEntry.getTitle(locale));
-
 			jsonArray.put(jsonObject);
 		}
 

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -199,8 +199,10 @@ public class ScreensAssetEntryServiceImpl
 		FileEntry fileEntry = dlAppService.getFileEntry(
 			assetEntry.getClassPK());
 
-		JSONObject fileEntryJSONObject = JSONFactoryUtil.createJSONObject(
-			JSONFactoryUtil.looseSerialize(fileEntry));
+		JSONObject fileEntryJSONObject = JSONFactoryUtil.createJSONObject();
+
+		fileEntryJSONObject.put("fileEntry", JSONFactoryUtil.createJSONObject(
+			JSONFactoryUtil.looseSerialize(fileEntry)));
 
 		fileEntryJSONObject.put("url", getFileEntryPreviewURL(fileEntry));
 

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -166,7 +166,8 @@ public class ScreensAssetEntryServiceImpl
 		return filteredAssetEntries;
 	}
 
-	protected JSONObject getAssetObjectJSONObject(AssetEntry assetEntry)
+	protected JSONObject getAssetObjectJSONObject(
+			AssetEntry assetEntry, Locale locale)
 		throws PortalException {
 
 		String className = assetEntry.getClassName();
@@ -177,9 +178,16 @@ public class ScreensAssetEntryServiceImpl
 			return getFileEntryJSONObject(assetEntry);
 		}
 		else if (className.equals(
-
 					"com.liferay.journal.model.JournalArticle")) {
+
 			return getJournalArticleJSONObject(assetEntry);
+		}
+		else if (className.equals(
+					"com.liferay.dynamic.data.lists.model.DDLRecord")) {
+
+			JSONObject ddlRecord = screensDDLRecordService.getDDLRecord(
+				assetEntry.getClassPK(), locale);
+			return ddlRecord;
 		}
 
 		return JSONFactoryUtil.createJSONObject();

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -237,10 +237,21 @@ public class ScreensAssetEntryServiceImpl
 				journalArticleResource.getArticleId());
 		}
 
-		JSONObject journalArticleJSONObject = JSONFactoryUtil.createJSONObject(
-			JSONFactoryUtil.looseSerialize(journalArticle));
+		JSONObject journalArticleJSONObject =
+			JSONFactoryUtil.createJSONObject();
 
-		journalArticleJSONObject.remove("content");
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			JSONFactoryUtil.looseSerialize(journalArticle));
+		journalArticleJSONObject.put("modelAttributes", jsonObject);
+		journalArticleJSONObject.put(
+			"modelValues", jsonObject.getString("content"));
+
+		jsonObject.remove("content");
+
+		journalArticleJSONObject.put(
+			"DDMStructure", JSONFactoryUtil.createJSONObject(
+				JSONFactoryUtil.looseSerialize(
+					journalArticle.getDDMStructure())));
 
 		return journalArticleJSONObject;
 	}


### PR DESCRIPTION
As a developer querying for assets I want to receive the full entity instead of just the asset generic information to be able to create real entities and show specific fields of those entities in the results

I'll also send the pull for 6.2.x