### PR TITLE
LPS-82717

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -901,7 +901,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				 cmd.equals(Constants.ADD_DYNAMIC)) &&
 				(size == 0)) {
 
-				contentType = MimeTypesUtil.getContentType(title);
+				contentType = MimeTypesUtil.getContentType(sourceFileName);
 			}
 
 			if (cmd.equals(Constants.ADD) ||

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorLocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorLocalRepositoryWrapper.java
@@ -50,7 +50,7 @@ public class ModelValidatorLocalRepositoryWrapper
 
 		FileContentReference fileContentReference =
 			FileContentReference.fromFile(
-				sourceFileName, DLAppUtil.getExtension(title, sourceFileName),
+				sourceFileName, DLAppUtil.getExtension(sourceFileName),
 				mimeType, file);
 
 		_modelValidator.validate(fileContentReference);
@@ -69,7 +69,7 @@ public class ModelValidatorLocalRepositoryWrapper
 
 		FileContentReference fileContentReference =
 			FileContentReference.fromInputStream(
-				sourceFileName, DLAppUtil.getExtension(title, sourceFileName),
+				sourceFileName, DLAppUtil.getExtension(sourceFileName),
 				mimeType, is, size);
 
 		_modelValidator.validate(fileContentReference);
@@ -89,7 +89,7 @@ public class ModelValidatorLocalRepositoryWrapper
 		FileContentReference fileContentReference =
 			FileContentReference.fromFile(
 				fileEntryId, sourceFileName,
-				DLAppUtil.getExtension(title, sourceFileName), mimeType, file);
+				DLAppUtil.getExtension(sourceFileName), mimeType, file);
 
 		_modelValidator.validate(fileContentReference);
 
@@ -109,8 +109,7 @@ public class ModelValidatorLocalRepositoryWrapper
 		FileContentReference fileContentReference =
 			FileContentReference.fromInputStream(
 				fileEntryId, sourceFileName,
-				DLAppUtil.getExtension(title, sourceFileName), mimeType, is,
-				size);
+				DLAppUtil.getExtension(sourceFileName), mimeType, is, size);
 
 		_modelValidator.validate(fileContentReference);
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorRepositoryWrapper.java
@@ -49,7 +49,7 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 
 		FileContentReference fileContentReference =
 			FileContentReference.fromFile(
-				sourceFileName, DLAppUtil.getExtension(title, sourceFileName),
+				sourceFileName, DLAppUtil.getExtension(sourceFileName),
 				mimeType, file);
 
 		_modelValidator.validate(fileContentReference);
@@ -68,7 +68,7 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 
 		FileContentReference fileContentReference =
 			FileContentReference.fromInputStream(
-				sourceFileName, DLAppUtil.getExtension(title, sourceFileName),
+				sourceFileName, DLAppUtil.getExtension(sourceFileName),
 				mimeType, is, size);
 
 		_modelValidator.validate(fileContentReference);
@@ -88,7 +88,7 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 		FileContentReference fileContentReference =
 			FileContentReference.fromFile(
 				fileEntryId, sourceFileName,
-				DLAppUtil.getExtension(title, sourceFileName), mimeType, file);
+				DLAppUtil.getExtension(sourceFileName), mimeType, file);
 
 		_modelValidator.validate(fileContentReference);
 
@@ -108,8 +108,7 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 		FileContentReference fileContentReference =
 			FileContentReference.fromInputStream(
 				fileEntryId, sourceFileName,
-				DLAppUtil.getExtension(title, sourceFileName), mimeType, is,
-				size);
+				DLAppUtil.getExtension(sourceFileName), mimeType, is, size);
 
 		_modelValidator.validate(fileContentReference);
 

--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -604,7 +604,7 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 
 		int pos = fileName.lastIndexOf(CharPool.PERIOD);
 
-		if (pos > 0) {
+		if (pos >= 0) {
 			return StringUtil.toLowerCase(fileName.substring(pos + 1));
 		}
 		else {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -260,8 +260,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
 
 			if (size == 0) {
-				String extension = DLAppUtil.getExtension(
-					title, sourceFileName);
+				String extension = DLAppUtil.getExtension(sourceFileName);
 
 				mimeType = MimeTypesUtil.getExtensionContentType(extension);
 			}
@@ -1049,8 +1048,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
 
 			if (size == 0) {
-				String extension = DLAppUtil.getExtension(
-					title, sourceFileName);
+				String extension = DLAppUtil.getExtension(sourceFileName);
 
 				mimeType = MimeTypesUtil.getExtensionContentType(extension);
 			}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -267,8 +267,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
 
 			if (size == 0) {
-				String extension = DLAppUtil.getExtension(
-					title, sourceFileName);
+				String extension = DLAppUtil.getExtension(sourceFileName);
 
 				mimeType = MimeTypesUtil.getExtensionContentType(extension);
 			}
@@ -2596,8 +2595,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
 
 			if (size == 0) {
-				String extension = DLAppUtil.getExtension(
-					title, sourceFileName);
+				String extension = DLAppUtil.getExtension(sourceFileName);
 
 				mimeType = MimeTypesUtil.getExtensionContentType(extension);
 			}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -179,7 +179,7 @@ public class DLFileEntryLocalServiceImpl
 
 		String name = String.valueOf(
 			counterLocalService.increment(DLFileEntry.class.getName()));
-		String extension = DLAppUtil.getExtension(title, sourceFileName);
+		String extension = DLAppUtil.getExtension(sourceFileName);
 
 		String fileName = DLUtil.getSanitizedFileName(title, extension);
 
@@ -1971,7 +1971,7 @@ public class DLFileEntryLocalServiceImpl
 		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
 			fileEntryId);
 
-		String extension = DLAppUtil.getExtension(title, sourceFileName);
+		String extension = DLAppUtil.getExtension(sourceFileName);
 
 		String extraSettings = StringPool.BLANK;
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLAppUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLAppUtil.java
@@ -29,12 +29,8 @@ import java.io.File;
  */
 public class DLAppUtil {
 
-	public static String getExtension(String title, String sourceFileName) {
+	public static String getExtension(String sourceFileName) {
 		String extension = FileUtil.getExtension(sourceFileName);
-
-		if (Validator.isNull(extension)) {
-			extension = FileUtil.getExtension(title);
-		}
 
 		return extension;
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLAppUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLAppUtil.java
@@ -41,7 +41,7 @@ public class DLAppUtil {
 		if (Validator.isNull(mimeType) ||
 			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
 
-			String extension = getExtension(title, sourceFileName);
+			String extension = getExtension(sourceFileName);
 
 			mimeType = MimeTypesUtil.getContentType(file, "A." + extension);
 		}


### PR DESCRIPTION
Hello @SamZiemer ,

Sending a new PR from here: https://github.com/SamZiemer/liferay-portal/pull/461.

> 
> Hello @SamZiemer ,
> 
> https://issues.liferay.com/browse/LPS-82717
> 
> The issue is that DLAppUtil's getExtension is passing in the Title to be checked for an extension if a sourceFile does not exist. The logic here is flawed because a Title of a document entry should never be used for checking extensions because no source Files exist. Because the logic exists, it is causing variety of issues that are described in LPS-82717.
> 
> The simple fix is to remove the use of Title being checked for extensions and/or mimeTypes.
> 
> Sincerely,
> Brian Kim