### PR TITLE
LPS-68289 Add checking to avoid ClassNotFoundException.

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -94,6 +94,10 @@ public class PACLAggregateTest extends AutoBalanceTestCase {
 		try {
 			List<Class<?>> classes = scanTestClasses();
 
+			if (classes.isEmpty()) {
+				return;
+			}
+
 			ProcessChannel<Result> processChannel =
 				localProcessExecutor.execute(
 					createProcessConfig(),


### PR DESCRIPTION
Hi Shuyang,

This was found while working on CI test problems, when I set "test.batch.size[integration-hypersonic20-jdk8]=20", AutoBalanceTestCase.slice() would return an empty list for PACLAggregateTest and thus cause ClassNotFoundException later.

For detailed error log, please see https://gist.github.com/tinatian/8fc1c6071cae86304015081b4133f8a2.


Tina.

