### PR TITLE
LPS-47165 Prevent spurious database updates by cloned UnicodeProperties

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/UnicodeProperties.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/UnicodeProperties.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.io.IOException;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -41,7 +41,7 @@ import java.util.TreeMap;
  *
  * @author Alexander Chow
  */
-public class UnicodeProperties extends HashMap<String, String> {
+public class UnicodeProperties extends LinkedHashMap<String, String> {
 
 	public UnicodeProperties() {
 		_safe = false;


### PR DESCRIPTION
Extend LinkedHashMap instead of HashMap to prevent Hibernate from writing instances of these properties again and again.