### PR TITLE
LPS-67154

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyAuditedModel.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyAuditedModel.java
@@ -16,7 +16,6 @@ package com.liferay.portal.verify;
 
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.concurrent.ThrowableAwareRunnable;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.verify.model.VerifiableAuditedModel;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 
 import java.util.ArrayList;
@@ -209,8 +207,8 @@ public class VerifyAuditedModel extends VerifyProcess {
 	}
 
 	protected void verifyAuditedModel(
-			Connection con, PreparedStatement ps, String tableName,
-			long primKey, Object[] auditedModelArray, boolean updateDates)
+			Connection con, ResultSet rs, String tableName,
+			Object[] auditedModelArray, boolean updateDates)
 		throws Exception {
 
 		try {
@@ -229,20 +227,16 @@ public class VerifyAuditedModel extends VerifyProcess {
 			Timestamp createDate = (Timestamp)auditedModelArray[3];
 			Timestamp modifiedDate = (Timestamp)auditedModelArray[4];
 
-			ps.setLong(1, companyId);
-			ps.setLong(2, userId);
-			ps.setString(3, userName);
+			rs.updateLong("companyId", companyId);
+			rs.updateLong("userId", userId);
+			rs.updateString("userName", userName);
 
 			if (updateDates) {
-				ps.setTimestamp(4, createDate);
-				ps.setTimestamp(5, modifiedDate);
-				ps.setLong(6, primKey);
-			}
-			else {
-				ps.setLong(4, primKey);
+				rs.updateTimestamp("createDate", createDate);
+				rs.updateTimestamp("modifiedDate", modifiedDate);
 			}
 
-			ps.addBatch();
+			rs.updateRow();
 		}
 		catch (Exception e) {
 			if (_log.isWarnEnabled()) {
@@ -258,11 +252,9 @@ public class VerifyAuditedModel extends VerifyProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer(
 				verifiableAuditedModel.getTableName())) {
 
-			StringBundler sb = new StringBundler(8);
+			StringBundler sb = new StringBundler(6);
 
-			sb.append("select ");
-			sb.append(verifiableAuditedModel.getPrimaryKeyColumnName());
-			sb.append(", companyId, userId");
+			sb.append("select companyId, userId");
 
 			if (verifiableAuditedModel.getJoinByTableName() != null) {
 				sb.append(StringPool.COMMA_AND_SPACE);
@@ -278,24 +270,14 @@ public class VerifyAuditedModel extends VerifyProcess {
 			long previousCompanyId = 0;
 
 			try (Connection con = DataAccess.getUpgradeOptimizedConnection();
-				PreparedStatement ps1 = con.prepareStatement(sb.toString());
-				ResultSet rs = ps1.executeQuery();
-				PreparedStatement ps2 =
-					AutoBatchPreparedStatementUtil.autoBatch(
-						_createPreparedStatement(
-							con, verifiableAuditedModel.getTableName(),
-							verifiableAuditedModel.getPrimaryKeyColumnName(),
-							verifiableAuditedModel.isUpdateDates()))) {
+				PreparedStatement ps = con.prepareStatement(sb.toString());
+				ResultSet rs = ps.executeQuery()) {
 
 				while (rs.next()) {
 					long companyId = rs.getLong("companyId");
-					long primKey = rs.getLong(
-						verifiableAuditedModel.getPrimaryKeyColumnName());
 					long previousUserId = rs.getLong("userId");
 
-					if (verifiableAuditedModel.getJoinByTableName()
-							!= null) {
-
+					if (verifiableAuditedModel.getJoinByTableName() != null) {
 						long relatedPrimKey = rs.getLong(
 							verifiableAuditedModel.getJoinByTableName());
 
@@ -317,36 +299,12 @@ public class VerifyAuditedModel extends VerifyProcess {
 					}
 
 					verifyAuditedModel(
-						con, ps2, verifiableAuditedModel.getTableName(),
-						primKey, auditedModelArray,
+						con, rs, verifiableAuditedModel.getTableName(),
+						auditedModelArray,
 						verifiableAuditedModel.isUpdateDates());
 				}
-
-				ps2.executeBatch();
 			}
 		}
-	}
-
-	private PreparedStatement _createPreparedStatement(
-			Connection con, String tableName, String primaryKeyColumnName,
-			boolean updateDates)
-		throws SQLException {
-
-		StringBundler sb = new StringBundler(7);
-
-		sb.append("update ");
-		sb.append(tableName);
-		sb.append(" set companyId = ?, userId = ?, userName = ?");
-
-		if (updateDates) {
-			sb.append(", createDate = ?, modifiedDate = ?");
-		}
-
-		sb.append(" where ");
-		sb.append(primaryKeyColumnName);
-		sb.append(" = ?");
-
-		return con.prepareStatement(sb.toString());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Hi Sam,

I have some concerns that this will make the performance worse, since I couldn't find a batch update operation for ResultSets. When we SDHed the fix to the client, this was not an issue, because we did not use batching in VerifyAuditedModel in Liferay 6.2. However, now I am removing the batching from VerifyAuditedModel, which could be undesirable.

When we SDHed this fix to the client, we had to update and customize jtds.jar because there was a bug in it that caused errors to be thrown when you called the ResultSet.update methods. However, we now use jconn4.jar instead of jtds.jar (see [LPS-59066](https://issues.liferay.com/browse/LPS-59066)). Therefore, my assumption is that updating/customizing the jar is not necessary, since the ResultSet.update methods should work fine with jconn. Unfortunately, I was unable to test this assumption, since Sybase is not supported in master and ee-7.0.x doesn't compile right now.