### PR TITLE
LPS 52107 - Children organizations do not inherit site membership from parent organizations

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.model.LayoutTemplate;
 import com.liferay.portal.kernel.model.LayoutTypeAccessPolicy;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
+import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.model.User;
@@ -59,6 +60,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
+import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
@@ -664,6 +666,24 @@ public class ServicePreAction extends Action {
 			}
 			else {
 				siteGroupId = PortalUtil.getSiteGroupId(layout.getGroupId());
+			}
+		}
+
+		if (PropsValues.ORGANIZATIONS_SITE_MEMBERSHIP_STRICT) {
+			long groupid = group.getGroupId();
+
+			List<Organization> organizations =
+				OrganizationLocalServiceUtil.getGroupOrganizations(groupid);
+
+			if(!organizations.isEmpty()) {
+				List<Organization> suborganizations =
+					OrganizationLocalServiceUtil.getSuborganizations(
+						organizations);
+
+				if (!organizations.contains(suborganizations)) {
+					OrganizationLocalServiceUtil.addGroupOrganizations(
+						groupid, suborganizations);
+				}
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -773,6 +773,20 @@ public class OrganizationLocalServiceImpl
 		return organizationPersistence.countByC_P(companyId, organizationId);
 	}
 
+	public long[] getSuborganizationsIds(List<Organization> organizationList) {
+		List<Organization> suborgList = getSuborganizations(organizationList);
+
+		long[] orgIds = new long[suborgList.size()];
+
+		for (int i = 0; i < suborgList.size(); i++) {
+			Organization org = suborgList.get(i);
+
+			orgIds[i] = org.getOrganizationId();
+		}
+
+		return orgIds;
+	}
+
 	/**
 	 * Returns the intersection of <code>allOrganizations</code> and
 	 * <code>availableOrganizations</code>.

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.service.base.OrganizationServiceBaseImpl;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
 import java.io.Serializable;
@@ -69,6 +70,16 @@ public class OrganizationServiceImpl extends OrganizationServiceBaseImpl {
 
 		organizationLocalService.addGroupOrganizations(
 			groupId, organizationIds);
+
+		if (PropsValues.ORGANIZATIONS_SITE_MEMBERSHIP_STRICT) {
+			List<Organization> orgList =
+				organizationLocalService.getOrganizations(organizationIds);
+
+			long[] suborgIds = organizationLocalService.getSuborganizationsIds(
+				orgList);
+
+			organizationLocalService.addGroupOrganizations(groupId, suborgIds);
+		}
 	}
 
 	/**
@@ -453,6 +464,18 @@ public class OrganizationServiceImpl extends OrganizationServiceBaseImpl {
 
 		organizationLocalService.unsetGroupOrganizations(
 			groupId, organizationIds);
+
+		if (PropsValues.ORGANIZATIONS_SITE_MEMBERSHIP_STRICT) {
+			List<Organization> organizationList =
+				organizationLocalService.getOrganizations(organizationIds);
+
+			long[] suborganizationsIds =
+				organizationLocalService.getSuborganizationsIds(
+					organizationList);
+
+			organizationLocalService.unsetGroupOrganizations(
+				groupId, suborganizationsIds);
+		}
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1205,6 +1205,8 @@ public class PropsValues {
 
 	public static final boolean ORGANIZATIONS_SEARCH_WITH_INDEX = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.ORGANIZATIONS_SEARCH_WITH_INDEX));
 
+	public static final boolean ORGANIZATIONS_SITE_MEMBERSHIP_STRICT = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.ORGANIZATIONS_SITE_MEMBERSHIP_STRICT));
+
 	public static String[] ORGANIZATIONS_TYPES = PropsUtil.getArray(PropsKeys.ORGANIZATIONS_TYPES);
 
 	public static final boolean PASSWORDS_DEFAULT_POLICY_ALLOW_DICTIONARY_WORDS = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.PASSWORDS_DEFAULT_POLICY_ALLOW_DICTIONARY_WORDS));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -2120,6 +2120,14 @@
     #
     organizations.search.with.index=true
 
+    #
+    # Set this property to true if you want child organizations and their users
+    # to be added automatically to a site when a parent organization is added.
+    # For example, if Liferay Global is added as a member to a site, Liferay
+    # Spain and Liferay Europe will also be added as members.
+    #
+    organizations.site.membership.strict=false
+
 ##
 ## User Groups
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalService.java
@@ -582,6 +582,9 @@ public interface OrganizationLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getSuborganizationsCount(long companyId, long organizationId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public long[] getSuborganizationsIds(List<Organization> organizationList);
+
 	/**
 	* Returns the intersection of <code>allOrganizations</code> and
 	* <code>availableOrganizations</code>.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceUtil.java
@@ -703,6 +703,11 @@ public class OrganizationLocalServiceUtil {
 		return getService().getSuborganizationsCount(companyId, organizationId);
 	}
 
+	public static long[] getSuborganizationsIds(
+		java.util.List<com.liferay.portal.kernel.model.Organization> organizationList) {
+		return getService().getSuborganizationsIds(organizationList);
+	}
+
 	/**
 	* Returns the intersection of <code>allOrganizations</code> and
 	* <code>availableOrganizations</code>.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceWrapper.java
@@ -767,6 +767,12 @@ public class OrganizationLocalServiceWrapper implements OrganizationLocalService
 			organizationId);
 	}
 
+	@Override
+	public long[] getSuborganizationsIds(
+		java.util.List<com.liferay.portal.kernel.model.Organization> organizationList) {
+		return _organizationLocalService.getSuborganizationsIds(organizationList);
+	}
+
 	/**
 	* Returns the intersection of <code>allOrganizations</code> and
 	* <code>availableOrganizations</code>.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1710,6 +1710,8 @@ public interface PropsKeys {
 
 	public static final String ORGANIZATIONS_SEARCH_WITH_INDEX = "organizations.search.with.index";
 
+	public static final String ORGANIZATIONS_SITE_MEMBERSHIP_STRICT = "organizations.site.membership.strict";
+
 	public static final String ORGANIZATIONS_TYPES = "organizations.types";
 
 	public static final String PASSWORDS_DEFAULT_POLICY_ALLOW_DICTIONARY_WORDS = "passwords.default.policy.allow.dictionary.words";


### PR DESCRIPTION
Hi Sam!
LPP: https://issues.liferay.com/browse/LPP-28259
LPS: https://issues.liferay.com/browse/LPS-52107

**Issue:**
The issue being reported by the client is that child organizations do not inherit site membership from parent organizations. 

**Summary of History:**
A previous LPP provides context for this fix. Specifically several decisions were made including:
- that the behavior of children organizations being added automatically is [intended](https://issues.liferay.com/browse/LPP-14323?focusedCommentId=548245&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-548245)
- that [users belonging to child orgs should be visible](https://issues.liferay.com/browse/LPP-14323?focusedCommentId=556942&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-556942) in Site Memberships -> Users upon being added through a parent org being added

A previous PR also outlined that the fix should work on preexisting organizations/sites, that it should account for a child organization being added to a parent organization after the membership is established, as well as automatic removal of all children if a parent is removed.

**The Fix:**
The fix involves checking if the children organizations of all site member organizations are members of the group on page load and adding them if they are not. Children organizations are also added when a parent organization is added and correspondingly removed when the parent is removed. This behavior only works for the 'highest tier' member in the relationship chain--so if Liferay Europe is added, then Liferay Spain is added as a member as well. However, if Liferay Global is added later, Liferay Europe is no longer considered independent and cannot be removed unless Liferay Global is removed. This means that inheritance is strictly enforced as mandatory and individual users and individual child organizations cannot be removed.

The fix itself uses a portal property to allow the user to determine the behavior they wish to have. It defaults to false which corresponds to how the portal works presently (inheritance does not occur). If set to true, inheritance will be enforced.

Please let me know if you have any questions or concerns. Thanks!