### PR TITLE
LPS-96247 Migrate away from deprecated SourceSetOutput.getClassesDir

### DIFF
--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
@@ -2790,10 +2790,12 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 		SourceSetOutput sourceSetOutput = sourceSet.getOutput();
 
-		if (FileUtil.isChild(
-				sourceSetOutput.getClassesDir(), project.getBuildDir())) {
+		SourceDirectorySet javaSourceDirectorySet = sourceSet.getJava();
 
-			sourceSetOutput.setClassesDir(classesDirName);
+		if (FileUtil.isChild(
+				javaSourceDirectorySet.getOutputDir(), project.getBuildDir())) {
+
+			javaSourceDirectorySet.setOutputDir(new File(classesDirName));
 			sourceSetOutput.setResourcesDir(classesDirName);
 		}
 	}

--- a/modules/sdk/gradle-plugins-maven-plugin-builder/src/main/java/com/liferay/gradle/plugins/maven/plugin/builder/MavenPluginBuilderPlugin.java
+++ b/modules/sdk/gradle-plugins-maven-plugin-builder/src/main/java/com/liferay/gradle/plugins/maven/plugin/builder/MavenPluginBuilderPlugin.java
@@ -145,9 +145,9 @@ public class MavenPluginBuilderPlugin implements Plugin<Project> {
 
 				@Override
 				public File call() throws Exception {
-					SourceSetOutput sourceSetOutput = sourceSet.getOutput();
+					SourceDirectorySet javaSourceDirectorySet = sourceSet.getJava();
 
-					return sourceSetOutput.getClassesDir();
+					return javaSourceDirectorySet.getOutputDir();
 				}
 
 			});

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/NodePlugin.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/NodePlugin.java
@@ -53,6 +53,7 @@ import org.gradle.api.Task;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.plugins.osgi.OsgiHelper;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
@@ -603,9 +604,9 @@ public class NodePlugin implements Plugin<Project> {
 			SourceSet sourceSet = GradleUtil.getSourceSet(
 				npmRunTask.getProject(), SourceSet.MAIN_SOURCE_SET_NAME);
 
-			SourceSetOutput sourceSetOutput = sourceSet.getOutput();
+			SourceDirectorySet javaSourceDirectorySet = sourceSet.getJava();
 
-			File classesDir = sourceSetOutput.getClassesDir();
+			File classesDir = javaSourceDirectorySet.getOutputDir();
 
 			if (!classesDir.exists()) {
 				TaskOutputs taskOutputs = npmRunTask.getOutputs();

--- a/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationBasePlugin.java
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationBasePlugin.java
@@ -150,6 +150,8 @@ public class TestIntegrationBasePlugin implements Plugin<Project> {
 
 		final SourceSetOutput sourceSetOutput =
 			testIntegrationSourceSet.getOutput();
+		final SourceDirectorySet javaSourceDirectorySet =
+			testIntegrationSourceSet.getJava();
 
 		final Method getClassesDirsMethod = ReflectionUtil.getMethod(
 			sourceSetOutput, "getClassesDirs");
@@ -203,7 +205,7 @@ public class TestIntegrationBasePlugin implements Plugin<Project> {
 
 					@Override
 					public File call() throws Exception {
-						return sourceSetOutput.getClassesDir();
+						return javaSourceDirectorySet.getOutputDir();
 					}
 
 				});

--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/internal/IdeaDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/internal/IdeaDefaultsPlugin.java
@@ -31,6 +31,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.XmlProvider;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
@@ -89,7 +90,9 @@ public class IdeaDefaultsPlugin extends BaseDefaultsPlugin<IdeaPlugin> {
 
 			SourceSetOutput sourceSetOutput = sourceSet.getOutput();
 
-			File classesDir = sourceSetOutput.getClassesDir();
+      SourceDirectorySet javaSourceDirectorySet = sourceSet.getJava();
+
+      File classesDir = javaSourceDirectorySet.getOutputDir();
 
 			if (!FileUtil.isChild(classesDir, project.getBuildDir())) {
 				excludeDirs.add(classesDir);


### PR DESCRIPTION
It's been removed in Gradle 5.x

https://issues.liferay.com/browse/LPS-96247