### PR TITLE
Update setenv.bat

### DIFF
--- a/tools/servers/tomcat/bin/setenv.bat
+++ b/tools/servers/tomcat/bin/setenv.bat
@@ -1,9 +1,1 @@
-if exist "%CATALINA_HOME%/jre@java.version@/win" (
-	if not "%JAVA_HOME%" == "" (
-		set JAVA_HOME=
-	)
-
-	set "JRE_HOME=%CATALINA_HOME%/jre@java.version@/win"
-)
-
 set "CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -Dorg.apache.catalina.loader.WebappClassLoader.ENABLE_CLEAR_REFERENCES=false -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=384m"


### PR DESCRIPTION
This file referenced jre1.6.0_20 for a long time, containing dead code for a long time. Since it also doesn't have Windows line-ending-encoding, editing it in Notepad is quite hard. It's best to keep this file with a single line in the default deployment. As the deleted code was ineffective anyways, I didn't bother opening an issue - hope this is sufficient.