### PR TITLE
Documentation in portal.properties: fixed ref between cache props

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -4843,7 +4843,7 @@
     #
     # Set this true if you want to disable the cache for authenticated users.
     # This property is not read when the property
-    # "browser.cache.signed.in.disabled" is true. This is useful to ensure that
+    # "browser.cache.disabled" is true. This is useful to ensure that
     # authenticated users cannot go to the sign in page by clicking on the back
     # button in their browsers.
     #


### PR DESCRIPTION
Cross reference from browser.cache.signed.in.disabled to browser.cache.disabled was incorrect, it pointed to itself.