### PR TITLE
LPS-85999 Facebook SSO must respect the portal's stranger policy

### DIFF
--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectLoginErrorMVCRenderCommand.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectLoginErrorMVCRenderCommand.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.login.authentication.facebook.connect.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.exception.UserEmailAddressException;
+import com.liferay.portal.kernel.facebook.FacebookConnect;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + PortletKeys.FAST_LOGIN,
+		"javax.portlet.name=" + PortletKeys.LOGIN,
+		"mvc.command.name=/login/facebook_connect_login_error"
+	},
+	service = MVCRenderCommand.class
+)
+public class FacebookConnectLoginErrorMVCRenderCommand
+	implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (!_facebookConnect.isEnabled(themeDisplay.getCompanyId())) {
+			throw new PortletException(
+				new PrincipalException.MustBeEnabled(
+					themeDisplay.getCompanyId(),
+					FacebookConnect.class.getName()));
+		}
+
+		String error = ParamUtil.getString(renderRequest, "error");
+
+		if (ArrayUtil.contains(_ERRORS, error)) {
+			SessionErrors.add(renderRequest, error);
+		}
+		else {
+			SessionErrors.add(renderRequest, "unknownError");
+		}
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			renderRequest);
+
+		HttpServletResponse httpServletResponse =
+			_portal.getHttpServletResponse(renderResponse);
+
+		try {
+			RequestDispatcher requestDispatcher =
+				_servletContext.getRequestDispatcher("/error.jsp");
+
+			requestDispatcher.forward(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception e) {
+			throw new PortletException("Unable to include error.jsp", e);
+		}
+
+		return MVCRenderConstants.MVC_PATH_VALUE_SKIP_DISPATCH;
+	}
+
+	private static final String[] _ERRORS = {
+		UserEmailAddressException.MustNotUseCompanyMx.class.getSimpleName(),
+		MustVerifyEmailAddressException.class.getSimpleName(),
+		StrangersNotAllowedException.class.getSimpleName()
+	};
+
+	@Reference
+	private FacebookConnect _facebookConnect;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.login.authentication.facebook.connect.web)"
+	)
+	private ServletContext _servletContext;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/MustVerifyEmailAddressException.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/MustVerifyEmailAddressException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.login.authentication.facebook.connect.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Stian Sigvartsen
+ */
+public class MustVerifyEmailAddressException extends PortalException {
+
+	public MustVerifyEmailAddressException(long companyId) {
+		super(
+			String.format(
+				"Company %s requires strangers to verify their email address",
+				companyId));
+
+		this.companyId = companyId;
+	}
+
+	public final long companyId;
+
+}

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/StrangersNotAllowedException.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/StrangersNotAllowedException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.login.authentication.facebook.connect.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Stian Sigvartsen
+ */
+public class StrangersNotAllowedException extends PortalException {
+
+	public StrangersNotAllowedException(long companyId) {
+		super(String.format("Company %s does not allow strangers", companyId));
+
+		this.companyId = companyId;
+	}
+
+	public final long companyId;
+
+}

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/error.jsp
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/error.jsp
@@ -1,0 +1,32 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<div class="sheet">
+	<h2 class="sheet-title">
+		<liferay-ui:message key="failed-to-sign-in-using-this-facebook-account" />
+	</h2>
+
+	<liferay-ui:error key="MustVerifyEmailAddressException" message="you-need-to-verify-your-email-address-on-facebook-first" />
+	<liferay-ui:error key="StrangersNotAllowedException" message="only-known-users-are-allowed-to-sign-in-using-facebook" />
+	<liferay-ui:error key="MustNotUseCompanyMx" message="this-facebook-account-cannot-be-used-to-register-a-new-user-because-its-email-domain-is-reserved" />
+	<liferay-ui:error key="unknownError" message="there-was-an-unknown-error" />
+
+	<aui:button-row>
+		<aui:button onClick="window.close();" value="close" />
+	</aui:button-row>
+</div>

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,25 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/content/Language.properties
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/content/Language.properties
@@ -1,0 +1,5 @@
+failed-to-sign-in-using-this-facebook-account=Failed to sign in using this Facebook account
+only-known-users-are-allowed-to-sign-in-using-facebook=Only known users are allowed to sign in using Facebook.
+there-was-an-unknown-error=There was an unknown error.
+this-facebook-account-cannot-be-used-to-register-a-new-user-because-its-email-domain-is-reserved=This Facebook account cannot be used to register a new user because its email domain is reserved.
+you-need-to-verify-your-email-address-on-facebook-first=You need to verify your email address on Facebook first.


### PR DESCRIPTION
Hi Brian. Tomas decided on the "error" parameter approach in the last commit here: https://github.com/stian-sigvartsen/liferay-portal/pull/123

I simply rebuilt the commit without its redundant parent commits relating to a different approach I originally suggested.

Tests pass here: https://github.com/stian-sigvartsen/liferay-portal/pull/135

/cc @topolik 