### PR TITLE
obj.statusText not return in tomcat 8 onwards

### DIFF
--- a/portal-web/docroot/html/js/liferay/look_and_feel.js
+++ b/portal-web/docroot/html/js/liferay/look_and_feel.js
@@ -1151,7 +1151,7 @@ AUI.add(
 						var messageClass = EMPTY;
 						var type = SUCCESS;
 
-						if (obj.statusText.toLowerCase() != OK) {
+						if ((obj.statusText.toLowerCase() != OK)  && (obj.status != 200)) {
 							type = ERROR;
 						}
 


### PR DESCRIPTION
tomcat8 and next versiones have not return obj.statusText; classic "200 OK" have not exists... only "200", only status

So, is necessary change all conditions referenced to statusText....