### PR TITLE
LPS-67091 Extend Asset Service to decorate assets that are DLFileEntries with their information

### DIFF
--- a/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensAssetEntryService.java
+++ b/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensAssetEntryService.java
@@ -21,6 +21,7 @@ import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.service.BaseService;
@@ -62,6 +63,10 @@ public interface ScreensAssetEntryService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JSONArray getAssetEntries(long companyId, long groupId,
 		java.lang.String portletItemName, Locale locale, int max)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public JSONObject getAssetEntryExtended(long entryId, Locale locale)
 		throws PortalException;
 
 	/**

--- a/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensAssetEntryServiceUtil.java
+++ b/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensAssetEntryServiceUtil.java
@@ -57,6 +57,12 @@ public class ScreensAssetEntryServiceUtil {
 			locale, max);
 	}
 
+	public static com.liferay.portal.kernel.json.JSONObject getAssetEntryExtended(
+		long entryId, java.util.Locale locale)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().getAssetEntryExtended(entryId, locale);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*

--- a/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensAssetEntryServiceWrapper.java
+++ b/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensAssetEntryServiceWrapper.java
@@ -50,6 +50,13 @@ public class ScreensAssetEntryServiceWrapper implements ScreensAssetEntryService
 			portletItemName, locale, max);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.json.JSONObject getAssetEntryExtended(
+		long entryId, java.util.Locale locale)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _screensAssetEntryService.getAssetEntryExtended(entryId, locale);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensAssetEntryServiceHttp.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensAssetEntryServiceHttp.java
@@ -122,6 +122,39 @@ public class ScreensAssetEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.json.JSONObject getAssetEntryExtended(
+		HttpPrincipal httpPrincipal, long entryId, java.util.Locale locale)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(ScreensAssetEntryServiceUtil.class,
+					"getAssetEntryExtended",
+					_getAssetEntryExtendedParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
+					locale);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portal.kernel.json.JSONObject)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(ScreensAssetEntryServiceHttp.class);
 	private static final Class<?>[] _getAssetEntriesParameterTypes0 = new Class[] {
 			com.liferay.asset.kernel.service.persistence.AssetEntryQuery.class,
@@ -130,5 +163,8 @@ public class ScreensAssetEntryServiceHttp {
 	private static final Class<?>[] _getAssetEntriesParameterTypes1 = new Class[] {
 			long.class, long.class, java.lang.String.class,
 			java.util.Locale.class, int.class
+		};
+	private static final Class<?>[] _getAssetEntryExtendedParameterTypes2 = new Class[] {
+			long.class, java.util.Locale.class
 		};
 }

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensAssetEntryServiceSoap.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensAssetEntryServiceSoap.java
@@ -88,5 +88,20 @@ public class ScreensAssetEntryServiceSoap {
 		}
 	}
 
+	public static java.lang.String getAssetEntryExtended(long entryId,
+		String locale) throws RemoteException {
+		try {
+			com.liferay.portal.kernel.json.JSONObject returnValue = ScreensAssetEntryServiceUtil.getAssetEntryExtended(entryId,
+					LocaleUtil.fromLanguageId(locale));
+
+			return returnValue.toString();
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(ScreensAssetEntryServiceSoap.class);
 }

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -310,20 +310,26 @@ public class ScreensAssetEntryServiceImpl
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (AssetEntry assetEntry : assetEntries) {
-			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-				JSONFactoryUtil.looseSerialize(assetEntry));
-
-			jsonObject.put("className", assetEntry.getClassName());
-			jsonObject.put("description", assetEntry.getDescription(locale));
-			jsonObject.put("locale", String.valueOf(locale));
-			jsonObject.put(
-				"object", getAssetObjectJSONObject(assetEntry, locale));
-			jsonObject.put("summary", assetEntry.getSummary(locale));
-			jsonObject.put("title", assetEntry.getTitle(locale));
+			JSONObject jsonObject = toJSONObject(assetEntry, locale);
 			jsonArray.put(jsonObject);
 		}
 
 		return jsonArray;
+	}
+
+	protected JSONObject toJSONObject(AssetEntry assetEntry, Locale locale)
+		throws PortalException {
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			JSONFactoryUtil.looseSerialize(assetEntry));
+
+		jsonObject.put("className", assetEntry.getClassName());
+		jsonObject.put("description", assetEntry.getDescription(locale));
+		jsonObject.put("locale", String.valueOf(locale));
+		jsonObject.put(
+			"object", getAssetObjectJSONObject(assetEntry, locale));
+		jsonObject.put("summary", assetEntry.getSummary(locale));
+		jsonObject.put("title", assetEntry.getTitle(locale));
+		return jsonObject;
 	}
 
 }

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -153,6 +153,11 @@ public class ScreensAssetEntryServiceImpl
 		}
 	}
 
+	@Override
+	public JSONObject getAssetEntryExtended(long entryId, Locale locale) throws PortalException {
+		return toJSONObject(assetEntryLocalService.getEntry(entryId), locale);
+	}
+
 	protected List<AssetEntry> filterAssetEntries(List<AssetEntry> assetEntries)
 		throws PortalException {
 

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -154,7 +154,9 @@ public class ScreensAssetEntryServiceImpl
 	}
 
 	@Override
-	public JSONObject getAssetEntryExtended(long entryId, Locale locale) throws PortalException {
+	public JSONObject getAssetEntryExtended(long entryId, Locale locale)
+		throws PortalException {
+
 		return toJSONObject(assetEntryLocalService.getEntry(entryId), locale);
 	}
 
@@ -324,14 +326,14 @@ public class ScreensAssetEntryServiceImpl
 
 	protected JSONObject toJSONObject(AssetEntry assetEntry, Locale locale)
 		throws PortalException {
+
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			JSONFactoryUtil.looseSerialize(assetEntry));
 
 		jsonObject.put("className", assetEntry.getClassName());
 		jsonObject.put("description", assetEntry.getDescription(locale));
 		jsonObject.put("locale", String.valueOf(locale));
-		jsonObject.put(
-			"object", getAssetObjectJSONObject(assetEntry, locale));
+		jsonObject.put("object", getAssetObjectJSONObject(assetEntry, locale));
 		jsonObject.put("summary", assetEntry.getSummary(locale));
 		jsonObject.put("title", assetEntry.getTitle(locale));
 		return jsonObject;


### PR DESCRIPTION
Added new method "getAssetEntryExtended" in ScreensAssetEntryServiceImpl that returns an asset entry in JSONObject format.