### PR TITLE
Fix Public/Private page type selection in the sidebar

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.es.js
@@ -32,7 +32,7 @@ function PageTypeSelector(props) {
 				);
 			}
 
-			Liferay.Util.navigate(window.location);
+			Liferay.Util.navigate(window.location.href);
 		},
 		[props.namespace]
 	);


### PR DESCRIPTION
## Problem :grimacing:

**[LPS-103594](https://issues.liferay.com/browse/LPS-103594)**

It takes multiple page type sets to swap between Public and Private pages in the page tree sidebar.

## Analysis :nerd_face:

`PageTypeSelector.es.js` makes a call to [`Liferay.Util.navigate()`](https://github.com/jesseyeh-liferay/liferay-portal/blob/962a82155b6b6a1fa4fb69f5ce246e5b02518af3/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.es.js#L35), which passes in `window.location` as the `url` argument. `navigate()` then runs a check on the `url` via [`canNavigate()`](https://github.com/jesseyeh-liferay/liferay-portal/blob/962a82155b6b6a1fa4fb69f5ce246e5b02518af3/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/navigate.es.js#L26), which exists in `App.js` in senna.js.

#### senna.js

`canNavigate()` passes the `url` to [`isWebUri()`](https://github.com/jesseyeh-liferay/senna.js/blob/43fc80fe7b69114f51b2390065507dd8e2bf9bb8/build/amd/senna/src/app/App.js#L395), which constructs a [new `Uri` object](https://github.com/jesseyeh-liferay/senna.js/blob/43fc80fe7b69114f51b2390065507dd8e2bf9bb8/src/utils/utils.js#L182). The constructor then makes a call to `maybeAddProtocolAndHostname_`, [which assumes that the `url` is a string](https://github.com/jesseyeh-liferay/senna.js/blob/43fc80fe7b69114f51b2390065507dd8e2bf9bb8/build/amd/metal-uri/src/Uri.js#L276), when it is in fact an `object`. This results in a `TypeError`.

## Solution :tada:

Instead of passing in `window.location` (an `object`), we can pass in `window.location.href` (a string) to avoid the `TypeError`.

## New Issues :open_mouth: 

The following new issues were encountered while resolving this issue:

[LPS-103996](https://issues.liferay.com/browse/LPS-103996)
[LPS-103997](https://issues.liferay.com/browse/LPS-103997)