### PR TITLE
LPS-86711 - escape special characters in the screenname properly for JS handling when running them through the AUI validator

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/DefaultScreenNameValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/DefaultScreenNameValidator.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.security.auth;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -33,7 +34,7 @@ public class DefaultScreenNameValidator implements ScreenNameValidator {
 	@Override
 	public String getAUIValidatorJS() {
 		return "function(val) {var pattern = new RegExp('[^A-Za-z0-9" +
-			getSpecialChars() +
+			getJSEscapedSpecialChars() +
 				"]');if (val.match(pattern)) {return false;}return true;}";
 	}
 
@@ -57,6 +58,16 @@ public class DefaultScreenNameValidator implements ScreenNameValidator {
 		return true;
 	}
 
+	protected String getJSEscapedSpecialChars() {
+		if (_jsEscapedSpecialChars == null) {
+			_jsEscapedSpecialChars = getSpecialChars();
+
+			_jsEscapedSpecialChars = HtmlUtil.escapeJS(_jsEscapedSpecialChars);
+		}
+
+		return _jsEscapedSpecialChars;
+	}
+
 	protected String getSpecialChars() {
 		if (_specialChars == null) {
 			String specialChars = PropsUtil.get(
@@ -72,6 +83,7 @@ public class DefaultScreenNameValidator implements ScreenNameValidator {
 		return !screenName.matches("[A-Za-z0-9" + getSpecialChars() + "]+");
 	}
 
+	private String _jsEscapedSpecialChars;
 	private String _specialChars;
 
 }


### PR DESCRIPTION
Hi Chris!

https://issues.liferay.com/browse/LPP-31963
https://issues.liferay.com/browse/LPS-86711

This issue involves the property "users.screen.name.special.characters" which allows the portal owner to designate special characters that are allowed in a user's screen name. The default value is below:

`users.screen.name.special.characters=.-_`

However, if an apostrophe/single quotation mark is added to the list, errors occur, breaking the JS of anything sharing the same screen as the screen name field. This is most clearly seen by clicking any buttons that should open a new menu, such as a the change profile picture button. The cause of this is due to the ScreenNameValidator, which uses JS to validate the screenname:

`	@Override
	public String getAUIValidatorJS() {
		return "function(val) {var pattern = new RegExp('[^A-Za-z0-9" +
			getSpecialChars() +
				"]');if (val.match(pattern)) {return false;}return true;}";
	}
`
getSpecialChars() returns a String of the characters that should be excluded, but an apostrophe is read as part of the regex syntax, rather than as a part of the list of items that should be excluded. This breaks the regular expression and therefore the rest of the JS on the screen. To fix this, we escape the special characters for JS so that it is read in a proper format. A new method was created specifically for JS escaped special characters since the getSpecialCharacters() method is used elsewhere to provide information to the user. This can be most easily seen if you enter an invalid name, receiving the error message below:

`The screen name cannot be an email address or a reserved word, such as postfix. It must contain only alphanumeric or the following special characters: -._.`

If we escape the _specialChars string, these items will be escaped for JS and therefore unreadable for the user.

Please let me know if you have any questions or concerns. Thanks! 