### PR TITLE
LPS-94798 Change overlayHorizontal when direction is down

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -163,6 +163,10 @@ AUI.add(
 						var triggerHorizontal = mapAlignHorizontalTrigger[direction] || defaultTriggerHorizontalAlign;
 						var triggerVertical = MAP_ALIGN_VERTICAL_TRIGGER[direction] || STR_TOP;
 
+						if (direction === 'down') {
+							overlayHorizontal = STR_LEFT;
+						}
+
 						alignPoints = [overlayVertical + overlayHorizontal, triggerVertical + triggerHorizontal];
 					}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94798

The box of the pagination is misaligned. I was able to find that the `direction` is set to `down` when the pagination is selected and this is used to correctly change the alignPoints with `overlayHorizontal = STR_LEFT;` This will align the box with the button and does not affect any other popup menu. Let me know if there are any questions or comments about this.

Thank you. 