### PR TITLE
Use the 'localizable' flag to avoid exploding the XML

### DIFF
--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalConverterImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalConverterImpl.java
@@ -517,6 +517,10 @@ public class JournalConverterImpl implements JournalConverter {
 
 		String name = dynamicElementElement.attributeValue("name");
 
+		if (!GetterUtil.getBoolean(ddmStructure.getFieldProperty(name, "localizable"))) {
+			availableLanguageIds = StringPool.EMPTY_ARRAY;
+		}
+
 		ddmField.setName(name);
 
 		String dataType = ddmStructure.getFieldDataType(name);


### PR DESCRIPTION
When one field has multi-language values, all fields are duplicated by the number of "available-locales" of the root element. For example, a HTML field with images encoded in "data" URL scheme (RFC-2397) may be language neutral and very large. Duplicating it in all available languages is meaningless, wasteful and bad for performance.

The DDM structure already has the 'localizable' flag. If a field is marked as "localizable: false", this change makes JournalConverter not to duplicate the content into all available languages.