### PR TITLE
LPS-82059 Catch all exceptions when retrieving a poll question

### DIFF
--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/init.jsp
@@ -51,6 +51,7 @@ page import="com.liferay.polls.web.internal.security.permission.resource.PollsPe
 page import="com.liferay.polls.web.internal.security.permission.resource.PollsQuestionPermission" %><%@
 page import="com.liferay.portal.kernel.bean.BeanParamUtil" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
+page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Portlet" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
@@ -22,7 +22,7 @@ PollsQuestion question = null;
 try {
 	question = PollsUtil.getQuestionByPortlet(portletPreferences);
 }
-catch (NoSuchQuestionException nsqe) {
+catch (PortalException pe) {
 }
 
 if (question != null) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82059
https://issues.liferay.com/browse/LPP-30445

Problem: Polls Questions permissioned not to display to a user causes the portlet to become unavailable because the Principle Exception is not handled by the view.jsp.
