### PR TITLE
LPS-98452 - Change log level from DEBUG to WARN

### DIFF
--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
@@ -84,8 +84,8 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 				BackgroundTaskConstants.STATUS_IN_PROGRESS, serviceContext);
 
 		if (backgroundTask == null) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
+			if (_log.isInfoEnabled()) {
+				_log.info(
 					"Unable to find background task " + backgroundTaskId);
 			}
 
@@ -137,8 +137,8 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 		catch (DuplicateLockException dle) {
 			status = BackgroundTaskConstants.STATUS_QUEUED;
 
-			if (_log.isWarnEnabled()) {
-				_log.warn(
+			if (_log.isInfoEnabled()) {
+				_log.info(
 					"Unable to acquire lock, queuing background task " +
 						backgroundTaskId,
 					dle);

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
@@ -84,8 +84,8 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 				BackgroundTaskConstants.STATUS_IN_PROGRESS, serviceContext);
 
 		if (backgroundTask == null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
+			if (_log.isWarnEnabled()) {
+				_log.warn(
 					"Unable to find background task " + backgroundTaskId);
 			}
 
@@ -137,8 +137,8 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 		catch (DuplicateLockException dle) {
 			status = BackgroundTaskConstants.STATUS_QUEUED;
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(
+			if (_log.isWarnEnabled()) {
+				_log.warn(
 					"Unable to acquire lock, queuing background task " +
 						backgroundTaskId,
 					dle);

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <category name="com.liferay.portal.background.task.internal.messaging.BackgroundTaskMessageListener">
+        <priority value="INFO" />
+    </category>
+</log4j:configuration>


### PR DESCRIPTION
Change the log level from debug to waring when the DuplicateLockException exception occurs. It is very useful to see this condition immediately on the log file.