### PR TITLE
[Technical-Support] LPS-67529

### DIFF
--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
@@ -20,11 +20,19 @@ import com.liferay.bookmarks.service.BookmarksEntryLocalService;
 import com.liferay.bookmarks.service.BookmarksFolderLocalService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceBlock;
+import com.liferay.portal.kernel.service.ResourceBlockLocalService;
 import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.verify.VerifyProcess;
 
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,7 +52,40 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 	protected void doVerify() throws Exception {
 		updateEntryAssets();
 		updateFolderAssets();
+		verifyResourceBlock(
+			BookmarksEntry.class.getName(), "entryId", "BookmarksEntry");
+		verifyResourceBlock(
+			BookmarksFolder.class.getName(), "folderId", "BookmarksFolder");
 		verifyTree();
+	}
+
+	protected Map<Long, String[]> getRoleIdsToActionIds(
+			String modelName, long resourceBlockId)
+		throws Exception {
+
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select roleId, actionIds from ResourceBlockPermission where " +
+					"resourceBlockId = " + resourceBlockId);
+			ResultSet rs1 = ps1.executeQuery()) {
+
+			Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
+
+			for (int i = 0; rs1.next(); i++) {
+				long roleId = rs1.getLong("roleId");
+				long actionIds = rs1.getLong("actionIds");
+
+				List<String> definedActionIds =
+					_resourceBlockLocalService.getActionIds(
+						modelName, actionIds);
+
+				roleIdsToActionIds.put(
+					roleId,
+					definedActionIds.toArray(
+						new String[definedActionIds.size()]));
+			}
+
+			return roleIdsToActionIds;
+		}
 	}
 
 	@Reference(unbind = "-")
@@ -59,6 +100,13 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 		BookmarksFolderLocalService bookmarksFolderLocalService) {
 
 		_bookmarksFolderLocalService = bookmarksFolderLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setResourceBlockLocalService(
+		ResourceBlockLocalService resourceBlockLocalService) {
+
+		_resourceBlockLocalService = resourceBlockLocalService;
 	}
 
 	protected void updateEntryAssets() throws Exception {
@@ -121,6 +169,114 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 		}
 	}
 
+	protected void updateResourceBlock(
+			String modelName, long referenceCount, long resourceBlockId,
+			String resourcePrimKey, Map<Long, String[]> roleIdsToActionIds,
+			String tableName)
+		throws Exception {
+
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select companyId, groupId, " + resourcePrimKey + " from " +
+					tableName + " where " + "resourceBlockId = " +
+						resourceBlockId + " order by modifiedDate desc");
+			ResultSet rs1 = ps1.executeQuery()) {
+
+			for (int i = 0; rs1.next(); i++) {
+				long companyId = rs1.getLong("companyId");
+				long groupId = rs1.getLong("groupId");
+				long tableResourcePrimKey = Long.valueOf(
+					rs1.getString(resourcePrimKey));
+
+				_resourceBlockLocalService.setIndividualScopePermissions(
+					companyId, groupId, modelName, tableResourcePrimKey,
+					roleIdsToActionIds);
+
+				long newResourceBlockId;
+
+				if (modelName.equals(BookmarksEntry.class.getName())) {
+					BookmarksEntry bookmarksEntry =
+						_bookmarksEntryLocalService.fetchBookmarksEntry(
+							tableResourcePrimKey);
+
+					newResourceBlockId = bookmarksEntry.getResourceBlockId();
+				}
+				else {
+					BookmarksFolder bookmarksFolder =
+						_bookmarksFolderLocalService.fetchBookmarksFolder(
+							tableResourcePrimKey);
+
+					newResourceBlockId = bookmarksFolder.getResourceBlockId();
+				}
+
+				PreparedStatement ps2 = connection.prepareStatement(
+					"update " + tableName + " set resourceBlockId = ?" +
+						" where resourceBlockId = ?");
+
+				ps2.setLong(1, newResourceBlockId);
+				ps2.setLong(2, resourceBlockId);
+
+				ps2.executeUpdate();
+
+				ResourceBlock resourceBlock =
+					_resourceBlockLocalService.fetchResourceBlock(
+						newResourceBlockId);
+
+				resourceBlock.setReferenceCount(referenceCount);
+
+				_resourceBlockLocalService.updateResourceBlock(resourceBlock);
+
+				break;
+			}
+		}
+	}
+
+	protected void verifyResourceBlock(
+			String modelName, String resourcePrimKey, String tableName)
+		throws Exception {
+
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append("select t.* from (select resourceBlockId, ");
+			sb.append("count(resourceBlockId) as total from ");
+			sb.append(tableName);
+			sb.append(" group by resourceBlockId) t left join ");
+			sb.append("ResourceBlock on ");
+			sb.append("(ResourceBlock.resourceBlockId = t.resourceBlockId) ");
+			sb.append("and (ResourceBlock.referenceCount = t.total) ");
+			sb.append("where ResourceBlock.resourceBlockId is null");
+
+			try (PreparedStatement ps = connection.prepareStatement(
+					sb.toString());
+				ResultSet rs = ps.executeQuery()) {
+
+				while (rs.next()) {
+					long resourceBlockId = rs.getLong("resourceBlockId");
+					long referenceCount = rs.getLong("total");
+
+					ResourceBlock resourceBlock =
+						_resourceBlockLocalService.fetchResourceBlock(
+							resourceBlockId);
+
+					if (resourceBlock == null) {
+						Map<Long, String[]> roleIdsToActionIds =
+							getRoleIdsToActionIds(modelName, resourceBlockId);
+
+						updateResourceBlock(
+							modelName, referenceCount, resourceBlockId,
+							resourcePrimKey, roleIdsToActionIds, tableName);
+					}
+					else {
+						resourceBlock.setReferenceCount(referenceCount);
+
+						_resourceBlockLocalService.updateResourceBlock(
+							resourceBlock);
+					}
+				}
+			}
+		}
+	}
+
 	protected void verifyTree() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
@@ -136,5 +292,6 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 
 	private BookmarksEntryLocalService _bookmarksEntryLocalService;
 	private BookmarksFolderLocalService _bookmarksFolderLocalService;
+	private ResourceBlockLocalService _resourceBlockLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceBlockLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceBlockLocalServiceImpl.java
@@ -417,10 +417,6 @@ public class ResourceBlockLocalServiceImpl
 	}
 
 	@Override
-	@Transactional(
-		isolation = Isolation.READ_COMMITTED,
-		propagation = Propagation.REQUIRES_NEW
-	)
 	public void releasePermissionedModelResourceBlock(
 		PermissionedModel permissionedModel) {
 
@@ -445,10 +441,6 @@ public class ResourceBlockLocalServiceImpl
 	 * @param resourceBlockId the primary key of the resource block
 	 */
 	@Override
-	@Transactional(
-		isolation = Isolation.READ_COMMITTED,
-		propagation = Propagation.REQUIRES_NEW
-	)
 	public void releaseResourceBlock(long resourceBlockId) {
 		Session session = resourceBlockPersistence.openSession();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourceBlockLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourceBlockLocalService.java
@@ -339,7 +339,6 @@ public interface ResourceBlockLocalService extends BaseLocalService,
 		java.lang.String name, long primKey, long roleId, long actionIdsLong)
 		throws PortalException;
 
-	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 	public void releasePermissionedModelResourceBlock(
 		PermissionedModel permissionedModel);
 
@@ -363,7 +362,6 @@ public interface ResourceBlockLocalService extends BaseLocalService,
 	*
 	* @param resourceBlockId the primary key of the resource block
 	*/
-	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 	public void releaseResourceBlock(long resourceBlockId);
 
 	public void removeAllGroupScopePermissions(long companyId,


### PR DESCRIPTION
Hi Preston,

I hope your are well.

cc @daledotshan 

This PR extends from https://github.com/Preston-Crary/liferay-portal/pull/148

**Root issue:**
The issue is caused by part fix of LPS-28276.

When execute one delete command(including delete different models(bookmarks,dlfileentry, mbthreads) or some bookmark entrys, for example, auto-clean Recycle Bin: CheckEntryMessageListener execute:), if this delete failed and bookmarks delete logic has been executed, our resourceBlock table data won't be rolled back. This will affect bookmarks permission.

**Verfiy explanation:**
Only resourceBlock data is lost and its actually permission is existed in resourceblockpermission.
I assume there are 10 BookmarksFolder and they are same resourceBlockId. The unclean data includes two kinds:
1. 10 datas are in Recycle Bin and they are all deleted( resourceBlock data is removed in resourceBlock table). This logic updateResourceBlock() will take care it.
2. 5 datas are in Recycle Bin and they are deleted  (resourceBlock data's referenceCount will be 5 in resourceBlock table, the normal value is 10). This logic (https://github.com/yuhai/liferay-portal/blob/4a0bddd647db9b90b02a20b0c562868dc1b5d2c9/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java#L269-L274) will take care it.

For test, I don't have good way to express this. Because once ResourceBlockLocalServiceUtil execute, even though without fix, the commit will take effect.

Could you please firstly check the verify way is ok for you?

Regards,
Hai

