### PR TITLE
LPS-78119 Search is giving locale based results even for administrator role for Web Content articles

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
@@ -449,22 +450,33 @@ public class JournalArticleIndexer
 			return Collections.emptyMap();
 		}
 
-		String localizedField = Field.getLocalizedName(
-			searchContext.getLocale(), field);
+		Set<Locale> availableLocales = new HashSet<>();
+
+		long[] groupIds = searchContext.getGroupIds();
+
+		if (groupIds == null) {
+			availableLocales = LanguageUtil.getAvailableLocales();
+		}
+		else {
+			for (long groupId : groupIds) {
+				availableLocales.addAll(
+					LanguageUtil.getAvailableLocales(groupId));
+			}
+		}
 
 		Map<String, Query> queries = new HashMap<>();
 
 		if (Validator.isNull(searchContext.getKeywords())) {
 			BooleanQuery localizedQuery = new BooleanQueryImpl();
 
-			Query query = localizedQuery.addTerm(field, value, like);
+			for (Locale locale : availableLocales) {
+				String localizedField = Field.getLocalizedName(locale, field);
 
-			queries.put(field, query);
+				Query localizedFieldQuery = localizedQuery.addTerm(
+					localizedField, value, like);
 
-			Query localizedFieldQuery = localizedQuery.addTerm(
-				localizedField, value, like);
-
-			queries.put(field, localizedFieldQuery);
+				queries.put(localizedField, localizedFieldQuery);
+			}
 
 			BooleanClauseOccur booleanClauseOccur = BooleanClauseOccur.SHOULD;
 
@@ -475,9 +487,13 @@ public class JournalArticleIndexer
 			searchQuery.add(localizedQuery, booleanClauseOccur);
 		}
 		else {
-			Query query = searchQuery.addTerm(localizedField, value, like);
+			for (Locale locale : availableLocales) {
+				String localizedField = Field.getLocalizedName(locale, field);
 
-			queries.put(field, query);
+				Query query = searchQuery.addTerm(localizedField, value, like);
+
+				queries.put(field, query);
+			}
 		}
 
 		return queries;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -540,6 +540,8 @@ public class JournalArticleIndexer
 		String articleDefaultLanguageId = LocalizationUtil.getDefaultLanguageId(
 			journalArticle.getDocument());
 
+		document.addText("defaultLanguageId", articleDefaultLanguageId);
+
 		String[] languageIds = LocalizationUtil.getAvailableLanguageIds(
 			journalArticle.getDocument());
 
@@ -549,12 +551,6 @@ public class JournalArticleIndexer
 			String description = journalArticle.getDescription(languageId);
 
 			String title = journalArticle.getTitle(languageId);
-
-			if (languageId.equals(articleDefaultLanguageId)) {
-				document.addText(Field.CONTENT, content);
-				document.addText(Field.DESCRIPTION, description);
-				document.addText("defaultLanguageId", languageId);
-			}
 
 			document.addText(
 				LocalizationUtil.getLocalizedName(Field.CONTENT, languageId),

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerLocalizedContentTest.java
@@ -121,7 +121,6 @@ public class JournalArticleIndexerLocalizedContentTest {
 
 		Map<String, String> contentStrings = new HashMap<String, String>() {
 			{
-				put("content", originalContent);
 				put("content_en_US", originalContent);
 				put("content_hu_HU", translatedContent);
 			}
@@ -258,7 +257,6 @@ public class JournalArticleIndexerLocalizedContentTest {
 
 		Map<String, String> contentStrings = new HashMap<String, String>() {
 			{
-				put("content", content);
 				put("content_ja_JP", content);
 			}
 		};

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerLocalizedContentTest.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -222,6 +223,49 @@ public class JournalArticleIndexerLocalizedContentTest {
 
 		FieldValuesAssert.assertFieldValues(
 			ddmContentStrings, "ddm__text", document, searchTerm);
+	}
+
+	@Test
+	public void testIndexedFieldsWithUnindexedTranslation() throws Exception {
+		String title = "entity title";
+
+		setTitle(
+			new JournalArticleTitle() {
+				{
+					put(LocaleUtil.US, title);
+				}
+			});
+
+		String content = "entity content";
+
+		setContent(
+			new JournalArticleContent() {
+				{
+					name = "content";
+					defaultLocale = LocaleUtil.US;
+
+					put(LocaleUtil.US, content);
+				}
+			});
+
+		addArticle();
+
+		String searchTerm = "title";
+
+		SearchContext searchContext = _getSearchContext(
+			searchTerm, LocaleUtil.HUNGARY);
+
+		Hits hits = _indexer.search(searchContext);
+
+		Assert.assertEquals(hits.toString(), 1, hits.getLength());
+
+		searchTerm = "content";
+
+		searchContext = _getSearchContext(searchTerm, LocaleUtil.HUNGARY);
+
+		hits = _indexer.search(searchContext);
+
+		Assert.assertEquals(hits.toString(), 1, hits.getLength());
 	}
 
 	@Test

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -1107,13 +1107,28 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 
 		queries.put(field, query);
 
-		String localizedFieldName = Field.getLocalizedName(
-			searchContext.getLocale(), field);
+		Set<Locale> availableLocales = new HashSet<>();
 
-		Query localizedQuery = addSearchTerm(
-			searchQuery, searchContext, localizedFieldName, like);
+		long[] groupIds = searchContext.getGroupIds();
 
-		queries.put(localizedFieldName, localizedQuery);
+		if (groupIds == null) {
+			availableLocales = LanguageUtil.getAvailableLocales();
+		}
+		else {
+			for (long groupId : groupIds) {
+				availableLocales.addAll(
+					LanguageUtil.getAvailableLocales(groupId));
+			}
+		}
+
+		for (Locale locale : availableLocales) {
+			String localizedFieldName = Field.getLocalizedName(locale, field);
+
+			Query localizedQuery = addSearchTerm(
+				searchQuery, searchContext, localizedFieldName, like);
+
+			queries.put(localizedFieldName, localizedQuery);
+		}
 
 		return queries;
 	}


### PR DESCRIPTION
[LPS-78119 ](https://issues.liferay.com/browse/LPS-78119)

Hi Eudaldo,

I'm sending this to you as Tibor Lipusz doesn't have time to deal with it recently.

*Issue(s):*
* Web Content title field doesn't have default translation ("title" field) indexed as of [LPS-67687](https://issues.liferay.com/browse/LPS-67687). Searching for title, therefore, doens't give back results when other language is selected.
* description and content fields still have default translation indexed, leading to inconsistent behaviour.

*Changes:*
Please note, this PR introduces a behavioral change that was discussed in the frame of a product team request, with the following points to consider. (For the original spec please visit [André's summary on PTR-294](https://issues.liferay.com/browse/PTR-294?focusedCommentId=1266624&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1266624).)

* Index one localized field per translation. (Do not index "title", "content" and "description" fields with default translation anymore.)
* Query has one clause per each Site language, as "should" (matching any).
* Query uses Site languages only, ignores Display Locale altogether.

*FYI:* Daniel Couso gave the following quidance regarding the 7.0 backport: 

> For 7.0, this will entail a major behavior change that should be introduced as an option keeping the old behavior by adding a new System Setting or Portal Property to choose between the two modes.

Please, help in deciding how important this change would be for 7.1. Is it a 7.1-must or 7.1-should.

Involving the Search Team in the review may be also beneficial, depending on your judgement. Also, let me know if I can help with anything.

Thank you in advance,
Istvan

cc @dacousalr 