### PR TITLE
LPS-69020 changed % height and width values to vh and vw because % height was based off its parent which doesn't render well in IE11

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/preview.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/preview.js
@@ -173,9 +173,9 @@ AUI.add(
 									},
 									centered: true,
 									cssClass: 'lfr-preview-file-image-overlay',
-									height: '90%',
+									height: '90vh',
 									plugins: [Liferay.WidgetZIndex],
-									width: '85%'
+									width: '85vw'
 								}
 							).render();
 


### PR DESCRIPTION
Here is an update for:
http://issues.liferay.com/browse/LPS-69020

Notes:
Hey Sam, please review my changes! I changed % values to vh and vw in order for the modal sizing to be relative to the viewport instead of its parent. This fix is for IE11 

Thank you!
Tyler