### PR TITLE
LPS-70631 Destination folderId must belong to destination groupId

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.document.library.kernel.exception.ImageSizeException;
 import com.liferay.document.library.kernel.exception.InvalidFileEntryTypeException;
 import com.liferay.document.library.kernel.exception.InvalidFileVersionException;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
@@ -2065,6 +2066,15 @@ public class DLFileEntryLocalServiceImpl
 			long groupId, long folderId, long fileEntryId, String fileName,
 			String title)
 		throws PortalException {
+
+		if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			DLFolder dlParentFolder = dlFolderPersistence.findByPrimaryKey(
+				folderId);
+
+			if (groupId != dlParentFolder.getGroupId()) {
+				throw new NoSuchFolderException();
+			}
+		}
 
 		DLFolder dlFolder = dlFolderPersistence.fetchByG_P_N(
 			groupId, folderId, title);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-70631

I have detected some folderId/groupId inconsistences in one Liferay customer.
After some investigations, I have detected that our code in `DLFileEntryLocalServiceImpl` is not validating folderId belongs to the same group than related DLFileEntry.

In order to solve it I am adding a new validation to method: `DLFileEntryLocalServiceImpl.validateFile(groupId,folderId, fileEntryId,fileName,title)` in case of parameter **folderId!=0**, the folder must exists inside the group with `groupId` id.