### PR TITLE
[Portlet 3.0]LPS-75367 

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletServletRequest.java
+++ b/portal-impl/src/com/liferay/portlet/PortletServletRequest.java
@@ -42,6 +42,7 @@ import javax.portlet.EventRequest;
 import javax.portlet.PortletRequest;
 
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -320,7 +321,13 @@ public class PortletServletRequest extends HttpServletRequestWrapper {
 
 	@Override
 	public String getPathTranslated() {
-		return _request.getPathTranslated();
+		ServletContext servletContext = _request.getServletContext();
+
+		if ((_pathInfo != null) && (servletContext != null)) {
+			return servletContext.getRealPath(_pathInfo);
+		}
+
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
Hi Shuyang,

This pull has passed on CI, please see https://github.com/tinatian/liferay-portal/pull/790.

This fixes 16 failures.

According to servlet 3.1 api, HttpServletRequest.getPathTranslated() should:
> Returns any extra path information after the servlet name but before the query string, and translates it to a real path.

Our PortletServletRequest is a HttpServletRequest wrapper with its own _pathInfo value which might not be different from the inner HttpServletRequest, so we should use its own _pathInfo to calculate instead of referring to the inner one.


Thanks.
Tina.
