### PR TITLE
Diana lin lps 85915 master 1003

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormInstanceRecordHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormInstanceRecordHelper.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.util;
+
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.portal.kernel.service.ServiceContext;
+
+import java.util.Locale;
+
+/**
+ * @author Diana Lin
+ */
+public interface DDMFormInstanceRecordHelper {
+
+	public void updateRequiredFieldsAccordingToVisibility(
+			ServiceContext serviceContext, long formInstanceId, DDMForm ddmForm,
+			DDMFormValues ddmFormValues, Locale locale)
+		throws Exception;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.8.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -29,6 +29,7 @@ import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
 import com.liferay.portal.kernel.captcha.CaptchaTextException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -102,13 +103,12 @@ public class AddFormInstanceRecordMVCActionCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		_addFormInstanceMVCCommandHelper.
-			updateRequiredFieldsAccordingToVisibility(
-				actionRequest, ddmForm, ddmFormValues,
-				themeDisplay.getLocale());
-
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DDMFormInstanceRecord.class.getName(), actionRequest);
+
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			serviceContext, formInstanceId, ddmForm, ddmFormValues,
+			themeDisplay.getLocale());
 
 		serviceContext.setRequest(_portal.getHttpServletRequest(actionRequest));
 
@@ -210,8 +210,7 @@ public class AddFormInstanceRecordMVCActionCommand
 	}
 
 	@Reference
-	private AddFormInstanceRecordMVCCommandHelper
-		_addFormInstanceMVCCommandHelper;
+	private DDMFormInstanceRecordHelper _ddmFormInstanceRecordHelper;
 
 	private DDMFormInstanceRecordService _ddmFormInstanceRecordService;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
@@ -14,34 +14,15 @@
 
 package com.liferay.dynamic.data.mapping.form.web.internal.portlet.action;
 
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluator;
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorEvaluateRequest;
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorEvaluateResponse;
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorFieldContextKey;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
-import com.liferay.dynamic.data.mapping.model.DDMFormField;
-import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayoutColumn;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayoutPage;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayoutRow;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.portlet.ActionRequest;
 
@@ -61,176 +42,17 @@ public class AddFormInstanceRecordMVCCommandHelper {
 			DDMFormValues ddmFormValues, Locale locale)
 		throws Exception {
 
-		List<DDMFormField> requiredFields = getRequiredFields(ddmForm);
-
-		if (requiredFields.isEmpty()) {
-			return;
-		}
-
-		DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse =
-			evaluate(actionRequest, ddmForm, ddmFormValues, locale);
-
-		Set<String> invisibleFields = getInvisibleFields(
-			ddmFormEvaluatorEvaluateResponse);
-
-		DDMFormLayout ddmFormLayout = getDDMFormLayout(actionRequest);
-
-		Set<String> fieldsFromDisabledPages = getFieldNamesFromDisabledPages(
-			ddmFormEvaluatorEvaluateResponse, ddmFormLayout);
-
-		invisibleFields.addAll(fieldsFromDisabledPages);
-
-		if (invisibleFields.isEmpty()) {
-			return;
-		}
-
-		removeRequiredProperty(invisibleFields, requiredFields);
-	}
-
-	protected DDMFormEvaluatorEvaluateResponse evaluate(
-			ActionRequest actionRequest, DDMForm ddmForm,
-			DDMFormValues ddmFormValues, Locale locale)
-		throws Exception {
-
-		DDMFormEvaluatorEvaluateRequest.Builder builder =
-			DDMFormEvaluatorEvaluateRequest.Builder.newBuilder(
-				ddmForm, ddmFormValues, locale);
-
-		builder.withCompanyId(
-			_portal.getCompanyId(actionRequest)
-		).withGroupId(
-			ParamUtil.getLong(actionRequest, "groupId")
-		).withUserId(
-			_portal.getUserId(actionRequest)
-		);
-
-		return _ddmFormEvaluator.evaluate(builder.build());
-	}
-
-	protected DDMFormLayout getDDMFormLayout(ActionRequest actionRequest)
-		throws PortalException {
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			DDMFormInstanceRecord.class.getName(), actionRequest);
 
 		long formInstanceId = ParamUtil.getLong(
 			actionRequest, "formInstanceId");
 
-		DDMFormInstance formInstance = _ddmFormInstanceService.getFormInstance(
-			formInstanceId);
-
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
-			formInstance.getStructureId());
-
-		return ddmStructure.getDDMFormLayout();
-	}
-
-	protected Set<String> getFieldNamesFromDisabledPages(
-		DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse,
-		DDMFormLayout ddmFormLayout) {
-
-		Set<Integer> disabledPagesIndexes =
-			ddmFormEvaluatorEvaluateResponse.getDisabledPagesIndexes();
-
-		Stream<Integer> disablePagesIndexesStream =
-			disabledPagesIndexes.stream();
-
-		Stream<String> fieldsStream = disablePagesIndexesStream.map(
-			index -> getFieldNamesFromPage(index, ddmFormLayout)
-		).flatMap(
-			field -> field.stream()
-		);
-
-		return fieldsStream.collect(Collectors.toSet());
-	}
-
-	protected Set<String> getFieldNamesFromPage(
-		int index, DDMFormLayout ddmFormLayout) {
-
-		DDMFormLayoutPage ddmFormLayoutPage =
-			ddmFormLayout.getDDMFormLayoutPage(index);
-
-		List<DDMFormLayoutRow> ddmFormLayoutRows =
-			ddmFormLayoutPage.getDDMFormLayoutRows();
-
-		Set<String> fieldNames = new HashSet<>();
-
-		for (DDMFormLayoutRow ddmFormLayoutRow : ddmFormLayoutRows) {
-			for (DDMFormLayoutColumn ddmFormLayoutColumn :
-					ddmFormLayoutRow.getDDMFormLayoutColumns()) {
-
-				fieldNames.addAll(ddmFormLayoutColumn.getDDMFormFieldNames());
-			}
-		}
-
-		return fieldNames;
-	}
-
-	protected Set<String> getInvisibleFields(
-		DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse) {
-
-		Map<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
-			ddmFormFieldsPropertyChanges =
-				ddmFormEvaluatorEvaluateResponse.
-					getDDMFormFieldsPropertyChanges();
-
-		Set<Map.Entry<DDMFormEvaluatorFieldContextKey, Map<String, Object>>>
-			entrySet = ddmFormFieldsPropertyChanges.entrySet();
-
-		Stream<Map.Entry<DDMFormEvaluatorFieldContextKey, Map<String, Object>>>
-			stream = entrySet.stream();
-
-		return stream.filter(
-			result -> {
-				return !MapUtil.getBoolean(result.getValue(), "visible", true);
-			}
-		).map(
-			result -> {
-				DDMFormEvaluatorFieldContextKey ddmFormFieldContextKey =
-					result.getKey();
-
-				return ddmFormFieldContextKey.getName();
-			}
-		).collect(
-			Collectors.toSet()
-		);
-	}
-
-	protected List<DDMFormField> getRequiredFields(DDMForm ddmForm) {
-		Map<String, DDMFormField> ddmFormFieldsMap =
-			ddmForm.getDDMFormFieldsMap(true);
-
-		Collection<DDMFormField> ddmFormFields = ddmFormFieldsMap.values();
-
-		Stream<DDMFormField> stream = ddmFormFields.stream();
-
-		stream = stream.filter(ddmFormField -> ddmFormField.isRequired());
-
-		return stream.collect(Collectors.toList());
-	}
-
-	protected void removeRequiredProperty(DDMFormField ddmFormField) {
-		ddmFormField.setRequired(false);
-	}
-
-	protected void removeRequiredProperty(
-		Set<String> invisibleFields, List<DDMFormField> requiredFields) {
-
-		Stream<DDMFormField> stream = requiredFields.stream();
-
-		stream = stream.filter(
-			field -> invisibleFields.contains(field.getName()));
-
-		stream.forEach(this::removeRequiredProperty);
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			serviceContext, formInstanceId, ddmForm, ddmFormValues, locale);
 	}
 
 	@Reference
-	private DDMFormEvaluator _ddmFormEvaluator;
-
-	@Reference
-	private DDMFormInstanceService _ddmFormInstanceService;
-
-	@Reference
-	private DDMStructureLocalService _ddmStructureLocalService;
-
-	@Reference
-	private Portal _portal;
+	private DDMFormInstanceRecordHelper _ddmFormInstanceRecordHelper;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/data/handler/DDMFormInstanceRecordStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/data/handler/DDMFormInstanceRecordStagedModelDataHandler.java
@@ -29,6 +29,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
@@ -37,6 +38,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -134,6 +136,13 @@ public class DDMFormInstanceRecordStagedModelDataHandler
 
 		DDMFormValues ddmFormValues = getImportDDMFormValues(
 			portletDataContext, recordElement, ddmFormInstanceId);
+
+		ServiceContext serviceContext = portletDataContext.createServiceContext(
+			record);
+
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			serviceContext, ddmFormInstanceId, ddmFormValues.getDDMForm(),
+			ddmFormValues, serviceContext.getLocale());
 
 		DDMFormInstanceRecord importedRecord =
 			(DDMFormInstanceRecord)record.clone();
@@ -264,6 +273,9 @@ public class DDMFormInstanceRecordStagedModelDataHandler
 
 	@Reference(service = DDMFormInstanceLocalService.class)
 	private DDMFormInstanceLocalService _ddmFormInstanceLocalService;
+
+	@Reference(service = DDMFormInstanceRecordHelper.class)
+	private DDMFormInstanceRecordHelper _ddmFormInstanceRecordHelper;
 
 	@Reference(
 		service = DDMFormInstanceRecordStagedModelRepository.class,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormInstanceRecordHelperImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormInstanceRecordHelperImpl.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.util;
+
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluator;
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorEvaluateRequest;
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorEvaluateResponse;
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorFieldContextKey;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutColumn;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutPage;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutRow;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Leonardo Barros
+ */
+@Component(immediate = true, service = DDMFormInstanceRecordHelper.class)
+public class DDMFormInstanceRecordHelperImpl
+	implements DDMFormInstanceRecordHelper {
+
+	@Override
+	public void updateRequiredFieldsAccordingToVisibility(
+			ServiceContext serviceContext, long formInstanceId, DDMForm ddmForm,
+			DDMFormValues ddmFormValues, Locale locale)
+		throws Exception {
+
+		List<DDMFormField> requiredFields = getRequiredFields(ddmForm);
+
+		if (requiredFields.isEmpty()) {
+			return;
+		}
+
+		DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse =
+			evaluate(serviceContext, ddmForm, ddmFormValues, locale);
+
+		Set<String> invisibleFields = getInvisibleFields(
+			ddmFormEvaluatorEvaluateResponse);
+
+		DDMFormLayout ddmFormLayout = getDDMFormLayout(formInstanceId);
+
+		Set<String> fieldsFromDisabledPages = getFieldNamesFromDisabledPages(
+			ddmFormEvaluatorEvaluateResponse, ddmFormLayout);
+
+		invisibleFields.addAll(fieldsFromDisabledPages);
+
+		if (invisibleFields.isEmpty()) {
+			return;
+		}
+
+		removeRequiredProperty(invisibleFields, requiredFields);
+	}
+
+	protected DDMFormEvaluatorEvaluateResponse evaluate(
+			ServiceContext serviceContext, DDMForm ddmForm,
+			DDMFormValues ddmFormValues, Locale locale)
+		throws Exception {
+
+		DDMFormEvaluatorEvaluateRequest.Builder builder =
+			DDMFormEvaluatorEvaluateRequest.Builder.newBuilder(
+				ddmForm, ddmFormValues, locale);
+
+		builder.withCompanyId(
+			serviceContext.getCompanyId()
+		).withGroupId(
+			serviceContext.getScopeGroupId()
+		).withUserId(
+			serviceContext.getUserId()
+		);
+
+		return _ddmFormEvaluator.evaluate(builder.build());
+	}
+
+	protected DDMFormLayout getDDMFormLayout(long formInstanceId)
+		throws PortalException {
+
+		DDMFormInstance formInstance = _ddmFormInstanceService.getFormInstance(
+			formInstanceId);
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+			formInstance.getStructureId());
+
+		return ddmStructure.getDDMFormLayout();
+	}
+
+	protected Set<String> getFieldNamesFromDisabledPages(
+		DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse,
+		DDMFormLayout ddmFormLayout) {
+
+		Set<Integer> disabledPagesIndexes =
+			ddmFormEvaluatorEvaluateResponse.getDisabledPagesIndexes();
+
+		Stream<Integer> disablePagesIndexesStream =
+			disabledPagesIndexes.stream();
+
+		Stream<String> fieldsStream = disablePagesIndexesStream.map(
+			index -> getFieldNamesFromPage(index, ddmFormLayout)
+		).flatMap(
+			field -> field.stream()
+		);
+
+		return fieldsStream.collect(Collectors.toSet());
+	}
+
+	protected Set<String> getFieldNamesFromPage(
+		int index, DDMFormLayout ddmFormLayout) {
+
+		DDMFormLayoutPage ddmFormLayoutPage =
+			ddmFormLayout.getDDMFormLayoutPage(index);
+
+		List<DDMFormLayoutRow> ddmFormLayoutRows =
+			ddmFormLayoutPage.getDDMFormLayoutRows();
+
+		Set<String> fieldNames = new HashSet<>();
+
+		for (DDMFormLayoutRow ddmFormLayoutRow : ddmFormLayoutRows) {
+			for (DDMFormLayoutColumn ddmFormLayoutColumn :
+					ddmFormLayoutRow.getDDMFormLayoutColumns()) {
+
+				fieldNames.addAll(ddmFormLayoutColumn.getDDMFormFieldNames());
+			}
+		}
+
+		return fieldNames;
+	}
+
+	protected Set<String> getInvisibleFields(
+		DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse) {
+
+		Map<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
+			ddmFormFieldsPropertyChanges =
+				ddmFormEvaluatorEvaluateResponse.
+					getDDMFormFieldsPropertyChanges();
+
+		Set<Map.Entry<DDMFormEvaluatorFieldContextKey, Map<String, Object>>>
+			entrySet = ddmFormFieldsPropertyChanges.entrySet();
+
+		Stream<Map.Entry<DDMFormEvaluatorFieldContextKey, Map<String, Object>>>
+			stream = entrySet.stream();
+
+		return stream.filter(
+			result -> {
+				return !MapUtil.getBoolean(result.getValue(), "visible", true);
+			}
+		).map(
+			result -> {
+				DDMFormEvaluatorFieldContextKey ddmFormFieldContextKey =
+					result.getKey();
+
+				return ddmFormFieldContextKey.getName();
+			}
+		).collect(
+			Collectors.toSet()
+		);
+	}
+
+	protected List<DDMFormField> getRequiredFields(DDMForm ddmForm) {
+		Map<String, DDMFormField> ddmFormFieldsMap =
+			ddmForm.getDDMFormFieldsMap(true);
+
+		Collection<DDMFormField> ddmFormFields = ddmFormFieldsMap.values();
+
+		Stream<DDMFormField> stream = ddmFormFields.stream();
+
+		stream = stream.filter(ddmFormField -> ddmFormField.isRequired());
+
+		return stream.collect(Collectors.toList());
+	}
+
+	protected void removeRequiredProperty(DDMFormField ddmFormField) {
+		ddmFormField.setRequired(false);
+	}
+
+	protected void removeRequiredProperty(
+		Set<String> invisibleFields, List<DDMFormField> requiredFields) {
+
+		Stream<DDMFormField> stream = requiredFields.stream();
+
+		stream = stream.filter(
+			field -> invisibleFields.contains(field.getName()));
+
+		stream.forEach(this::removeRequiredProperty);
+	}
+
+	@Reference
+	private DDMFormEvaluator _ddmFormEvaluator;
+
+	@Reference
+	private DDMFormInstanceService _ddmFormInstanceService;
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormInstanceRecordHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormInstanceRecordHelperTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.dynamic.data.mapping.form.web.internal.portlet.action;
+package com.liferay.dynamic.data.mapping.internal.util;
 
 import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluator;
 import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorEvaluateRequest;
@@ -29,9 +29,11 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -42,10 +44,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-
-import javax.portlet.ActionRequest;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,7 +63,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @PrepareForTest(ResourceBundleUtil.class)
 @RunWith(PowerMockRunner.class)
-public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
+public class DDMFormInstanceRecordHelperTest extends PowerMockito {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
@@ -89,8 +87,9 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 
 		_ddmFormField.setRequired(false);
 
-		_addRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(
-			_actionRequest, _ddmForm, _ddmFormValues, LocaleUtil.US);
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			_serviceContext, _ddmFormInstanceId, _ddmForm, _ddmFormValues,
+			LocaleUtil.US);
 
 		Assert.assertFalse(_ddmFormField.isRequired());
 	}
@@ -105,8 +104,9 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 
 		_ddmFormField.setRequired(false);
 
-		_addRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(
-			_actionRequest, _ddmForm, _ddmFormValues, LocaleUtil.US);
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			_serviceContext, _ddmFormInstanceId, _ddmForm, _ddmFormValues,
+			LocaleUtil.US);
 
 		Assert.assertFalse(_ddmFormField.isRequired());
 	}
@@ -121,8 +121,9 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 
 		mockGetDDMFormLayout();
 
-		_addRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(
-			_actionRequest, _ddmForm, _ddmFormValues, LocaleUtil.US);
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			_serviceContext, _ddmFormInstanceId, _ddmForm, _ddmFormValues,
+			LocaleUtil.US);
 
 		Assert.assertFalse(_ddmFormField.isRequired());
 	}
@@ -137,8 +138,9 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 
 		mockGetDDMFormLayout();
 
-		_addRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(
-			_actionRequest, _ddmForm, _ddmFormValues, LocaleUtil.US);
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			_serviceContext, _ddmFormInstanceId, _ddmForm, _ddmFormValues,
+			LocaleUtil.US);
 
 		Assert.assertTrue(_ddmFormField.isRequired());
 	}
@@ -211,39 +213,30 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 	}
 
 	protected void setUpAddRecordMVCCommandHelper() throws Exception {
-		_addRecordMVCCommandHelper =
-			new AddFormInstanceRecordMVCCommandHelper();
+		_ddmFormInstanceRecordHelper = new DDMFormInstanceRecordHelperImpl();
 
 		field(
-			AddFormInstanceRecordMVCCommandHelper.class,
-			"_ddmFormInstanceService"
+			DDMFormInstanceRecordHelperImpl.class, "_ddmFormInstanceService"
 		).set(
-			_addRecordMVCCommandHelper, _ddmFormInstanceService
+			_ddmFormInstanceRecordHelper, _ddmFormInstanceService
 		);
 
 		field(
-			AddFormInstanceRecordMVCCommandHelper.class, "_ddmFormEvaluator"
+			DDMFormInstanceRecordHelperImpl.class, "_ddmFormEvaluator"
 		).set(
-			_addRecordMVCCommandHelper, _ddmFormEvaluator
+			_ddmFormInstanceRecordHelper, _ddmFormEvaluator
 		);
 
 		field(
-			AddFormInstanceRecordMVCCommandHelper.class,
-			"_ddmStructureLocalService"
+			DDMFormInstanceRecordHelperImpl.class, "_ddmStructureLocalService"
 		).set(
-			_addRecordMVCCommandHelper, _ddmStructureLocalService
+			_ddmFormInstanceRecordHelper, _ddmStructureLocalService
 		);
 
 		field(
-			AddFormInstanceRecordMVCCommandHelper.class, "_portal"
+			DDMFormInstanceRecordHelperImpl.class, "_portal"
 		).set(
-			_addRecordMVCCommandHelper, _portal
-		);
-
-		when(
-			_portal, "getHttpServletRequest", _actionRequest
-		).thenReturn(
-			_request
+			_ddmFormInstanceRecordHelper, _portal
 		);
 	}
 
@@ -267,16 +260,14 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 		);
 	}
 
-	@Mock
-	private ActionRequest _actionRequest;
-
-	private AddFormInstanceRecordMVCCommandHelper _addRecordMVCCommandHelper;
 	private DDMForm _ddmForm;
 
 	@Mock
 	private DDMFormEvaluator _ddmFormEvaluator;
 
 	private DDMFormField _ddmFormField;
+	private long _ddmFormInstanceId;
+	private DDMFormInstanceRecordHelper _ddmFormInstanceRecordHelper;
 
 	@Mock
 	private DDMFormInstanceService _ddmFormInstanceService;
@@ -290,6 +281,6 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 	private Portal _portal;
 
 	@Mock
-	private HttpServletRequest _request;
+	private ServiceContext _serviceContext;
 
 }


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-85915

Went through the tests and they look good.

Notes from @diana-lin 

> Problem:  Required fields which have been skipped from Form Rules remain marked as required when they are imported.  This causes a `RequiredValue` exception to be thrown.
> 
> Context:  On Form submission, required fields which have been skipped have their `required` property updated to `false`.  This same update should be imposed on Form import.
> 
> Solution:  Update Form fields to required/not required on import.  Since the functionality of `AddFormInstanceRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(...)` will be used in both the `dynamic-data-mapping-form-web` and `dynamic-data-mapping-service` modules, we propose creating a service.