### PR TITLE
[TECHNICAL SUPPORT] LPS-75166 Upgrade from 6.2 to DXP fails during UpgradeMobileDeviceRules if a Device Family is added to a page

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeMobileDeviceRules.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeMobileDeviceRules.java
@@ -125,7 +125,7 @@ public class UpgradeMobileDeviceRules extends UpgradeProcess {
 		sb1.append("(MDRRuleGroupInstance.companyId = ResourcePermission.");
 		sb1.append(
 			"companyId) and (MDRRuleGroupInstance.ruleGroupInstanceId = ");
-		sb1.append("ResourcePermission.primKeyId) and (MDRRuleGroupInstance.");
+		sb1.append("ResourcePermission.primKey) and (MDRRuleGroupInstance.");
 		sb1.append("userId = ResourcePermission.ownerId) and ");
 		sb1.append("(ResourcePermission.name = '");
 		sb1.append(_CLASS_NAME);


### PR DESCRIPTION
Hi,

I don't know if I should send this to you but you reviewed the LPS which caused the regression so I figured it's ok.

Thanks!
Norbert

https://issues.liferay.com/browse/LPS-75166