### PR TITLE
[TECHNICAL SUPPORT] LPS-90727 XSS Vulnerability in Control Panel 

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1968,7 +1968,7 @@ public class PortalImpl implements Portal {
 			WebKeys.CURRENT_COMPLETE_URL);
 
 		if (currentCompleteURL == null) {
-			currentCompleteURL = HttpUtil.getCompleteURL(request);
+			currentCompleteURL = HtmlUtil.escapeURL(HttpUtil.getCompleteURL(request));
 
 			request.setAttribute(
 				WebKeys.CURRENT_COMPLETE_URL, currentCompleteURL);
@@ -1999,6 +1999,8 @@ public class PortalImpl implements Portal {
 
 				currentURL = currentURL.substring(
 					currentURL.indexOf(CharPool.SLASH));
+
+				currentURL = HtmlUtil.escapeURL(currentURL);
 			}
 		}
 


### PR DESCRIPTION
XSS vulnerability is caused be javascript appearing before the query string. I escaped the URL string so that it can be safely set as the URL attribute and the pop-up no longer appears. It escapes the string following the domain.

https://issues.liferay.com/browse/LPS-90727