### PR TITLE
LPS 68701 Add title to modal iframe 

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.22"
+String alloyUIVersion = "3.1.0-deprecated.23"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -238,6 +238,8 @@ AUI.add(
 
 					var uri = config.uri;
 
+					var title = config.title;
+
 					if (uri) {
 						if (config.cache === false) {
 							uri = Liferay.Util.addParams(A.guid() + '=' + Date.now(), uri);
@@ -291,6 +293,7 @@ AUI.add(
 								},
 
 								iframeId: iframeId,
+								iframeTitle: title,
 								uri: uri
 							}
 						);


### PR DESCRIPTION
## Disclaimer

Bug is captured in https://issues.liferay.com/browse/LPS-68701

Liferay.Util.openWindow() creates an iframe that does not have a title attribute. Accessibility guidelines indicate that frame and iframe elements should contain a title attribute to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail.
https://www.w3.org/TR/WCAG20-TECHS/H64.html
https://section508.gov/content/quick-reference-guide#1194.22i
Steps
1. Portlet menu > Configuration
2. Inspect the dialog that opens in browser's developer tools
3. Check if the iframe element for the dialog contents has a title attribute
Result: iframe does not have a title attribute
Expected: iframe has a title attribute describing the dialog contents

## Solution

### Intent
To add the ability to configure the desired title attribute of the the modal iframe

### Steps
- As a prerequisite **AlloyUI** had to be changed so as to render the `iframe` template with `title`attribute that can be specified through the configuration object that is in place alreasy.
This piece of work was done in https://issues.liferay.com/browse/AUI-3122. 

- As a result of this change, the consuming code now can pass the `title` attribute when the modal is initialized. 

- The current implementation of the portal generates these modals already with passing the `title` attribute (in most case it appears to be the the content of the corresponding <h*> element of the header) to the configuration object so no further action is required in further scopes.

### Test
Tested against major browsers by following the steps described in https://issues.liferay.com/browse/LPS-68701

![captura de pantalla 2017-08-24 a las 14 54 22](https://user-images.githubusercontent.com/6104164/29667640-6edacf38-88dd-11e7-97f8-49978b21d9d1.png)

 