### PR TITLE
Lps 72317 Avoid AutoLoginFilter's service tracker being invoked twice

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
@@ -56,15 +56,6 @@ import javax.servlet.http.HttpSession;
  */
 public class AutoLoginFilter extends BasePortalFilter {
 
-	public AutoLoginFilter() {
-		Registry registry = RegistryUtil.getRegistry();
-
-		_serviceTracker = registry.trackServices(
-			AutoLogin.class, new AutoLoginServiceTrackerCustomizer());
-
-		_serviceTracker.open();
-	}
-
 	protected String getLoginRemoteUser(
 			HttpServletRequest request, HttpServletResponse response,
 			HttpSession session, String[] credentials)
@@ -278,8 +269,7 @@ public class AutoLoginFilter extends BasePortalFilter {
 
 	private static final List<AutoLogin> _autoLogins =
 		new CopyOnWriteArrayList<>();
-
-	private final ServiceTracker<?, AutoLogin> _serviceTracker;
+	private static final ServiceTracker<?, AutoLogin> _serviceTracker;
 
 	private static class AutoLoginServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer<AutoLogin, AutoLogin> {
@@ -317,6 +307,15 @@ public class AutoLoginFilter extends BasePortalFilter {
 			_autoLogins.remove(autoLogin);
 		}
 
+	}
+
+	static {
+		Registry registry = RegistryUtil.getRegistry();
+
+		_serviceTracker = registry.trackServices(
+			AutoLogin.class, new AutoLoginServiceTrackerCustomizer());
+
+		_serviceTracker.open();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
@@ -276,10 +276,12 @@ public class AutoLoginFilter extends BasePortalFilter {
 	private static final Log _log = LogFactoryUtil.getLog(
 		AutoLoginFilter.class);
 
-	private final List<AutoLogin> _autoLogins = new CopyOnWriteArrayList<>();
+	private static final List<AutoLogin> _autoLogins =
+		new CopyOnWriteArrayList<>();
+
 	private final ServiceTracker<?, AutoLogin> _serviceTracker;
 
-	private class AutoLoginServiceTrackerCustomizer
+	private static class AutoLoginServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer<AutoLogin, AutoLogin> {
 
 		@Override

--- a/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
@@ -41,8 +41,8 @@ import com.liferay.registry.ServiceReference;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
@@ -267,8 +267,8 @@ public class AutoLoginFilter extends BasePortalFilter {
 	private static final Log _log = LogFactoryUtil.getLog(
 		AutoLoginFilter.class);
 
-	private static final List<AutoLogin> _autoLogins =
-		new CopyOnWriteArrayList<>();
+	private static final Set<AutoLogin> _autoLogins =
+		new CopyOnWriteArraySet<>();
 	private static final ServiceTracker<?, AutoLogin> _serviceTracker;
 
 	private static class AutoLoginServiceTrackerCustomizer


### PR DESCRIPTION
Hi Shuyang,

I have confirmed that AutoLoginFilter can be invoked twice on ee-7.0.x, but only once on master.

And this can be backported to ee-7.0.x safely, it passed ci test on ee-7.0.x, please see https://github.com/tinatian/liferay-portal-ee/pull/74.

By the way, I did not test it with the steps of the ticket.


Tina.