### PR TITLE
LPS-100248 change default value to false for site.control.panel.membe…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -11525,7 +11525,7 @@
     #
     # Env: LIFERAY_SITES_PERIOD_CONTROL_PERIOD_PANEL_PERIOD_MEMBERS_PERIOD_VISIBLE
     #
-    sites.control.panel.members.visible=true
+    sites.control.panel.members.visible=false
 
     #
     # Set this to true to allow site administrators to make a site inherit the


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-100248

Hello Eudaldo,

Please let me know if this should go to someone else.

Users that belong to a site can bypass Control Panel permissions by using URL http://localhost:8080/group/control_panel/manage/-/sites to access the Control Panel Sites. The portal property `sites.control.panel.members.visible` has the default value set to true and allows this behavior to occur. By using the URL, the user can view Membership Type, Active status, and private sites which can be argued should not be viewed unless given proper permissions.

The default value should be changed to false to prevent this behavior to occur.

Let me know if there are any questions or comments about this.
Thank you.
