### PR TITLE
LPS-74784

### DIFF
--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/v2_0_0/UpgradeUserNotificationEvent.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/v2_0_0/UpgradeUserNotificationEvent.java
@@ -14,16 +14,8 @@
 
 package com.liferay.notifications.web.internal.upgrade.v2_0_0;
 
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
-import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.LoggingTimer;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 
 /**
  * @author Sergio González
@@ -33,57 +25,13 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 
 	public UpgradeUserNotificationEvent(
 		UserNotificationEventLocalService userNotificationEventLocalService) {
-
-		_userNotificationEventLocalService = userNotificationEventLocalService;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (!hasTable("Notifications_UserNotificationEvent")) {
-			return;
-		}
-
-		updateUserNotificationEvents();
 	}
 
 	protected void updateUserNotificationEvents() throws Exception {
-		try (LoggingTimer loggingTimer = new LoggingTimer();
-			PreparedStatement ps = connection.prepareStatement(
-				"select userNotificationEventId from " +
-					"Notifications_UserNotificationEvent");
-			ResultSet rs = ps.executeQuery()) {
-
-			while (rs.next()) {
-				long userNotificationEventId = rs.getLong(
-					"userNotificationEventId");
-
-				UserNotificationEvent userNotificationEvent =
-					_userNotificationEventLocalService.getUserNotificationEvent(
-						userNotificationEventId);
-
-				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-					userNotificationEvent.getPayload());
-
-				userNotificationEvent.setDeliveryType(
-					UserNotificationDeliveryConstants.TYPE_WEBSITE);
-				userNotificationEvent.setDelivered(true);
-
-				boolean actionRequired = jsonObject.getBoolean(
-					"actionRequired");
-
-				jsonObject.remove("actionRequired");
-
-				userNotificationEvent.setPayload(jsonObject.toString());
-
-				userNotificationEvent.setActionRequired(actionRequired);
-
-				_userNotificationEventLocalService.updateUserNotificationEvent(
-					userNotificationEvent);
-			}
-		}
 	}
-
-	private final UserNotificationEventLocalService
-		_userNotificationEventLocalService;
 
 }


### PR DESCRIPTION
Hi @SamZiemer,

There were three potential solutions I thought of for this:

1. Remove the registration of this upgrade process in NotificationsWebUpgrade.java and upgrade straight from v1_3_0 to v2_1_0.
2. Remove the logic from the v2_0_0 upgrade process.
3. Remove the logic from the v2_1_0 upgrade process (and apply the fix added to it to the v2_0_0 upgrade process).

I didn't like option 1 because I thought it could be confusing to users if they saw the upgrade process go straight from v1_3_0 to v2_1_0, apparently skipping v2_0_0. So it was between options 2 and 3. I liked option 2 better because, my understanding is that you cannot use the module until it has successfully upgraded to the latest version. So if you have the upgrade process in the latest version, users will be forced to run it before they can use the module. I couldn't find any explanation why the latest upgrade process was added in [LPS-65111](https://issues.liferay.com/browse/LPS-65111), but I can only assume that someone found a way to upgrade to v2_0_0 without that process having been run, so in this case, keeping the logic in v2_1_0 seems safer.

Please let me know if my understanding is not correct.