### PR TITLE
[TECHNICAL-SUPPORT] LPS-86368

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -631,7 +632,15 @@ public class FileEntryStagedModelDataHandler
 				}
 
 				if (ExportImportThreadLocal.isStagingInProcess()) {
-					_overrideFileVersion(importedFileEntry, version);
+					ServiceContextThreadLocal.pushServiceContext(
+						serviceContext);
+
+					try {
+						_overrideFileVersion(importedFileEntry, version);
+					}
+					finally {
+						ServiceContextThreadLocal.popServiceContext();
+					}
 				}
 			}
 			else {


### PR DESCRIPTION
/cc @moltam89 

Relevant tickets:
https://issues.liferay.com/browse/LPP-31765
https://issues.liferay.com/browse/LPS-86368

Forwarded from: https://github.com/moltam89/liferay-portal/pull/446

If a document is published to live that has had more than one version increment since the last time it was published, then the modified date for the DLFileEntry in the database (in the DLFileEntry table) will be updated with the current timestamp, instead of the date the document was actually modified. This is because, Liferay treats subsequent imported versions with Staging as updates, and while the modifiedDate was technically updated at the time of the document update (so before the export), it did not happen during the "update," so it assumes the modifiedDate still needs to be changed.

As it turns out, simply persisting the serviceContext available earlier in the import process for when it does the update allows it to keep access to the correct modifiedDate, eliminating the need for it to overwrite it with the current date.

I ended up putting this code change entirely outside of the call to _overrideFileVersion()_ because I think it looks cleaner to keep the related logic for it one place. There is also an argument to be made for putting it inside the method though (see https://github.com/moltam89/liferay-portal/pull/446#issuecomment-435974343), so if it is better, please feel free to go with that instead.

Also, if there are any other questions or concerns with this from a DL perspective or otherwise, please let me know. Thank you!