### PR TITLE
COMMERCE-1999 fixed cache related bug on old management bar

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar/js/management_bar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar/js/management_bar.js
@@ -173,6 +173,7 @@ AUI.add(
 							checkBoxesSelector: instance.get(
 								'checkBoxesSelector'
 							),
+							id: instance.get('id'),
 							itemsCountContainerSelector: instance
 								.get('itemsCountContainer')
 								.attr('class'),
@@ -335,6 +336,10 @@ AUI.add(
 			},
 
 			testRestoreTask(state, params, node) {
+				if (state.owner !== params.id) {
+					return;
+				}
+
 				var returnNode;
 
 				var currentNode = A.one(node);


### PR DESCRIPTION
This is related to a bug we found in commerce migrating to 7.2

The management bar we've used doesn't correctly handle cached components state and this breaks at page loading.