### PR TITLE
Update HtmlUtil.java

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/HtmlUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/HtmlUtil.java
@@ -181,8 +181,7 @@ public class HtmlUtil {
 	}
 
 	/**
-	 * Replaces all Microsoft&reg; Word Unicode characters with plain HTML
-	 * entities or characters.
+	 * Replaces several Windows-1252 characters
 	 *
 	 * @param      text the text
 	 * @return     the converted text, or <code>null</code> if the text is


### PR DESCRIPTION
I realize this method is deprecated (for very good reasons) but I still think it's imperative to change the JavaDoc description.  The previous description made no sense. This method can/has caused serious issue if relied upon.  I replaced the word all with "several", I changed the description to add the official character set name, and I removed the "plain html entities or characters".  I realize this might seem much less descriptive but in reality it is way more accurate.  You essentially cannot say anything more descriptive than this or else it is no longer true and if relied upon can cause a lot of issues