### PR TITLE
LPS-65071: passing fqcn to internal logger

### DIFF
--- a/util-slf4j/src/com/liferay/util/sl4fj/LiferayLoggerAdapter.java
+++ b/util-slf4j/src/com/liferay/util/sl4fj/LiferayLoggerAdapter.java
@@ -203,7 +203,8 @@ public class LiferayLoggerAdapter
 
 		FormattingTuple formattingTuple = MessageFormatter.arrayFormat(
 			message, arguments);
-
+		
+		_log.setLogWrapperClassName(fqcn);
 		switch (level) {
 			case LocationAwareLogger.DEBUG_INT:
 				_log.debug(formattingTuple.getMessage(), t);


### PR DESCRIPTION
LPS-65071: delegating the fqcn as the wrapper class name to the internal logger; this allows to create custom logging wrappers with correct line numbers in logfiles
