### PR TITLE
LPS-74168: Update Liferay-Releng-Portal-Required property

### DIFF
--- a/modules/apps/frontend-theme-porygon/app.bnd
+++ b/modules/apps/frontend-theme-porygon/app.bnd
@@ -6,7 +6,7 @@ Liferay-Releng-Demo-Url:
 Liferay-Releng-Deprecated: false
 Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
-Liferay-Releng-Portal-Required: true
+Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: false
 Liferay-Releng-Support-Url: http://www.liferay.com


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-74168 
Porygon Theme should not be a required app.