### PR TITLE
LPS-42478 Set context classloader to null to make hibernate use its own classloader rather than context classloader

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/QueryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/QueryImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.orm.Query;
 import com.liferay.portal.kernel.dao.orm.ScrollableResults;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
 import com.liferay.portal.kernel.security.pacl.NotPrivileged;
+import com.liferay.portal.kernel.util.ClassLoaderUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 
@@ -114,6 +115,11 @@ public class QueryImpl implements Query {
 	public List<?> list(boolean copy, boolean unmodifiable)
 		throws ORMException {
 
+		ClassLoader contextClassLoader =
+			ClassLoaderUtil.getContextClassLoader();
+
+		ClassLoaderUtil.setContextClassLoader(null);
+
 		try {
 			List<?> list = _query.list();
 
@@ -129,16 +135,27 @@ public class QueryImpl implements Query {
 		catch (Exception e) {
 			throw ExceptionTranslator.translate(e);
 		}
+		finally {
+			ClassLoaderUtil.setContextClassLoader(contextClassLoader);
+		}
 	}
 
 	@NotPrivileged
 	@Override
 	public ScrollableResults scroll() throws ORMException {
+		ClassLoader contextClassLoader =
+			ClassLoaderUtil.getContextClassLoader();
+
+		ClassLoaderUtil.setContextClassLoader(null);
+
 		try {
 			return new ScrollableResultsImpl(_query.scroll());
 		}
 		catch (Exception e) {
 			throw ExceptionTranslator.translate(e);
+		}
+		finally {
+			ClassLoaderUtil.setContextClassLoader(contextClassLoader);
 		}
 	}
 
@@ -378,6 +395,9 @@ public class QueryImpl implements Query {
 			throw ExceptionTranslator.translate(e);
 		}
 	}
+
+	private static final ClassLoader _hibernateClassLoader =
+		org.hibernate.Query.class.getClassLoader();
 
 	private final String[] _names;
 	private final org.hibernate.Query _query;


### PR DESCRIPTION
Hi Shuyang,

I tested this change locally and passed, let's see if there is any ci failure.

cc @istvansajtos @lipusz  This is another solution for this issue.

Tina