### PR TITLE
LPS-70650 Autofocus not being set on Sign In portlet

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -315,6 +315,10 @@
 
 				var focusable = !el.is(':disabled') && !el.is(':hidden');
 
+				if (el.parents(":disabled").length > 0) {
+					focusable =false;
+				}
+
 				if (!form.length || focusable) {
 					el.focus();
 				}


### PR DESCRIPTION
It was caused by Jquery “is(':disabled')" is not compitable for IE.
As the "input tag" is surrounded by the disabled "fieldset" tag.
We can use parents(":disabled") for a change..