### PR TITLE
 [TECHNICAL SUPPORT] LPS-98519

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/init-ext.jspf
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/init-ext.jspf
@@ -21,8 +21,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.portal.kernel.json.JSONArray" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@
-page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %>
+page import="com.liferay.portal.kernel.util.GetterUtil" %>
 
 <%@ page import="java.util.Locale" %><%@
 page import="java.util.Map" %>

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/start.jsp
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/start.jsp
@@ -16,9 +16,7 @@
 
 <%@ include file="/data_layout_builder/init.jsp" %>
 
-<liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, "/o/dynamic-data-mapping-form-builder/css/main.css") %>" rel="stylesheet" type="text/css" />
-</liferay-util:html-top>
+<liferay-util:dynamic-include key="com.liferay.data.engine.taglib#/data_layout_builder/start.jsp#pre" />
 
 <div class="container-fluid-1280 ddm-translation-manager">
 	<liferay-frontend:translation-manager
@@ -28,3 +26,5 @@
 		id="translationManager"
 	/>
 </div>
+
+<liferay-util:dynamic-include key="com.liferay.data.engine.taglib#/data_layout_builder/start.jsp#post" />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/taglib/DDMFormBuilderTopHeadDynamicInclude.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/taglib/DDMFormBuilderTopHeadDynamicInclude.java
@@ -51,19 +51,20 @@ public class DDMFormBuilderTopHeadDynamicInclude extends BaseDynamicInclude {
 
 	@Override
 	public void include(
-			HttpServletRequest request, HttpServletResponse response,
-			String key)
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
 		throws IOException {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
-			WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
-		PrintWriter printWriter = response.getWriter();
+		PrintWriter printWriter = httpServletResponse.getWriter();
 
 		String cdnBaseURL = themeDisplay.getCDNBaseURL();
 
 		String staticResourceURL = _portal.getStaticResourceURL(
-			request,
+			httpServletRequest,
 			cdnBaseURL.concat(
 				_postfix
 			).concat(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/taglib/DDMFormBuilderTopHeadDynamicInclude.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/taglib/DDMFormBuilderTopHeadDynamicInclude.java
@@ -68,7 +68,7 @@ public class DDMFormBuilderTopHeadDynamicInclude extends BaseDynamicInclude {
 			cdnBaseURL.concat(
 				_postfix
 			).concat(
-				"/alloy/css/main.css"
+				"/css/main.css"
 			));
 
 		String content = "<link href=\"".concat(staticResourceURL);
@@ -79,7 +79,15 @@ public class DDMFormBuilderTopHeadDynamicInclude extends BaseDynamicInclude {
 
 	@Override
 	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
-		dynamicIncludeRegistry.register("/html/common/themes/top_head.jsp#pre");
+		dynamicIncludeRegistry.register(
+			"com.liferay.dynamic.data.mapping.form.web#" +
+				"EditElementSetInstanceMVCRenderCommand#render");
+		dynamicIncludeRegistry.register(
+			"com.liferay.dynamic.data.mapping.form.web#" +
+				"EditFormInstanceMVCRenderCommand#render");
+		dynamicIncludeRegistry.register(
+			"com.liferay.data.engine.taglib#/data_layout_builder/start.jsp" +
+				"#pre");
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/taglib/DDMFormBuilderTopHeadDynamicInclude.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/taglib/DDMFormBuilderTopHeadDynamicInclude.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.builder.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rafael Praxedes
+ */
+@Component(immediate = true, service = DynamicInclude.class)
+public class DDMFormBuilderTopHeadDynamicInclude extends BaseDynamicInclude {
+
+	@Activate
+	public void activate() {
+		_postfix = _portal.getPathProxy();
+
+		if (_postfix.isEmpty()) {
+			_postfix = _servletContext.getContextPath();
+		}
+		else {
+			_postfix = _postfix.concat(_servletContext.getContextPath());
+		}
+	}
+
+	@Override
+	public void include(
+			HttpServletRequest request, HttpServletResponse response,
+			String key)
+		throws IOException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PrintWriter printWriter = response.getWriter();
+
+		String cdnBaseURL = themeDisplay.getCDNBaseURL();
+
+		String staticResourceURL = _portal.getStaticResourceURL(
+			request,
+			cdnBaseURL.concat(
+				_postfix
+			).concat(
+				"/alloy/css/main.css"
+			));
+
+		String content = "<link href=\"".concat(staticResourceURL);
+
+		printWriter.println(
+			content.concat("\" rel=\"stylesheet\" type = \"text/css\" />"));
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register("/html/common/themes/top_head.jsp#pre");
+	}
+
+	@Reference
+	private Portal _portal;
+
+	private String _postfix;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.dynamic.data.mapping.form.builder)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/EditElementSetInstanceMVCRenderCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/EditElementSetInstanceMVCRenderCommand.java
@@ -16,11 +16,14 @@ package com.liferay.dynamic.data.mapping.form.web.internal.portlet.action;
 
 import com.liferay.dynamic.data.mapping.constants.DDMPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.servlet.taglib.DynamicIncludeUtil;
+import com.liferay.portal.kernel.util.Portal;
 
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Bruno Basto
@@ -39,7 +42,17 @@ public class EditElementSetInstanceMVCRenderCommand
 	public String render(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
+		DynamicIncludeUtil.include(
+			portal.getHttpServletRequest(renderRequest),
+			portal.getHttpServletResponse(renderResponse),
+			"com.liferay.dynamic.data.mapping.form.web#" +
+				"EditElementSetInstanceMVCRenderCommand#render",
+			true);
+
 		return "/admin/edit_element_set.jsp";
 	}
+
+	@Reference
+	protected Portal portal;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/EditFormInstanceMVCRenderCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/EditFormInstanceMVCRenderCommand.java
@@ -16,11 +16,14 @@ package com.liferay.dynamic.data.mapping.form.web.internal.portlet.action;
 
 import com.liferay.dynamic.data.mapping.constants.DDMPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.servlet.taglib.DynamicIncludeUtil;
+import com.liferay.portal.kernel.util.Portal;
 
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Bruno Basto
@@ -38,7 +41,17 @@ public class EditFormInstanceMVCRenderCommand implements MVCRenderCommand {
 	public String render(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
+		DynamicIncludeUtil.include(
+			portal.getHttpServletRequest(renderRequest),
+			portal.getHttpServletResponse(renderResponse),
+			"com.liferay.dynamic.data.mapping.form.web#" +
+				"EditFormInstanceMVCRenderCommand#render",
+			true);
+
 		return "/admin/edit_form_instance.jsp";
 	}
+
+	@Reference
+	protected Portal portal;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -36,10 +36,6 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-element-set") : LanguageUtil.get(request, "edit-element-set"));
 %>
 
-<liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, "/o/dynamic-data-mapping-form-builder/css/main.css") %>" rel="stylesheet" type="text/css" />
-</liferay-util:html-top>
-
 <portlet:actionURL name="saveStructure" var="saveStructureURL">
 	<portlet:param name="mvcRenderCommandName" value="/admin/edit_element_set" />
 </portlet:actionURL>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -37,10 +37,6 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-form") : LanguageUtil.get(request, "edit-form"));
 %>
 
-<liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, "/o/dynamic-data-mapping-form-builder/css/main.css") %>" rel="stylesheet" type="text/css" />
-</liferay-util:html-top>
-
 <portlet:actionURL name="saveFormInstance" var="saveFormInstanceURL">
 	<portlet:param name="mvcRenderCommandName" value="/admin/edit_form_instance" />
 </portlet:actionURL>


### PR DESCRIPTION
Brian Chan rejected first pr, see: https://github.com/brianchandotcom/liferay-portal/pull/76236#issuecomment-515627026

I have implemented an alternative solution:

1.  I am reverting the changes that caused this regression (see https://github.com/liferay/liferay-portal/commit/cc19e9a6bed401a3479d9444b9cc247343b451d3 and https://github.com/liferay/liferay-portal/commit/6993c25a75c8a04695a7810fee6eafd4d59a3b27)
2. With these commits I am getting back **DDMFormBuilderTopHeadDynamicInclude** that was removed. I am applying a SF in https://github.com/liferay/liferay-portal/commit/514b7d0a307ab84aff41e73da079fd0350be588f due some changes done in SF logic since it was removed.
3. In last commit https://github.com/liferay/liferay-portal/commit/81e453015d162bf05f889eac95d29172d879c2c8 I am appliying the correct solution to the reverted commits. In **DDMFormBuilderTopHeadDynamicInclude**, am replacing original `dynamicIncludeRegistry.register("/html/common/themes/top_head.jsp#pre");` with `dynamicIncludeRegistry.register` in three specific places. 

Using this approach, we avoid some problems because CSS link is generated by dynamic-data-mapping-form-builder osgi module, the module that owns the CSS, even it is used in other osgi modules (in this case data-layout-builder and dynamic-data-mapping-form-web )
