### PR TITLE
LPS-65071,LPS-53982: Backport 6.2

### DIFF
--- a/util-slf4j/src/com/liferay/util/sl4fj/LiferayLoggerAdapter.java
+++ b/util-slf4j/src/com/liferay/util/sl4fj/LiferayLoggerAdapter.java
@@ -32,6 +32,7 @@ public class LiferayLoggerAdapter
 
 	public LiferayLoggerAdapter(Log log) {
 		_log = log;
+		_log.setLogWrapperClassName(LiferayLoggerAdapter.class.getName());
 	}
 
 	@Override
@@ -195,7 +196,7 @@ public class LiferayLoggerAdapter
 
 		FormattingTuple formattingTuple = MessageFormatter.arrayFormat(
 			message, arguments);
-
+		_log.setLogWrapperClassName(fqcn);
 		switch (level) {
 			case LocationAwareLogger.DEBUG_INT:
 				_log.debug(formattingTuple.getMessage(), t);


### PR DESCRIPTION
setting wrapper classname in constructor -> plugins directly using the slf4j bridge
setting wrapper classname in log -> enabling logging wrapper on top of the slf4j bridge
