### PR TITLE
[TECHNICAL SUPPORT] LPS-65498 'Unable to encrypt blank password' error on scheduled import from LDAP

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -325,7 +325,7 @@ public class LDAPAuth implements Authenticator {
 			// Get user or create from LDAP
 
 			if (!ldapAuthResult.isAuthenticated()) {
-				password = StringPool.BLANK;
+				password = null;
 			}
 
 			User user = _ldapUserImporter.importUser(

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultLDAPToPortalConverter.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultLDAPToPortalConverter.java
@@ -165,7 +165,7 @@ public class DefaultLDAPToPortalConverter implements LDAPToPortalConverter {
 
 		LDAPUser ldapUser = new LDAPUser();
 
-		ldapUser.setAutoPassword(password.equals(StringPool.BLANK));
+		ldapUser.setAutoPassword(password == null);
 		ldapUser.setAutoScreenName(autoScreenName);
 
 		Contact contact = _contactPersistence.create(0);
@@ -267,7 +267,7 @@ public class DefaultLDAPToPortalConverter implements LDAPToPortalConverter {
 
 		ldapUser.setServiceContext(serviceContext);
 
-		ldapUser.setUpdatePassword(!password.equals(StringPool.BLANK));
+		ldapUser.setUpdatePassword(password != null);
 
 		User user = _userPersistence.create(0);
 

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -235,7 +235,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 				return importUser(
 					ldapServerId, companyId, ldapContext, attributes,
-					StringPool.BLANK);
+					null);
 			}
 			else {
 				return null;
@@ -341,7 +341,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			ldapServerId, companyId, ldapContext, fullUserDN);
 
 		User user = importUser(
-			ldapServerId, companyId, ldapContext, attributes, StringPool.BLANK);
+			ldapServerId, companyId, ldapContext, attributes, null);
 
 		ldapContext.close();
 
@@ -792,8 +792,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 					User user = importUser(
 						ldapServerId, companyId, userAttributes, userMappings,
 						userExpandoMappings, contactMappings,
-						contactExpandoMappings, StringPool.BLANK,
-						ldapUserIgnoreAttributes);
+						contactExpandoMappings, null, ldapUserIgnoreAttributes);
 
 					importGroups(
 						ldapServerId, companyId, ldapContext, userAttributes,
@@ -1168,7 +1167,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				User user = importUser(
 					ldapServerId, companyId, userAttributes, userMappings,
 					userExpandoMappings, contactMappings,
-					contactExpandoMappings, StringPool.BLANK,
+					contactExpandoMappings, null,
 					ldapUserIgnoreAttributes);
 
 				if (user != null) {

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1453,9 +1453,13 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				modifiedDate = LDAPUtil.parseDate(modifyTimestamp);
 
 				if (modifiedDate.equals(user.getModifiedDate())) {
-					updateUserPassword(
-						ldapImportConfiguration, user.getUserId(),
-						ldapUser.getScreenName(), password, passwordReset);
+					if (ldapUser.isUpdatePassword() ||
+						!ldapImportConfiguration.importUserPasswordEnabled()) {
+
+						updateUserPassword(
+							ldapImportConfiguration, user.getUserId(),
+							user.getScreenName(), password, passwordReset);
+					}
 
 					if (_log.isDebugEnabled()) {
 						_log.debug(
@@ -1501,7 +1505,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			ldapUser.setScreenName(user.getScreenName());
 		}
 
-		if (ldapUser.isUpdatePassword()) {
+		if (ldapUser.isUpdatePassword() ||
+			!ldapImportConfiguration.importUserPasswordEnabled()) {
+
 			password = updateUserPassword(
 				ldapImportConfiguration, user.getUserId(),
 				ldapUser.getScreenName(), password, passwordReset);


### PR DESCRIPTION
Hi,

Sending this again as it will be needed to be resolved in order to be able to reproduce an other issue.

To summarize again: This fix has nothing to do with changing whether or not we allow blank password for users. It just removes related logic from LDAP module (if it gets a password it tries to set it, if it doesn't get one then it doesn't) and leaves this decision entirely to the User service. (Which by the way still doesn't allow blank passwords.)

Br,
Norbert