### PR TITLE
LPS-90927 Use the default language from the nameXML and compare that …

### DIFF
--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/LayoutPrototypeHelperUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/LayoutPrototypeHelperUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 
 import java.util.List;
 import java.util.Locale;
@@ -37,10 +38,15 @@ public class LayoutPrototypeHelperUtil {
 			List<LayoutPrototype> layoutPrototypes)
 		throws Exception {
 
-		String name = nameMap.get(LocaleUtil.getDefault());
-
 		for (LayoutPrototype layoutPrototype : layoutPrototypes) {
-			String curName = layoutPrototype.getName(LocaleUtil.getDefault());
+			String nameXML = layoutPrototype.getName();
+
+			Locale defaultLocale = LocaleUtil.fromLanguageId(
+				LocalizationUtil.getDefaultLanguageId(nameXML));
+
+			String name = nameMap.get(defaultLocale);
+
+			String curName = layoutPrototype.getName(defaultLocale);
 
 			if ((name == null) || name.equals(curName)) {
 				return null;


### PR DESCRIPTION
After upgrading from 7.0 fix pack 46 and lower while using Japanese as a default language, a warning will be thrown upon startup while trying to add a duplicate layout prototype. This is due to a translation change in LPS-77699.

This fix uses the default language identified by the XML so the name can be compared without translation issues.