### PR TITLE
Remove extra period in the default repos property

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurators/RootProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurators/RootProjectConfigurator.java
@@ -150,7 +150,7 @@ public class RootProjectConfigurator implements Plugin<Project> {
 	public RootProjectConfigurator(Settings settings) {
 		_defaultRepositoryEnabled = GradleUtil.getProperty(
 			settings,
-			WorkspacePlugin.PROPERTY_PREFIX + ".default.repository.enabled",
+			WorkspacePlugin.PROPERTY_PREFIX + "default.repository.enabled",
 			_DEFAULT_REPOSITORY_ENABLED);
 	}
 


### PR DESCRIPTION
The property named below:

    liferay.workspace.default.repositories.enabled

Was being incorrectly looked up as follows:

    liferay.workspace..default.repositories.enabled

Due to a stray character in the RootProjectConfigurator constructor.

Signed-off-by: Gary Tierney <gary.tierney@fastmail.com>