### PR TITLE
[TS] LPS-83223

### DIFF
--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/test/BlogsExportImportTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/test/BlogsExportImportTest.java
@@ -55,7 +55,7 @@ public class BlogsExportImportTest extends BasePortletExportImportTestCase {
 
 	@Override
 	public String getPortletId() {
-		return BlogsPortletKeys.BLOGS;
+		return BlogsPortletKeys.BLOGS_ADMIN;
 	}
 
 	@Before

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/web/internal/exportimport/data/handler/test/BlogsAdminPortletDataHandlerTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/web/internal/exportimport/data/handler/test/BlogsAdminPortletDataHandlerTest.java
@@ -12,22 +12,20 @@
  * details.
  */
 
-package com.liferay.wiki.web.internal.exportimport.data.handler.test;
+package com.liferay.blogs.web.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.constants.BlogsPortletKeys;
+import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.exportimport.kernel.lar.DataLevel;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.lar.test.BasePortletDataHandlerTestCase;
-import com.liferay.portal.service.test.ServiceTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.wiki.constants.WikiPortletKeys;
-import com.liferay.wiki.model.WikiNode;
-import com.liferay.wiki.util.test.WikiTestUtil;
 
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -36,32 +34,23 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  */
 @RunWith(Arquillian.class)
-public class WikiPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
+public class BlogsAdminPortletDataHandlerTest
+	extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
-
-	@Before
-	@Override
-	public void setUp() throws Exception {
-		ServiceTestUtil.setUser(TestPropsValues.getUser());
-
-		super.setUp();
-	}
 
 	@Override
 	protected void addStagedModels() throws Exception {
-		WikiNode node = WikiTestUtil.addNode(stagingGroup.getGroupId());
-
 		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(stagingGroup.getGroupId());
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup, TestPropsValues.getUserId());
 
-		WikiTestUtil.addPage(
-			TestPropsValues.getUserId(), node.getNodeId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
-			serviceContext);
+		BlogsEntryLocalServiceUtil.addEntry(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), serviceContext);
 	}
 
 	@Override
@@ -70,13 +59,8 @@ public class WikiPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 	}
 
 	@Override
-	protected String[] getDataPortletPreferences() {
-		return new String[] {"hiddenNodes, visibleNodes"};
-	}
-
-	@Override
 	protected String getPortletId() {
-		return WikiPortletKeys.WIKI;
+		return BlogsPortletKeys.BLOGS_ADMIN;
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/data/handler/BlogsAdminPortletDataHandler.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/data/handler/BlogsAdminPortletDataHandler.java
@@ -47,13 +47,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Zsolt Berentey
  */
 @Component(
-	property = {
-		"javax.portlet.name=" + BlogsPortletKeys.BLOGS,
-		"javax.portlet.name=" + BlogsPortletKeys.BLOGS_ADMIN
-	},
+	property = "javax.portlet.name=" + BlogsPortletKeys.BLOGS_ADMIN,
 	service = PortletDataHandler.class
 )
-public class BlogsPortletDataHandler extends BasePortletDataHandler {
+public class BlogsAdminPortletDataHandler extends BasePortletDataHandler {
 
 	public static final String NAMESPACE = "blogs";
 
@@ -97,10 +94,10 @@ public class BlogsPortletDataHandler extends BasePortletDataHandler {
 			return portletPreferences;
 		}
 
-		_blogsEntryLocalService.deleteEntries(
+		blogsEntryLocalService.deleteEntries(
 			portletDataContext.getScopeGroupId());
 
-		_blogsStatsUserLocalService.deleteStatsUserByGroupId(
+		blogsStatsUserLocalService.deleteStatsUserByGroupId(
 			portletDataContext.getScopeGroupId());
 
 		return portletPreferences;
@@ -124,7 +121,7 @@ public class BlogsPortletDataHandler extends BasePortletDataHandler {
 			"group-id", String.valueOf(portletDataContext.getScopeGroupId()));
 
 		ActionableDynamicQuery actionableDynamicQuery =
-			_blogsEntryLocalService.getExportActionableDynamicQuery(
+			blogsEntryLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		actionableDynamicQuery.performActions();
@@ -167,7 +164,7 @@ public class BlogsPortletDataHandler extends BasePortletDataHandler {
 		if (ExportImportDateUtil.isRangeFromLastPublishDate(
 				portletDataContext)) {
 
-			_staging.populateLastPublishDateCounts(
+			staging.populateLastPublishDateCounts(
 				portletDataContext,
 				new StagedModelType[] {
 					new StagedModelType(BlogsEntry.class.getName())
@@ -177,7 +174,7 @@ public class BlogsPortletDataHandler extends BasePortletDataHandler {
 		}
 
 		ActionableDynamicQuery actionableDynamicQuery =
-			_blogsEntryLocalService.getExportActionableDynamicQuery(
+			blogsEntryLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		actionableDynamicQuery.performCount();
@@ -187,20 +184,20 @@ public class BlogsPortletDataHandler extends BasePortletDataHandler {
 	protected void setBlogsEntryLocalService(
 		BlogsEntryLocalService blogsEntryLocalService) {
 
-		_blogsEntryLocalService = blogsEntryLocalService;
+		this.blogsEntryLocalService = blogsEntryLocalService;
 	}
 
 	@Reference(unbind = "-")
 	protected void setBlogsStatsUserLocalService(
 		BlogsStatsUserLocalService blogsStatsUserLocalService) {
 
-		_blogsStatsUserLocalService = blogsStatsUserLocalService;
+		this.blogsStatsUserLocalService = blogsStatsUserLocalService;
 	}
 
-	private BlogsEntryLocalService _blogsEntryLocalService;
-	private BlogsStatsUserLocalService _blogsStatsUserLocalService;
+	protected BlogsEntryLocalService blogsEntryLocalService;
+	protected BlogsStatsUserLocalService blogsStatsUserLocalService;
 
 	@Reference
-	private Staging _staging;
+	protected Staging staging;
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/data/handler/BlogsPortletDataHandler.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/data/handler/BlogsPortletDataHandler.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.web.internal.exportimport.data.handler;
+
+import com.liferay.blogs.constants.BlogsPortletKeys;
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author arthurchan35
+ */
+@Component(
+	property = "javax.portlet.name=" + BlogsPortletKeys.BLOGS,
+	service = PortletDataHandler.class
+)
+public class BlogsPortletDataHandler extends BlogsAdminPortletDataHandler {
+
+	@Activate
+	protected void activate() {
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
+		super.activate();
+	}
+
+}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/data/handler/BlogsPortletDataHandler.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/data/handler/BlogsPortletDataHandler.java
@@ -30,6 +30,11 @@ import org.osgi.service.component.annotations.Component;
 )
 public class BlogsPortletDataHandler extends BlogsAdminPortletDataHandler {
 
+	@Override
+	public boolean isDisplayPortlet() {
+		return false;
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);

--- a/modules/apps/bookmarks/bookmarks-service/bnd.bnd
+++ b/modules/apps/bookmarks/bookmarks-service/bnd.bnd
@@ -3,3 +3,4 @@ Bundle-SymbolicName: com.liferay.bookmarks.service
 Bundle-Version: 3.0.0
 Liferay-Require-SchemaVersion: 2.0.0
 Liferay-Service: true
+-dsannotations-options: inherit

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksAdminPortletDataHandler.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksAdminPortletDataHandler.java
@@ -51,13 +51,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
-	property = {
-		"javax.portlet.name=" + BookmarksPortletKeys.BOOKMARKS,
-		"javax.portlet.name=" + BookmarksPortletKeys.BOOKMARKS_ADMIN
-	},
+	property = "javax.portlet.name=" + BookmarksPortletKeys.BOOKMARKS_ADMIN,
 	service = PortletDataHandler.class
 )
-public class BookmarksPortletDataHandler extends BasePortletDataHandler {
+public class BookmarksAdminPortletDataHandler extends BasePortletDataHandler {
 
 	public static final String NAMESPACE = "bookmarks";
 
@@ -75,7 +72,7 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	public boolean validateSchemaVersion(String schemaVersion) {
-		return _portletDataHandlerHelper.validateSchemaVersion(
+		return portletDataHandlerHelper.validateSchemaVersion(
 			schemaVersion, getSchemaVersion());
 	}
 
@@ -107,9 +104,9 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 			return portletPreferences;
 		}
 
-		_bookmarksEntryStagedModelRepository.deleteStagedModels(
+		bookmarksEntryStagedModelRepository.deleteStagedModels(
 			portletDataContext);
-		_bookmarksFolderStagedModelRepository.deleteStagedModels(
+		bookmarksFolderStagedModelRepository.deleteStagedModels(
 			portletDataContext);
 
 		return portletPreferences;
@@ -131,7 +128,7 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 
 		if (portletDataContext.getBooleanParameter(NAMESPACE, "folders")) {
 			ExportActionableDynamicQuery folderActionableDynamicQuery =
-				_bookmarksFolderStagedModelRepository.
+				bookmarksFolderStagedModelRepository.
 					getExportActionableDynamicQuery(portletDataContext);
 
 			folderActionableDynamicQuery.performActions();
@@ -139,7 +136,7 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 
 		if (portletDataContext.getBooleanParameter(NAMESPACE, "entries")) {
 			ActionableDynamicQuery entryActionableDynamicQuery =
-				_bookmarksEntryStagedModelRepository.
+				bookmarksEntryStagedModelRepository.
 					getExportActionableDynamicQuery(portletDataContext);
 
 			entryActionableDynamicQuery.performActions();
@@ -195,7 +192,7 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 		if (ExportImportDateUtil.isRangeFromLastPublishDate(
 				portletDataContext)) {
 
-			_staging.populateLastPublishDateCounts(
+			staging.populateLastPublishDateCounts(
 				portletDataContext,
 				new StagedModelType[] {
 					new StagedModelType(BookmarksEntry.class.getName()),
@@ -206,13 +203,13 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 		}
 
 		ActionableDynamicQuery entryExportActionableDynamicQuery =
-			_bookmarksEntryStagedModelRepository.
-				getExportActionableDynamicQuery(portletDataContext);
+			bookmarksEntryStagedModelRepository.getExportActionableDynamicQuery(
+				portletDataContext);
 
 		entryExportActionableDynamicQuery.performCount();
 
 		ActionableDynamicQuery folderExportActionableDynamicQuery =
-			_bookmarksFolderStagedModelRepository.
+			bookmarksFolderStagedModelRepository.
 				getExportActionableDynamicQuery(portletDataContext);
 
 		folderExportActionableDynamicQuery.performCount();
@@ -226,19 +223,19 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 	@Reference(
 		target = "(model.class.name=com.liferay.bookmarks.model.BookmarksEntry)"
 	)
-	private StagedModelRepository<BookmarksEntry>
-		_bookmarksEntryStagedModelRepository;
+	protected StagedModelRepository<BookmarksEntry>
+		bookmarksEntryStagedModelRepository;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.bookmarks.model.BookmarksFolder)"
 	)
-	private StagedModelRepository<BookmarksFolder>
-		_bookmarksFolderStagedModelRepository;
+	protected StagedModelRepository<BookmarksFolder>
+		bookmarksFolderStagedModelRepository;
 
 	@Reference
-	private PortletDataHandlerHelper _portletDataHandlerHelper;
+	protected PortletDataHandlerHelper portletDataHandlerHelper;
 
 	@Reference
-	private Staging _staging;
+	protected Staging staging;
 
 }

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksPortletDataHandler.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksPortletDataHandler.java
@@ -32,6 +32,11 @@ import org.osgi.service.component.annotations.Component;
 public class BookmarksPortletDataHandler
 	extends BookmarksAdminPortletDataHandler {
 
+	@Override
+	public boolean isDisplayPortlet() {
+		return false;
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksPortletDataHandler.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksPortletDataHandler.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.bookmarks.internal.exportimport.data.handler;
+
+import com.liferay.bookmarks.constants.BookmarksPortletKeys;
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author arthurchan35
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + BookmarksPortletKeys.BOOKMARKS,
+	service = PortletDataHandler.class
+)
+public class BookmarksPortletDataHandler
+	extends BookmarksAdminPortletDataHandler {
+
+	@Activate
+	protected void activate() {
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
+		super.activate();
+	}
+
+}

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/internal/exportimport/data/handler/test/BookmarksAdminPortletDataHandlerTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/internal/exportimport/data/handler/test/BookmarksAdminPortletDataHandlerTest.java
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  */
 @RunWith(Arquillian.class)
-public class BookmarksPortletDataHandlerTest
+public class BookmarksAdminPortletDataHandlerTest
 	extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
@@ -111,7 +111,7 @@ public class BookmarksPortletDataHandlerTest
 
 	@Override
 	protected String getPortletId() {
-		return BookmarksPortletKeys.BOOKMARKS;
+		return BookmarksPortletKeys.BOOKMARKS_ADMIN;
 	}
 
 	@Override

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/internal/exportimport/test/BookmarksExportImportTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/internal/exportimport/test/BookmarksExportImportTest.java
@@ -56,7 +56,7 @@ public class BookmarksExportImportTest extends BasePortletExportImportTestCase {
 
 	@Override
 	public String getPortletId() {
-		return BookmarksPortletKeys.BOOKMARKS;
+		return BookmarksPortletKeys.BOOKMARKS_ADMIN;
 	}
 
 	@Before

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLAdminPortletDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLAdminPortletDataHandlerTest.java
@@ -90,7 +90,8 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  */
 @RunWith(Arquillian.class)
-public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
+public class DLAdminPortletDataHandlerTest
+	extends BasePortletDataHandlerTestCase {
 
 	public static final String NAMESPACE = "document_library";
 
@@ -213,7 +214,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 		initContext();
 
 		portletDataHandler.exportData(
-			portletDataContext, DLPortletKeys.DOCUMENT_LIBRARY, null);
+			portletDataContext, DLPortletKeys.DOCUMENT_LIBRARY_ADMIN, null);
 
 		Assert.assertTrue(atomicInteger.get() >= 1);
 	}
@@ -413,7 +414,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 
 	@Override
 	protected String getPortletId() {
-		return DLPortletKeys.DOCUMENT_LIBRARY;
+		return DLPortletKeys.DOCUMENT_LIBRARY_ADMIN;
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLPortletDataHandler.java
@@ -32,6 +32,11 @@ import org.osgi.service.component.annotations.Component;
 )
 public class DLPortletDataHandler extends DLAdminPortletDataHandler {
 
+	@Override
+	public boolean isDisplayPortlet() {
+		return false;
+	}
+
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLPortletDataHandler.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.lar;
+
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author arthurchan35
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + DLPortletKeys.DOCUMENT_LIBRARY,
+	service = PortletDataHandler.class
+)
+public class DLPortletDataHandler extends DLAdminPortletDataHandler {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
+		super.activate(bundleContext);
+	}
+
+}

--- a/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/ChangesetPortlet.java
+++ b/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/ChangesetPortlet.java
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Component;
 	immediate = true,
 	property = {
 		"com.liferay.portlet.display-category=category.hidden",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.scopeable=false",
 		"javax.portlet.name=" + ChangesetPortletKeys.CHANGESET,
 		"javax.portlet.resource-bundle=content.Language",

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/lar/test/MBAdminPortletDataHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/lar/test/MBAdminPortletDataHandlerTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.message.boards.compat.lar.test;
+package com.liferay.message.boards.lar.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.lar.DataLevel;
@@ -20,15 +20,14 @@ import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.constants.MBPortletKeys;
-import com.liferay.message.boards.kernel.model.MBCategory;
-import com.liferay.message.boards.kernel.model.MBMessage;
-import com.liferay.message.boards.kernel.service.MBBanLocalServiceUtil;
-import com.liferay.message.boards.kernel.service.MBCategoryLocalServiceUtil;
-import com.liferay.message.boards.kernel.service.MBCategoryServiceUtil;
-import com.liferay.message.boards.kernel.service.MBMessageLocalServiceUtil;
-import com.liferay.message.boards.kernel.service.MBThreadFlagLocalServiceUtil;
-import com.liferay.message.boards.kernel.service.MBThreadLocalServiceUtil;
+import com.liferay.message.boards.model.MBCategory;
+import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
+import com.liferay.message.boards.service.MBBanLocalServiceUtil;
+import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
+import com.liferay.message.boards.service.MBCategoryServiceUtil;
+import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
+import com.liferay.message.boards.service.MBThreadFlagLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
@@ -61,7 +60,8 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  */
 @RunWith(Arquillian.class)
-public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
+public class MBAdminPortletDataHandlerTest
+	extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
 	@Rule
@@ -137,9 +137,7 @@ public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 			serviceContext);
 
 		MBThreadFlagLocalServiceUtil.addThreadFlag(
-			TestPropsValues.getUserId(),
-			MBThreadLocalServiceUtil.getThread(message.getThreadId()),
-			serviceContext);
+			TestPropsValues.getUserId(), message.getThread(), serviceContext);
 
 		User user = UserTestUtil.addUser(TestPropsValues.getGroupId());
 
@@ -179,7 +177,7 @@ public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 
 	@Override
 	protected String getPortletId() {
-		return MBPortletKeys.MESSAGE_BOARDS;
+		return MBPortletKeys.MESSAGE_BOARDS_ADMIN;
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/lar/test/MBExportImportTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/lar/test/MBExportImportTest.java
@@ -62,7 +62,7 @@ public class MBExportImportTest extends BasePortletExportImportTestCase {
 
 	@Override
 	public String getPortletId() {
-		return MBPortletKeys.MESSAGE_BOARDS;
+		return MBPortletKeys.MESSAGE_BOARDS_ADMIN;
 	}
 
 	@Before

--- a/modules/apps/message-boards/message-boards-web/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-web/bnd.bnd
@@ -6,3 +6,4 @@ Import-Package:\
 	\
 	*
 Web-ContextPath: /message-boards-web
+-dsannotations-options: inherit

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/data/handler/MBAdminPortletDataHandler.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/data/handler/MBAdminPortletDataHandler.java
@@ -64,13 +64,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Daniel Kocsis
  */
 @Component(
-	property = {
-		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
-		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN
-	},
+	property = "javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN,
 	service = PortletDataHandler.class
 )
-public class MBPortletDataHandler extends BasePortletDataHandler {
+public class MBAdminPortletDataHandler extends BasePortletDataHandler {
 
 	public static final String NAMESPACE = "message_boards";
 
@@ -125,16 +122,16 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 			return portletPreferences;
 		}
 
-		_mbBanLocalService.deleteBansByGroupId(
+		mbBanLocalService.deleteBansByGroupId(
 			portletDataContext.getScopeGroupId());
 
-		_mbCategoryLocalService.deleteCategories(
+		mbCategoryLocalService.deleteCategories(
 			portletDataContext.getScopeGroupId());
 
-		_mbStatsUserLocalService.deleteStatsUsersByGroupId(
+		mbStatsUserLocalService.deleteStatsUsersByGroupId(
 			portletDataContext.getScopeGroupId());
 
-		_mbThreadLocalService.deleteThreads(
+		mbThreadLocalService.deleteThreads(
 			portletDataContext.getScopeGroupId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
 
@@ -158,7 +155,7 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 			portletDataContext.getBooleanParameter(NAMESPACE, "messages")) {
 
 			ActionableDynamicQuery categoryActionableDynamicQuery =
-				_mbCategoryLocalService.getExportActionableDynamicQuery(
+				mbCategoryLocalService.getExportActionableDynamicQuery(
 					portletDataContext);
 
 			categoryActionableDynamicQuery.performActions();
@@ -173,7 +170,7 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 
 		if (portletDataContext.getBooleanParameter(NAMESPACE, "thread-flags")) {
 			ActionableDynamicQuery threadFlagActionableDynamicQuery =
-				_mbThreadFlagLocalService.getExportActionableDynamicQuery(
+				mbThreadFlagLocalService.getExportActionableDynamicQuery(
 					portletDataContext);
 
 			threadFlagActionableDynamicQuery.performActions();
@@ -181,7 +178,7 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 
 		if (portletDataContext.getBooleanParameter(NAMESPACE, "user-bans")) {
 			ActionableDynamicQuery banActionableDynamicQuery =
-				_mbBanLocalService.getExportActionableDynamicQuery(
+				mbBanLocalService.getExportActionableDynamicQuery(
 					portletDataContext);
 
 			banActionableDynamicQuery.performActions();
@@ -261,7 +258,7 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 		if (ExportImportDateUtil.isRangeFromLastPublishDate(
 				portletDataContext)) {
 
-			_staging.populateLastPublishDateCounts(
+			staging.populateLastPublishDateCounts(
 				portletDataContext,
 				new StagedModelType[] {
 					new StagedModelType(MBBan.class.getName()),
@@ -275,13 +272,13 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 		}
 
 		ActionableDynamicQuery banActionableDynamicQuery =
-			_mbBanLocalService.getExportActionableDynamicQuery(
+			mbBanLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		banActionableDynamicQuery.performCount();
 
 		ActionableDynamicQuery categoryActionableDynamicQuery =
-			_mbCategoryLocalService.getExportActionableDynamicQuery(
+			mbCategoryLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		categoryActionableDynamicQuery.performCount();
@@ -292,13 +289,13 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 		messageActionableDynamicQuery.performCount();
 
 		ActionableDynamicQuery threadActionableDynamicQuery =
-			_mbThreadLocalService.getExportActionableDynamicQuery(
+			mbThreadLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		threadActionableDynamicQuery.performCount();
 
 		ActionableDynamicQuery threadFlagActionableDynamicQuery =
-			_mbThreadFlagLocalService.getExportActionableDynamicQuery(
+			mbThreadFlagLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		threadFlagActionableDynamicQuery.performCount();
@@ -308,7 +305,7 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 		final PortletDataContext portletDataContext) {
 
 		final ExportActionableDynamicQuery actionableDynamicQuery =
-			_mbMessageLocalService.getExportActionableDynamicQuery(
+			mbMessageLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		actionableDynamicQuery.setAddCriteriaMethod(
@@ -366,52 +363,52 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 
 	@Reference(unbind = "-")
 	protected void setMBBanLocalService(MBBanLocalService mbBanLocalService) {
-		_mbBanLocalService = mbBanLocalService;
+		this.mbBanLocalService = mbBanLocalService;
 	}
 
 	@Reference(unbind = "-")
 	protected void setMBCategoryLocalService(
 		MBCategoryLocalService mbCategoryLocalService) {
 
-		_mbCategoryLocalService = mbCategoryLocalService;
+		this.mbCategoryLocalService = mbCategoryLocalService;
 	}
 
 	@Reference(unbind = "-")
 	protected void setMBMessageLocalService(
 		MBMessageLocalService mbMessageLocalService) {
 
-		_mbMessageLocalService = mbMessageLocalService;
+		this.mbMessageLocalService = mbMessageLocalService;
 	}
 
 	@Reference(unbind = "-")
 	protected void setMBStatsUserLocalService(
 		MBStatsUserLocalService mbStatsUserLocalService) {
 
-		_mbStatsUserLocalService = mbStatsUserLocalService;
+		this.mbStatsUserLocalService = mbStatsUserLocalService;
 	}
 
 	@Reference(unbind = "-")
 	protected void setMBThreadFlagLocalService(
 		MBThreadFlagLocalService mbThreadFlagLocalService) {
 
-		_mbThreadFlagLocalService = mbThreadFlagLocalService;
+		this.mbThreadFlagLocalService = mbThreadFlagLocalService;
 	}
 
 	@Reference(unbind = "-")
 	protected void setMBThreadLocalService(
 		MBThreadLocalService mbThreadLocalService) {
 
-		_mbThreadLocalService = mbThreadLocalService;
+		this.mbThreadLocalService = mbThreadLocalService;
 	}
 
-	private MBBanLocalService _mbBanLocalService;
-	private MBCategoryLocalService _mbCategoryLocalService;
-	private MBMessageLocalService _mbMessageLocalService;
-	private MBStatsUserLocalService _mbStatsUserLocalService;
-	private MBThreadFlagLocalService _mbThreadFlagLocalService;
-	private MBThreadLocalService _mbThreadLocalService;
+	protected MBBanLocalService mbBanLocalService;
+	protected MBCategoryLocalService mbCategoryLocalService;
+	protected MBMessageLocalService mbMessageLocalService;
+	protected MBStatsUserLocalService mbStatsUserLocalService;
+	protected MBThreadFlagLocalService mbThreadFlagLocalService;
+	protected MBThreadLocalService mbThreadLocalService;
 
 	@Reference
-	private Staging _staging;
+	protected Staging staging;
 
 }

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/data/handler/MBPortletDataHandler.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/data/handler/MBPortletDataHandler.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.web.internal.exportimport.data.handler;
+
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.message.boards.constants.MBPortletKeys;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author arthurchan35
+ */
+@Component(
+	property = "javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
+	service = PortletDataHandler.class
+)
+public class MBPortletDataHandler extends MBAdminPortletDataHandler {
+
+	@Activate
+	protected void activate() {
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
+		super.activate();
+	}
+
+}

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/data/handler/MBPortletDataHandler.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/data/handler/MBPortletDataHandler.java
@@ -30,6 +30,11 @@ import org.osgi.service.component.annotations.Component;
 )
 public class MBPortletDataHandler extends MBAdminPortletDataHandler {
 
+	@Override
+	public boolean isDisplayPortlet() {
+		return false;
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingImplTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingImplTest.java
@@ -267,7 +267,8 @@ public class StagingImplTest {
 				portletDataContext, ChangesetPortletKeys.CHANGESET);
 
 			portletData = portletDataContext.getZipEntryAsString(
-				changesetPortletPath + "/0/portlet-data.xml");
+				changesetPortletPath + StringPool.SLASH + _group.getGroupId() +
+					"/portlet-data.xml");
 		}
 
 		Document document = SAXReaderUtil.read(portletData);

--- a/modules/apps/wiki/wiki-service/bnd.bnd
+++ b/modules/apps/wiki/wiki-service/bnd.bnd
@@ -40,4 +40,5 @@ Import-Package:\
 	*
 Liferay-Require-SchemaVersion: 1.1.0
 Liferay-Service: true
+-dsannotations-options: inherit
 -includeresource: @biz.aQute.bndlib-[0-9]*.jar!/aQute/bnd/annotation/metatype/*

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiAdminPortletDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiAdminPortletDataHandler.java
@@ -56,13 +56,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
-	property = {
-		"javax.portlet.name=" + WikiPortletKeys.WIKI,
-		"javax.portlet.name=" + WikiPortletKeys.WIKI_ADMIN
-	},
+	property = "javax.portlet.name=" + WikiPortletKeys.WIKI_ADMIN,
 	service = PortletDataHandler.class
 )
-public class WikiPortletDataHandler extends BasePortletDataHandler {
+public class WikiAdminPortletDataHandler extends BasePortletDataHandler {
 
 	public static final String NAMESPACE = "wiki";
 
@@ -95,7 +92,7 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 		finally {
 			WikiCacheThreadLocal.setClearCache(clearCache);
 
-			_portalCache.removeAll();
+			portalCache.removeAll();
 		}
 	}
 
@@ -118,7 +115,7 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 				WikiPage.class.getName()));
 		setStagingControls(getExportControls());
 
-		_portalCache = _multiVMPool.getPortalCache(
+		portalCache = multiVMPool.getPortalCache(
 			WikiPageDisplay.class.getName());
 	}
 
@@ -134,7 +131,7 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 			return portletPreferences;
 		}
 
-		_wikiNodeLocalService.deleteNodes(portletDataContext.getScopeGroupId());
+		wikiNodeLocalService.deleteNodes(portletDataContext.getScopeGroupId());
 
 		return portletPreferences;
 	}
@@ -157,13 +154,13 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 			"group-id", String.valueOf(portletDataContext.getScopeGroupId()));
 
 		ActionableDynamicQuery nodeActionableDynamicQuery =
-			_wikiNodeLocalService.getExportActionableDynamicQuery(
+			wikiNodeLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		nodeActionableDynamicQuery.performActions();
 
 		ActionableDynamicQuery pageActionableDynamicQuery =
-			_wikiPageLocalService.getExportActionableDynamicQuery(
+			wikiPageLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		pageActionableDynamicQuery.performActions();
@@ -216,7 +213,7 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 		if (ExportImportDateUtil.isRangeFromLastPublishDate(
 				portletDataContext)) {
 
-			_staging.populateLastPublishDateCounts(
+			staging.populateLastPublishDateCounts(
 				portletDataContext,
 				new StagedModelType[] {
 					new StagedModelType(WikiNode.class.getName()),
@@ -227,13 +224,13 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 		}
 
 		ActionableDynamicQuery nodeActionableDynamicQuery =
-			_wikiNodeLocalService.getExportActionableDynamicQuery(
+			wikiNodeLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		nodeActionableDynamicQuery.performCount();
 
 		ActionableDynamicQuery pageExportActionableDynamicQuery =
-			_wikiPageLocalService.getExportActionableDynamicQuery(
+			wikiPageLocalService.getExportActionableDynamicQuery(
 				portletDataContext);
 
 		pageExportActionableDynamicQuery.performCount();
@@ -248,25 +245,25 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 	protected void setWikiNodeLocalService(
 		WikiNodeLocalService wikiNodeLocalService) {
 
-		_wikiNodeLocalService = wikiNodeLocalService;
+		this.wikiNodeLocalService = wikiNodeLocalService;
 	}
 
 	@Reference(unbind = "-")
 	protected void setWikiPageLocalService(
 		WikiPageLocalService wikiPageLocalService) {
 
-		_wikiPageLocalService = wikiPageLocalService;
+		this.wikiPageLocalService = wikiPageLocalService;
 	}
 
 	@Reference
-	private MultiVMPool _multiVMPool;
+	protected MultiVMPool multiVMPool;
 
-	private PortalCache<?, ?> _portalCache;
+	protected PortalCache<?, ?> portalCache;
 
 	@Reference
-	private Staging _staging;
+	protected Staging staging;
 
-	private WikiNodeLocalService _wikiNodeLocalService;
-	private WikiPageLocalService _wikiPageLocalService;
+	protected WikiNodeLocalService wikiNodeLocalService;
+	protected WikiPageLocalService wikiPageLocalService;
 
 }

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPortletDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPortletDataHandler.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wiki.internal.exportimport.data.handler;
+
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.wiki.constants.WikiPortletKeys;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author arthurchan35
+ */
+@Component(
+	immediate = true, property = "javax.portlet.name=" + WikiPortletKeys.WIKI,
+	service = PortletDataHandler.class
+)
+public class WikiPortletDataHandler extends WikiAdminPortletDataHandler {
+
+	@Activate
+	protected void activate() {
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
+		super.activate();
+	}
+
+}

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPortletDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPortletDataHandler.java
@@ -30,6 +30,11 @@ import org.osgi.service.component.annotations.Component;
 )
 public class WikiPortletDataHandler extends WikiAdminPortletDataHandler {
 
+	@Override
+	public boolean isDisplayPortlet() {
+		return false;
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/test/WikiExportImportTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/test/WikiExportImportTest.java
@@ -66,7 +66,7 @@ public class WikiExportImportTest extends BasePortletExportImportTestCase {
 
 	@Override
 	public String getPortletId() {
-		return WikiPortletKeys.WIKI;
+		return WikiPortletKeys.WIKI_ADMIN;
 	}
 
 	@Before

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/web/internal/exportimport/data/handler/test/WikiAdminPortletDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/web/internal/exportimport/data/handler/test/WikiAdminPortletDataHandlerTest.java
@@ -12,20 +12,22 @@
  * details.
  */
 
-package com.liferay.blogs.web.internal.exportimport.data.handler.test;
+package com.liferay.wiki.web.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.blogs.constants.BlogsPortletKeys;
-import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.exportimport.kernel.lar.DataLevel;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.lar.test.BasePortletDataHandlerTestCase;
+import com.liferay.portal.service.test.ServiceTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.wiki.constants.WikiPortletKeys;
+import com.liferay.wiki.model.WikiNode;
+import com.liferay.wiki.util.test.WikiTestUtil;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -34,23 +36,33 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  */
 @RunWith(Arquillian.class)
-public class BlogsPortletDataHandlerTest
+public class WikiAdminPortletDataHandlerTest
 	extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
 	@Rule
-	public static final AggregateTestRule aggregateTestRule =
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		ServiceTestUtil.setUser(TestPropsValues.getUser());
+
+		super.setUp();
+	}
 
 	@Override
 	protected void addStagedModels() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				stagingGroup, TestPropsValues.getUserId());
+		WikiNode node = WikiTestUtil.addNode(stagingGroup.getGroupId());
 
-		BlogsEntryLocalServiceUtil.addEntry(
-			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), serviceContext);
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(stagingGroup.getGroupId());
+
+		WikiTestUtil.addPage(
+			TestPropsValues.getUserId(), node.getNodeId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
+			serviceContext);
 	}
 
 	@Override
@@ -59,8 +71,13 @@ public class BlogsPortletDataHandlerTest
 	}
 
 	@Override
+	protected String[] getDataPortletPreferences() {
+		return new String[] {"hiddenNodes, visibleNodes"};
+	}
+
+	@Override
 	protected String getPortletId() {
-		return BlogsPortletKeys.BLOGS;
+		return WikiPortletKeys.WIKI_ADMIN;
 	}
 
 	@Override

--- a/modules/core/portal-compat/message-boards/portal-message-boards-compat-test/src/testIntegration/java/com/liferay/portal/message/boards/compat/lar/test/MBAdminPortletDataHandlerTest.java
+++ b/modules/core/portal-compat/message-boards/portal-message-boards-compat-test/src/testIntegration/java/com/liferay/portal/message/boards/compat/lar/test/MBAdminPortletDataHandlerTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.message.boards.lar.test;
+package com.liferay.portal.message.boards.compat.lar.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.lar.DataLevel;
@@ -20,14 +20,15 @@ import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.constants.MBPortletKeys;
-import com.liferay.message.boards.model.MBCategory;
-import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.kernel.model.MBCategory;
+import com.liferay.message.boards.kernel.model.MBMessage;
+import com.liferay.message.boards.kernel.service.MBBanLocalServiceUtil;
+import com.liferay.message.boards.kernel.service.MBCategoryLocalServiceUtil;
+import com.liferay.message.boards.kernel.service.MBCategoryServiceUtil;
+import com.liferay.message.boards.kernel.service.MBMessageLocalServiceUtil;
+import com.liferay.message.boards.kernel.service.MBThreadFlagLocalServiceUtil;
+import com.liferay.message.boards.kernel.service.MBThreadLocalServiceUtil;
 import com.liferay.message.boards.model.MBThread;
-import com.liferay.message.boards.service.MBBanLocalServiceUtil;
-import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
-import com.liferay.message.boards.service.MBCategoryServiceUtil;
-import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
-import com.liferay.message.boards.service.MBThreadFlagLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
@@ -60,7 +61,8 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  */
 @RunWith(Arquillian.class)
-public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
+public class MBAdminPortletDataHandlerTest
+	extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
 	@Rule
@@ -136,7 +138,9 @@ public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 			serviceContext);
 
 		MBThreadFlagLocalServiceUtil.addThreadFlag(
-			TestPropsValues.getUserId(), message.getThread(), serviceContext);
+			TestPropsValues.getUserId(),
+			MBThreadLocalServiceUtil.getThread(message.getThreadId()),
+			serviceContext);
 
 		User user = UserTestUtil.addUser(TestPropsValues.getGroupId());
 
@@ -176,7 +180,7 @@ public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 
 	@Override
 	protected String getPortletId() {
-		return MBPortletKeys.MESSAGE_BOARDS;
+		return MBPortletKeys.MESSAGE_BOARDS_ADMIN;
 	}
 
 	@Override


### PR DESCRIPTION
Hi @matethurzo

The PR extends from https://github.com/matethurzo/liferay-portal/pull/2185

Please refer to the fix explanation:

Commit 1 to 2:
The root issue is ChangesetPortlet property definition wrong. Please refer to https://github.com/liferay/liferay-portal/blob/master/definitions/liferay-portlet-app_7_1_0.dtd#L478-L485. For ChangesetPortlet, its preferences-unique-per-layout should false. Otherwise we will use same the data "com_liferay_exportimport_web_portlet_ChangesetPortlet created, with ownerId = 0, ownerType = 3, plid = 0" for different groups.

Commit 3 to 13:
The root issue is we treated the portlet **com_liferay_document_library_web_portlet_DLPortlet** as DataSiteLevelPortlets. However, it shouldn't belong to this level because the portlet can be placed in layout and it is instanceable portlet.

Commit 14(the last commit).
We refer to the link from https://dev.liferay.com/en/discover/portal/-/knowledge_base/7-0/exporting-importing-app-data

> You can export/import app content two ways. You can navigate to the app’s administrative area located in the Menu, or you can visit the indiviual app that resides on a Liferay page. Both export/import menus work the same, but the administrative area may hold different content than its indiviual app counterpart

I think the statement is conflict. For now, DLAdminPortlet and DLPortlet hold same data for export/import. On 7.0, we can export/import data from DLPortlet. This is different from 6.2. For the link statement, we added the last commit to keep the current behavior, even though the method is opposite with the portlet's function. If the expected behavior is DLPortlet should not own export/import data function, please remove the commit.

cc @arthurchan35 

Regards,
Hai
