### PR TITLE
LPS-84243 Re-enable Form Page controls after exiting edit mode

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder/form_builder.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder/form_builder.js
@@ -793,19 +793,37 @@ AUI.add(
 
 						var container = instance.get('container');
 
-						var controlTrigger = container.one('.form-builder-page-header .form-builder-controls-trigger');
+						var controlTriggers = container.all('.form-builder-controls-trigger');
 
-						var controlTriggerButton = controlTrigger.one('.dropdown-toggle');
+						var controlTriggerButtons = controlTriggers.all('.dropdown-toggle');
 
 						if (instance.isEditMode()) {
 							instance._destroySortable(instance.sortable1);
 							container.addClass('edit-mode');
-							controlTrigger.addClass('disabled');
-							controlTriggerButton.addClass('disabled');
+							controlTriggers.each(
+								function(item) {
+									item.addClass('disabled');
+								}
+							);
+							controlTriggerButtons.each(
+								function(item) {
+									item.addClass('disabled');
+								}
+							);
 						}
 						else {
 							instance._applyDragAndDrop();
 							container.removeClass('edit-mode');
+							controlTriggers.each(
+								function(item) {
+									item.removeClass('disabled');
+								}
+							);
+							controlTriggerButtons.each(
+								function(item) {
+									item.removeClass('disabled');
+								}
+							);
 						}
 					},
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84243

The page addition controls should be disabled while editing a translation per https://issues.liferay.com/browse/LPS-79730, however they should be re-enabled after leaving that mode. Also, the control trigger selection did not account that there is actually 3 available controls, 1 for a single page and 2 (initially hidden) for the multiple page header. The 2 for the multiple page header were not selected with  ".form-builder-page-header .form-builder-controls-trigger".

Note: If any changes need to be made, make sure to test both with 1 Form page and multiple Form pages.