### PR TITLE
LPS-103676 Embedded page does not show URLs without "http://" correctly

### DIFF
--- a/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
+++ b/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
@@ -65,7 +65,9 @@ public class IFrameConfigurationAction extends DefaultConfigurationAction {
 			!StringUtil.startsWith(src, "https://") &&
 			!StringUtil.startsWith(src, "mhtml://")) {
 
-			src = _http.getProtocol(actionRequest) + "://" + src;
+			src =
+				_http.getProtocol(actionRequest) + Http.PROTOCOL_DELIMITER +
+					src;
 
 			setPreference(actionRequest, "src", src);
 		}

--- a/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
+++ b/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
@@ -61,7 +61,8 @@ public class IFrameConfigurationAction extends DefaultConfigurationAction {
 
 		String src = getParameter(actionRequest, "src");
 
-		if (!src.startsWith("/") && !StringUtil.startsWith(src, "http://") &&
+		if (Validator.isNotNull(src) && !src.startsWith("/") &&
+			!StringUtil.startsWith(src, "http://") &&
 			!StringUtil.startsWith(src, "https://") &&
 			!StringUtil.startsWith(src, "mhtml://")) {
 

--- a/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
+++ b/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
@@ -62,9 +62,7 @@ public class IFrameConfigurationAction extends DefaultConfigurationAction {
 		String src = getParameter(actionRequest, "src");
 
 		if (Validator.isNotNull(src) && !src.startsWith("/") &&
-			!StringUtil.startsWith(src, "http://") &&
-			!StringUtil.startsWith(src, "https://") &&
-			!StringUtil.startsWith(src, "mhtml://")) {
+			!_http.hasProtocol(src)) {
 
 			src =
 				_http.getProtocol(actionRequest) + Http.PROTOCOL_DELIMITER +

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -196,6 +197,19 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			PropertiesParamUtil.getProperties(
 				actionRequest, "TypeSettingsProperties--");
 
+		String src = formTypeSettingsProperties.getProperty(
+			"embeddedLayoutURL");
+
+		if (Validator.isNotNull(src) && !src.startsWith("/") &&
+			!StringUtil.startsWith(src, "http://") &&
+			!StringUtil.startsWith(src, "https://") &&
+			!StringUtil.startsWith(src, "mhtml://")) {
+
+			src = _http.getProtocol(actionRequest) + "://" + src;
+
+			formTypeSettingsProperties.put("embeddedLayoutURL", src);
+		}
+
 		String linkToLayoutUuid = ParamUtil.getString(
 			actionRequest, "linkToLayoutUuid");
 
@@ -283,6 +297,9 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -205,7 +205,9 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			!StringUtil.startsWith(src, "https://") &&
 			!StringUtil.startsWith(src, "mhtml://")) {
 
-			src = _http.getProtocol(actionRequest) + "://" + src;
+			src =
+				_http.getProtocol(actionRequest) + Http.PROTOCOL_DELIMITER +
+					src;
 
 			formTypeSettingsProperties.put("embeddedLayoutURL", src);
 		}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -201,9 +201,7 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			"embeddedLayoutURL");
 
 		if (Validator.isNotNull(src) && !src.startsWith("/") &&
-			!StringUtil.startsWith(src, "http://") &&
-			!StringUtil.startsWith(src, "https://") &&
-			!StringUtil.startsWith(src, "mhtml://")) {
+			!_http.hasProtocol(src)) {
 
 			src =
 				_http.getProtocol(actionRequest) + Http.PROTOCOL_DELIMITER +

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -17,6 +17,7 @@ package com.liferay.layout.admin.web.internal.portlet.action;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.seo.service.LayoutSEOEntryService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.EventsProcessorUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -48,6 +49,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -203,11 +205,28 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 		if (Validator.isNotNull(src) && !src.startsWith("/") &&
 			!_http.hasProtocol(src)) {
 
-			src =
-				_http.getProtocol(actionRequest) + Http.PROTOCOL_DELIMITER +
-					src;
+			boolean isFriendlyURL = false;
+			List<Layout> layouts = _layoutLocalService.getLayouts(
+				themeDisplay.getCompanyId());
 
-			formTypeSettingsProperties.put("embeddedLayoutURL", src);
+			for (Layout friendlyLayout : layouts) {
+				String friendlyURL = friendlyLayout.getFriendlyURL(
+					themeDisplay.getLocale());
+
+				if (friendlyURL.equals(StringPool.SLASH + src)) {
+					isFriendlyURL = true;
+
+					break;
+				}
+			}
+
+			if (!isFriendlyURL) {
+				src =
+					_http.getProtocol(actionRequest) + Http.PROTOCOL_DELIMITER +
+						src;
+
+				formTypeSettingsProperties.put("embeddedLayoutURL", src);
+			}
 		}
 
 		String linkToLayoutUuid = ParamUtil.getString(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-103676

**Issue**:
URL defined for Embedded Page is not a valid URL by itself.

**Solution**:
URL configuration of Embedded Pages automatically prepends the URL with "http://" or "https://" when it's not starting with it and is not a friendly URL.