### PR TITLE
LPS-76988 Fix doImportMissingReference methods to prevent NullPointerExceptions

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -226,6 +226,10 @@ public class DLFileEntryTypeStagedModelDataHandler
 		existingFileEntryType = fetchExistingFileEntryType(
 			uuid, groupId, fileEntryTypeKey, preloaded);
 
+		if (existingFileEntryType == null) {
+			return;
+		}
+
 		Map<Long, Long> fileEntryTypeIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				DLFileEntryType.class);

--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -323,6 +323,10 @@ public class FileEntryStagedModelDataHandler
 
 		FileEntry existingFileEntry = fetchMissingReference(uuid, groupId);
 
+		if (existingFileEntry == null) {
+			return;
+		}
+
 		Map<Long, Long> dlFileEntryIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				DLFileEntry.class);

--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
@@ -200,6 +200,10 @@ public class FolderStagedModelDataHandler
 
 		Folder existingFolder = fetchMissingReference(uuid, groupId);
 
+		if (existingFolder == null) {
+			return;
+		}
+
 		Map<Long, Long> folderIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				Folder.class);

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/DDLRecordSetStagedModelDataHandler.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/DDLRecordSetStagedModelDataHandler.java
@@ -144,6 +144,10 @@ public class DDLRecordSetStagedModelDataHandler
 
 		DDLRecordSet existingRecordSet = fetchMissingReference(uuid, groupId);
 
+		if (existingRecordSet == null) {
+			return;
+		}
+
 		Map<Long, Long> recordSetIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				DDLRecordSet.class);

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/DDLRecordStagedModelDataHandler.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/DDLRecordStagedModelDataHandler.java
@@ -134,6 +134,10 @@ public class DDLRecordStagedModelDataHandler
 
 		DDLRecord existingRecord = fetchMissingReference(uuid, groupId);
 
+		if (existingRecord == null) {
+			return;
+		}
+
 		Map<Long, Long> recordIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				DDLRecord.class);

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -344,6 +344,10 @@ public class LayoutStagedModelDataHandler
 
 		existingLayout = fetchMissingReference(uuid, groupId, privateLayout);
 
+		if (existingLayout == null) {
+			return;
+		}
+
 		Map<Long, Layout> layouts =
 			(Map<Long, Layout>)portletDataContext.getNewPrimaryKeysMap(
 				Layout.class + ".layout");


### PR DESCRIPTION
Hey Máté,

I realized that about half of the _doImportMissingReference_ methods are missing the null checks, which can be a problem e.g. if we create REFERENCE_TYPE_WEAK references therefore it is not guaranteed that the referenced content really exists at the import side.

I'm going to send pull request to the dynamic-data-mapping and to the journal subrepo as well.

Thanks,
Tamás