### PR TITLE
LPS-77702 Fixed Saving Timers in Condition Node for Kaleo Workflow

### DIFF
--- a/definitions/liferay-workflow-definition_7_0_0.xsd
+++ b/definitions/liferay-workflow-definition_7_0_0.xsd
@@ -178,6 +178,13 @@
 						<xs:element name="script" type="xs:string" />
 						<xs:element name="script-language" type="script-language-type" />
 						<xs:element minOccurs="0" name="script-required-contexts" type="xs:string" />
+						<xs:element minOccurs="0" name="task-timers">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element maxOccurs="unbounded" name="task-timer" type="task-timer-complex-type" />
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
 						<xs:element ref="transitions" />
 					</xs:sequence>
 				</xs:extension>


### PR DESCRIPTION
Hello @gregory-bretall,

https://issues.liferay.com/browse/LPS-77702
https://issues.liferay.com/browse/LPP-28795

The issue is that the user is unable to save a timer on a condition node in the Liferay Kaleo workflow engine. 
The reason for this issue is that the condition element in definitions\liferay-workflow-definition_7_0_0.xsd does not have an implementation of timers in it. 
The fix for this issue is simple in that I just brought over the existing timer element from the task element into the condition element. I also made the timer element optional in the condition node so that users can decide whether they want timers saved or not.

Please let me know if there is any issue or you have any questions. Thanks!