### PR TITLE
LPS-86681 PasswordModifiedFilter check is unnecessary during imperson…

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.security.auth.session.AuthenticatedSessionManag
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 
 import java.util.Date;
@@ -73,6 +74,12 @@ public class PasswordModifiedFilter extends BasePortalFilter {
 			User user = PortalUtil.getUser(request);
 
 			if ((user == null) || user.isDefaultUser()) {
+				return false;
+			}
+
+			Long realUserId = (Long)session.getAttribute(WebKeys.USER_ID);
+
+			if ((realUserId == null) || user.getUserId() != realUserId) {
 				return false;
 			}
 


### PR DESCRIPTION
Hello @topolik ,

Resending from https://github.com/topolik/liferay-portal/pull/692

Impersonation check is done by comparing the request user id with the session user id as the session still maintains the impersonator's user id. We need to check whether session user id is null as well for when there is no impersonator, ex. when a user is simply just logging in.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim