### PR TITLE
_http and _layoutLocalService should be 'protected' for subclass

### DIFF
--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalConverterImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalConverterImpl.java
@@ -1247,11 +1247,11 @@ public class JournalConverterImpl implements JournalConverter {
 	private GroupLocalService _groupLocalService;
 
 	@Reference
-	private Http _http;
+	protected Http _http;
 
 	private final Map<String, String> _journalTypesToDDMTypes;
 
 	@Reference(unbind = "-")
-	private LayoutLocalService _layoutLocalService;
+	protected LayoutLocalService _layoutLocalService;
 
 }


### PR DESCRIPTION
The other 3 service @Reference have public or protected setter, which subclass can use to inject service reference to the base class JournalConverterImpl. A subclass cannot do that for these 2 private references. At the minimum, declare them protected.