### PR TITLE
[TCK] LPS-74563PortletRequest.getProperty and getProperties should throw IllegalArgumentException when name is null

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -412,6 +412,10 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 	@Override
 	public Enumeration<String> getProperties(String name) {
+		if (name == null) {
+			throw new IllegalArgumentException();
+		}
+
 		List<String> values = new ArrayList<>();
 
 		Enumeration<String> enumeration = _request.getHeaders(name);
@@ -437,6 +441,10 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 	@Override
 	public String getProperty(String name) {
+		if (name == null) {
+			throw new IllegalArgumentException();
+		}
+
 		String value = _request.getHeader(name);
 
 		if (value == null) {


### PR DESCRIPTION
Hi Shuyang,
This pull has passed CI test, please see https://github.com/tinatian/liferay-portal/pull/725

This is not required by spec, but required by api java doc, please see :https://portals.apache.org/pluto/portlet-3.0-apidocs/javax/portlet/PortletRequest.html#getProperty(java.lang.String)
https://portals.apache.org/pluto/portlet-3.0-apidocs/javax/portlet/PortletRequest.html#getProperties(java.lang.String)

Thanks.
Tina.