### PR TITLE
LPS-77428 - Staged sites share "Last Publish Date" for certain portlet types

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/DDMFormAdminPortlet.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/DDMFormAdminPortlet.java
@@ -80,6 +80,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 		"com.liferay.portlet.icon=/admin/icons/form.png",
 		"com.liferay.portlet.instanceable=false",
 		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",

--- a/modules/apps/web-experience/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/AssetCategoryAdminPortlet.java
+++ b/modules/apps/web-experience/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/AssetCategoryAdminPortlet.java
@@ -87,6 +87,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.display-category=category.hidden",
 		"com.liferay.portlet.icon=/icons/asset_category_admin.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",

--- a/modules/apps/web-experience/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/portlet/AssetTagsAdminPortlet.java
+++ b/modules/apps/web-experience/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/portlet/AssetTagsAdminPortlet.java
@@ -53,6 +53,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.display-category=category.hidden",
 		"com.liferay.portlet.icon=/icons/asset_tag_admin.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",


### PR DESCRIPTION
Hi Chris!

LPP: https://issues.liferay.com/browse/LPP-28517
LPS: https://issues.liferay.com/browse/LPS-77428

Certain portlet types share portlet preferences across sites due to using the 'shared' portlet id and 'shared' owner id of 0 and 0. While this is understandable for certain portlets,  this does not work as well for portlets that can be staged since those portlets would then share a portlet preference file across all possible staged sites. Since the last publish date is found in the portlet preferences, this breaks any views dealing with "last publish date".

The fix explicitly designates specific admin portlets that can be staged (Forms, Asset Categories and Asset Tags) to _not_ be "unique per layout". This makes them consistent with the other admin portlets and prevents their last publish dates from being overwritten by other sites.

If you have any other questions or concerns, please let me know. Thanks!