### PR TITLE
LPP-27151 - Lexicon icons are missing from web page

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -184,10 +184,6 @@
 			<param-name>url-regex-pattern</param-name>
 			<param-value>.+/lexicon/icons.svg</param-value>
 		</init-param>
-		<init-param>
-			<param-name>Access-Control-Allow-Origin</param-name>
-			<param-value>*</param-value>
-		</init-param>
 	</filter>
 	<filter>
 		<filter-name>Header Filter - No Cache</filter-name>


### PR DESCRIPTION
- This issue is caused by LPS-72903, LPS-72903 added the Access-Control-Allow-Origin to the response header by default, as a result, it will collide with tomcat configuration.


- see https://issues.liferay.com/browse/LPS-74722?focusedCommentId=1114893&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1114893 for details.