### PR TITLE
LPS-92478 Don't copy parameters for Captcha

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
@@ -446,6 +447,10 @@ public class DDMFormDisplayContext {
 
 	protected String createCaptchaResourceURL() {
 		ResourceURL resourceURL = _renderResponse.createResourceURL();
+
+		LiferayPortletURL liferayPortletURL = (LiferayPortletURL)resourceURL;
+
+		liferayPortletURL.setCopyCurrentRenderParameters(false);
 
 		resourceURL.setResourceID("captcha");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92478
https://issues.liferay.com/browse/LPP-33367

Because ResourceURL by [default copy the parameters of the request](https://github.com/liferay/liferay-portal/blob/d869b10ee301fd02782efd393c178bdb4623d405/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java#L1250-L1252), the URL can become too long for Captcha to accept. So we need to setCopyCurrentRenderParameters(false).