### PR TITLE
LPS-66069

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/permission/DDLRecordSetPermission.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/permission/DDLRecordSetPermission.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dynamic.data.lists.service.permission;
 
+import com.liferay.dynamic.data.lists.constants.DDLActionKeys;
 import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.lists.model.DDLRecordSetConstants;
@@ -72,8 +73,8 @@ public class DDLRecordSetPermission {
 		String portletId = PortletProviderUtil.getPortletId(
 			DDLRecord.class.getName(), PortletProvider.Action.EDIT);
 
-		if (recordSet.getScope() ==
-				DDLRecordSetConstants.SCOPE_DYNAMIC_DATA_LISTS) {
+		if ((actionId != DDLActionKeys.ADD_RECORD) && (recordSet.getScope() ==
+				DDLRecordSetConstants.SCOPE_DYNAMIC_DATA_LISTS)) {
 
 			Boolean hasPermission = StagingPermissionUtil.hasPermission(
 				permissionChecker, recordSet.getGroupId(),

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/lar/DDMStructureStagedModelDataHandler.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/lar/DDMStructureStagedModelDataHandler.java
@@ -237,14 +237,7 @@ public class DDMStructureStagedModelDataHandler
 
 		String uuid = referenceElement.attributeValue("uuid");
 
-		Map<Long, Long> groupIds =
-			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-				Group.class);
-
-		long groupId = GetterUtil.getLong(
-			referenceElement.attributeValue("group-id"));
-
-		groupId = MapUtil.getLong(groupIds, groupId);
+		long groupId = portletDataContext.getScopeGroupId();
 
 		long classNameId = PortalUtil.getClassNameId(
 			referenceElement.attributeValue("referenced-class-name"));
@@ -256,6 +249,20 @@ public class DDMStructureStagedModelDataHandler
 
 		existingStructure = fetchExistingStructure(
 			uuid, groupId, classNameId, structureKey, preloaded);
+
+		if (existingStructure == null) {
+			Map<Long, Long> groupIds =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					Group.class);
+
+			groupId = GetterUtil.getLong(
+				referenceElement.attributeValue("group-id"));
+
+			groupId = MapUtil.getLong(groupIds, groupId);
+
+			existingStructure = fetchExistingStructure(
+				uuid, groupId, classNameId, structureKey, preloaded);
+		}
 
 		Map<Long, Long> structureIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(


### PR DESCRIPTION
Hi Sam,

Please see forum threads [here](https://in.liferay.com/web/global.engineering/forums/-/message_boards/message/21133979) and [here](https://in.liferay.com/web/global.engineering/forums/-/message_boards/message/20971077), in which engineers on the DDL team and on the staging team both agreed that we should implement this fix.

The reason I added the second commit was because I found the following bug. When you first publish a DDLRecordSet to live, if you are using a global DDMStructure, the DDLRecordSet gets the ddmStructureId that corresponds to the live site. Later, however, when you first publish records from staging to live, the ddmStructureId attached to the DDLRecordSet changes to the ddmStructureId corresponding to the global site. If you had already added records on the live site, they will get deleted because it thinks that you are publishing a change to the structure.

The second commit prevents this bug from occurring by modifying the way we get the ddmStructureId. Now, it will return the ddmStructureId attached to the live site if it exists, and it will use the groupId from the referenceElement otherwise. This prevents the DDLRecordSet from having its ddmStructureId modified.