### PR TITLE
LPS-104116

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -78,7 +78,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.batch.engine.service.jar!commons-compress.jar</file-name>
-				<version>1.18</version>
+				<version>1.19</version>
 				<project-name>Apache Commons Compress</project-name>
 				<project-url>https://commons.apache.org/proper/commons-compress/</project-url>
 				<licenses>
@@ -2089,7 +2089,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch6.impl.jar!bcpg-jdk15on.jar</file-name>
-				<version>1.59</version>
+				<version>1.61</version>
 				<project-name>Bouncy Castle OpenPGP API</project-name>
 				<project-url>http://www.bouncycastle.org/java.html</project-url>
 				<licenses>
@@ -2101,7 +2101,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch6.impl.jar!bcpkix-jdk15on.jar</file-name>
-				<version>1.59</version>
+				<version>1.61</version>
 				<project-name>Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs</project-name>
 				<project-url>http://www.bouncycastle.org/java.html</project-url>
 				<licenses>
@@ -2113,7 +2113,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch6.impl.jar!bcprov-jdk15on.jar</file-name>
-				<version>1.59</version>
+				<version>1.61</version>
 				<project-name>Bouncy Castle Provider</project-name>
 				<project-url>http://www.bouncycastle.org/java.html</project-url>
 				<licenses>
@@ -3918,18 +3918,6 @@
 				</licenses>
 			</library>
 			<library>
-				<file-name>com.liferay.push.notifications.sender.android.jar!json-simple.jar</file-name>
-				<version>1.1</version>
-				<project-name>JSON.simple</project-name>
-				<project-url>http://code.google.com/p/json-simple/</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
 				<file-name>com.liferay.push.notifications.sender.apple.jar!apns.jar</file-name>
 				<version>1.0.0.Beta6</version>
 				<project-name>Java Apple Push Notification Service Library</project-name>
@@ -4872,9 +4860,9 @@
 			</library>
 			<library>
 				<file-name>lib/development/jserrorcollector.jar</file-name>
-				<version>c7d2d9161321e9</version>
+				<version>0.6-atlassian-3</version>
 				<project-name>JSErrorCollector</project-name>
-				<project-url>https://github.com/mguillem/JSErrorCollector</project-url>
+				<project-url>https://github.com/atlassian/JSErrorCollector</project-url>
 				<licenses>
 					<license>
 						<license-name>Apache License 2.0</license-name>
@@ -4933,7 +4921,7 @@
 			</library>
 			<library>
 				<file-name>lib/development/jutf7.jar</file-name>
-				<version/>
+				<version>1.0.0</version>
 				<project-name>jutf7</project-name>
 				<project-url>http://jutf7.sourceforge.net</project-url>
 				<licenses>
@@ -5529,7 +5517,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/axis.jar</file-name>
-				<version>1.4.LIFERAY-PATCHED-3</version>
+				<version>1.4.LIFERAY-PATCHED-4</version>
 				<project-name>Axis</project-name>
 				<project-url>http://ws.apache.org/axis</project-url>
 				<licenses>
@@ -5774,7 +5762,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-discovery.jar</file-name>
-				<version>0.4.0</version>
+				<version>0.4</version>
 				<project-name>Commons Discovery.jar</project-name>
 				<project-url>http://commons.apache.org/discovery</project-url>
 				<licenses>
@@ -5812,7 +5800,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-httpclient.jar</file-name>
-				<version>3.1.0</version>
+				<version>3.1</version>
 				<project-name>Commons HttpClient</project-name>
 				<project-url>http://hc.apache.org/httpclient-legacy/index.html</project-url>
 				<licenses>
@@ -5837,7 +5825,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-lang.jar</file-name>
-				<version>2.6.0</version>
+				<version>2.6</version>
 				<project-name>Commons Lang</project-name>
 				<project-url>http://commons.apache.org/lang</project-url>
 				<licenses>
@@ -5850,7 +5838,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-logging.jar</file-name>
-				<version>1.2.0</version>
+				<version>1.2</version>
 				<project-name>Commons Logging</project-name>
 				<project-url>http://commons.apache.org/logging</project-url>
 				<licenses>
@@ -5862,7 +5850,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-math.jar</file-name>
-				<version>2.0.0</version>
+				<version>2.0</version>
 				<project-name>Commons Math</project-name>
 				<project-url>http://commons.apache.org/math</project-url>
 				<licenses>
@@ -5927,7 +5915,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/crypt.jar</file-name>
-				<version/>
+				<version>1.0</version>
 				<project-name>Manticore UFC Crypt</project-name>
 				<project-url>http://manticore.2y.net/Java/examples/Crypt.html</project-url>
 				<licenses>
@@ -6012,7 +6000,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/freshcookies-security.jar</file-name>
-				<version>0.6</version>
+				<version>0.60</version>
 				<project-name>Freshcookies</project-name>
 				<project-url>http://freshcookies.org/freshcookies-security</project-url>
 				<licenses>
@@ -6024,7 +6012,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/gif89.jar</file-name>
-				<version/>
+				<version>1.0</version>
 				<project-name>Gif89Encoder</project-name>
 				<project-url>http://jmge.net/java/gifenc</project-url>
 				<licenses>
@@ -6052,7 +6040,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/hibernate-commons-annotations.jar</file-name>
-				<version>3.2.0</version>
+				<version>3.2.0.Final</version>
 				<project-name>Hibernate</project-name>
 				<project-url>http://www.hibernate.org</project-url>
 				<licenses>
@@ -6137,7 +6125,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/ical4j.jar</file-name>
-				<version>1.0</version>
+				<version>1.0 RC3</version>
 				<project-name>iCal4j</project-name>
 				<project-url>http://ical4j.sourceforge.net</project-url>
 				<licenses>
@@ -6272,7 +6260,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/javassist.jar</file-name>
-				<version>3.18.2</version>
+				<version>3.18.2 GA</version>
 				<project-name>Javassist</project-name>
 				<project-url>http://www.csg.is.titech.ac.jp/~chiba/javassist</project-url>
 				<licenses>
@@ -6369,7 +6357,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/jazzy.jar</file-name>
-				<version>0.5</version>
+				<version>0.5.2-rtext-1.4.1-2</version>
 				<project-name>Jazzy</project-name>
 				<project-url>http://jazzy.sourceforge.net</project-url>
 				<licenses>
@@ -6393,7 +6381,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/jcifs.jar</file-name>
-				<version>1.3.14</version>
+				<version>1.3.14-kohsuke-1</version>
 				<project-name>jCIFS</project-name>
 				<project-url>http://jcifs.samba.org</project-url>
 				<licenses>
@@ -6517,7 +6505,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/jhlabs-filters.jar</file-name>
-				<version/>
+				<version>01012005</version>
 				<project-name>JH Labs Java Image Filters</project-name>
 				<project-url>http://www.jhlabs.com/ip/filters</project-url>
 				<licenses>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -429,9 +429,9 @@
 			</library>
 			<library>
 				<file-name>lib/development/jserrorcollector.jar</file-name>
-				<version>c7d2d9161321e9</version>
+				<version>0.6-atlassian-3</version>
 				<project-name>JSErrorCollector</project-name>
-				<project-url>https://github.com/mguillem/JSErrorCollector</project-url>
+				<project-url>https://github.com/atlassian/JSErrorCollector</project-url>
 				<licenses>
 					<license>
 						<license-name>Apache License 2.0</license-name>
@@ -492,7 +492,7 @@
 			</library>
 			<library>
 				<file-name>lib/development/jutf7.jar</file-name>
-				<version></version>
+				<version>1.0.0</version>
 				<project-name>jutf7</project-name>
 				<project-url>http://jutf7.sourceforge.net</project-url>
 				<licenses>
@@ -1084,7 +1084,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/axis.jar</file-name>
-				<version>1.4.LIFERAY-PATCHED-3</version>
+				<version>1.4.LIFERAY-PATCHED-4</version>
 				<project-name>Axis</project-name>
 				<project-url>http://ws.apache.org/axis</project-url>
 				<licenses>
@@ -1349,7 +1349,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-discovery.jar</file-name>
-				<version>0.4.0</version>
+				<version>0.4</version>
 				<project-name>Commons Discovery.jar</project-name>
 				<project-url>http://commons.apache.org/discovery</project-url>
 				<licenses>
@@ -1387,7 +1387,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-httpclient.jar</file-name>
-				<version>3.1.0</version>
+				<version>3.1</version>
 				<project-name>Commons HttpClient</project-name>
 				<project-url>http://hc.apache.org/httpclient-legacy/index.html</project-url>
 				<licenses>
@@ -1412,7 +1412,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-lang.jar</file-name>
-				<version>2.6.0</version>
+				<version>2.6</version>
 				<project-name>Commons Lang</project-name>
 				<project-url>http://commons.apache.org/lang</project-url>
 				<licenses>
@@ -1425,7 +1425,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-logging.jar</file-name>
-				<version>1.2.0</version>
+				<version>1.2</version>
 				<project-name>Commons Logging</project-name>
 				<project-url>http://commons.apache.org/logging</project-url>
 				<licenses>
@@ -1449,7 +1449,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/commons-math.jar</file-name>
-				<version>2.0.0</version>
+				<version>2.0</version>
 				<project-name>Commons Math</project-name>
 				<project-url>http://commons.apache.org/math</project-url>
 				<licenses>
@@ -1502,7 +1502,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/crypt.jar</file-name>
-				<version></version>
+				<version>1.0</version>
 				<project-name>Manticore UFC Crypt</project-name>
 				<project-url>http://manticore.2y.net/Java/examples/Crypt.html</project-url>
 				<licenses>
@@ -1592,7 +1592,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/freshcookies-security.jar</file-name>
-				<version>0.6</version>
+				<version>0.60</version>
 				<project-name>Freshcookies</project-name>
 				<project-url>http://freshcookies.org/freshcookies-security</project-url>
 				<licenses>
@@ -1604,7 +1604,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/gif89.jar</file-name>
-				<version></version>
+				<version>1.0</version>
 				<project-name>Gif89Encoder</project-name>
 				<project-url>http://jmge.net/java/gifenc</project-url>
 				<licenses>
@@ -1632,7 +1632,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/hibernate-commons-annotations.jar</file-name>
-				<version>3.2.0</version>
+				<version>3.2.0.Final</version>
 				<project-name>Hibernate</project-name>
 				<project-url>http://www.hibernate.org</project-url>
 				<licenses>
@@ -1719,7 +1719,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/ical4j.jar</file-name>
-				<version>1.0</version>
+				<version>1.0 RC3</version>
 				<project-name>iCal4j</project-name>
 				<project-url>http://ical4j.sourceforge.net</project-url>
 				<licenses>
@@ -1856,7 +1856,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/javassist.jar</file-name>
-				<version>3.18.2</version>
+				<version>3.18.2 GA</version>
 				<project-name>Javassist</project-name>
 				<project-url>http://www.csg.is.titech.ac.jp/~chiba/javassist</project-url>
 				<licenses>
@@ -1953,7 +1953,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/jazzy.jar</file-name>
-				<version>0.5</version>
+				<version>0.5.2-rtext-1.4.1-2</version>
 				<project-name>Jazzy</project-name>
 				<project-url>http://jazzy.sourceforge.net</project-url>
 				<licenses>
@@ -1977,7 +1977,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/jcifs.jar</file-name>
-				<version>1.3.14</version>
+				<version>1.3.14-kohsuke-1</version>
 				<project-name>jCIFS</project-name>
 				<project-url>http://jcifs.samba.org</project-url>
 				<licenses>
@@ -2101,7 +2101,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/jhlabs-filters.jar</file-name>
-				<version></version>
+				<version>01012005</version>
 				<project-name>JH Labs Java Image Filters</project-name>
 				<project-url>http://www.jhlabs.com/ip/filters</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -72,7 +72,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.batch.engine.service.jar!commons-compress.jar</td><td nowrap>1.18</td><td nowrap><a href="https://commons.apache.org/proper/commons-compress/">Apache Commons Compress</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+<td nowrap>com.liferay.batch.engine.service.jar!commons-compress.jar</td><td nowrap>1.19</td><td nowrap><a href="https://commons.apache.org/proper/commons-compress/">Apache Commons Compress</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -932,17 +932,17 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.search.elasticsearch6.impl.jar!bcpg-jdk15on.jar</td><td nowrap>1.59</td><td nowrap><a href="http://www.bouncycastle.org/java.html">Bouncy Castle OpenPGP API</a></td><td nowrap><a href="http://www.bouncycastle.org/licence.html">Bouncy Castle Licence</a>
+<td nowrap>com.liferay.portal.search.elasticsearch6.impl.jar!bcpg-jdk15on.jar</td><td nowrap>1.61</td><td nowrap><a href="http://www.bouncycastle.org/java.html">Bouncy Castle OpenPGP API</a></td><td nowrap><a href="http://www.bouncycastle.org/licence.html">Bouncy Castle Licence</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.search.elasticsearch6.impl.jar!bcpkix-jdk15on.jar</td><td nowrap>1.59</td><td nowrap><a href="http://www.bouncycastle.org/java.html">Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs</a></td><td nowrap><a href="http://www.bouncycastle.org/licence.html">Bouncy Castle Licence</a>
+<td nowrap>com.liferay.portal.search.elasticsearch6.impl.jar!bcpkix-jdk15on.jar</td><td nowrap>1.61</td><td nowrap><a href="http://www.bouncycastle.org/java.html">Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs</a></td><td nowrap><a href="http://www.bouncycastle.org/licence.html">Bouncy Castle Licence</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.search.elasticsearch6.impl.jar!bcprov-jdk15on.jar</td><td nowrap>1.59</td><td nowrap><a href="http://www.bouncycastle.org/java.html">Bouncy Castle Provider</a></td><td nowrap><a href="http://www.bouncycastle.org/licence.html">Bouncy Castle Licence</a>
+<td nowrap>com.liferay.portal.search.elasticsearch6.impl.jar!bcprov-jdk15on.jar</td><td nowrap>1.61</td><td nowrap><a href="http://www.bouncycastle.org/java.html">Bouncy Castle Provider</a></td><td nowrap><a href="http://www.bouncycastle.org/licence.html">Bouncy Castle Licence</a>
 <br>
 </td><td></td>
 </tr>
@@ -1717,11 +1717,6 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.push.notifications.sender.android.jar!json-simple.jar</td><td nowrap>1.1</td><td nowrap><a href="http://code.google.com/p/json-simple/">JSON.simple</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
-<br>
-</td><td></td>
-</tr>
-<tr>
 <td nowrap>com.liferay.push.notifications.sender.apple.jar!apns.jar</td><td nowrap>1.0.0.Beta6</td><td nowrap><a href="http://notnoop.github.com/java-apns">Java Apple Push Notification Service Library</a></td><td nowrap><a href="http://www.opensource.org/licenses/bsd-license.php">New BSD License</a>
 <br>
 </td><td></td>
@@ -2124,7 +2119,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/development/jserrorcollector.jar</td><td nowrap>c7d2d9161321e9</td><td nowrap><a href="https://github.com/mguillem/JSErrorCollector">JSErrorCollector</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/development/jserrorcollector.jar</td><td nowrap>0.6-atlassian-3</td><td nowrap><a href="https://github.com/atlassian/JSErrorCollector">JSErrorCollector</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2151,7 +2146,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/development/jutf7.jar</td><td nowrap></td><td nowrap><a href="http://jutf7.sourceforge.net">jutf7</a></td><td nowrap><a href="http://opensource.org/licenses/MIT">MIT License</a>
+<td nowrap>lib/development/jutf7.jar</td><td nowrap>1.0.0</td><td nowrap><a href="http://jutf7.sourceforge.net">jutf7</a></td><td nowrap><a href="http://opensource.org/licenses/MIT">MIT License</a>
 <br>
 </td><td></td>
 </tr>
@@ -2415,7 +2410,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/axis.jar</td><td nowrap>1.4.LIFERAY-PATCHED-3</td><td nowrap><a href="http://ws.apache.org/axis">Axis</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/axis.jar</td><td nowrap>1.4.LIFERAY-PATCHED-4</td><td nowrap><a href="http://ws.apache.org/axis">Axis</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td>
 					See modules/third-party/org-apache-axis/patches.
@@ -2525,7 +2520,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/commons-discovery.jar</td><td nowrap>0.4.0</td><td nowrap><a href="http://commons.apache.org/discovery">Commons Discovery.jar</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/commons-discovery.jar</td><td nowrap>0.4</td><td nowrap><a href="http://commons.apache.org/discovery">Commons Discovery.jar</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 <copyright-notice>Copyright (c) 2002-2006 The Apache Software Foundation</copyright-notice>
 <br>
@@ -2544,7 +2539,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/commons-httpclient.jar</td><td nowrap>3.1.0</td><td nowrap><a href="http://hc.apache.org/httpclient-legacy/index.html">Commons HttpClient</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/commons-httpclient.jar</td><td nowrap>3.1</td><td nowrap><a href="http://hc.apache.org/httpclient-legacy/index.html">Commons HttpClient</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2556,19 +2551,19 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/commons-lang.jar</td><td nowrap>2.6.0</td><td nowrap><a href="http://commons.apache.org/lang">Commons Lang</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/commons-lang.jar</td><td nowrap>2.6</td><td nowrap><a href="http://commons.apache.org/lang">Commons Lang</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 <copyright-notice>Copyright (c) 2001-2007 The Apache Software Foundation</copyright-notice>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/commons-logging.jar</td><td nowrap>1.2.0</td><td nowrap><a href="http://commons.apache.org/logging">Commons Logging</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/commons-logging.jar</td><td nowrap>1.2</td><td nowrap><a href="http://commons.apache.org/logging">Commons Logging</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/commons-math.jar</td><td nowrap>2.0.0</td><td nowrap><a href="http://commons.apache.org/math">Commons Math</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/commons-math.jar</td><td nowrap>2.0</td><td nowrap><a href="http://commons.apache.org/math">Commons Math</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2597,7 +2592,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/crypt.jar</td><td nowrap></td><td nowrap><a href="http://manticore.2y.net/Java/examples/Crypt.html">Manticore UFC Crypt</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
+<td nowrap>lib/portal/crypt.jar</td><td nowrap>1.0</td><td nowrap><a href="http://manticore.2y.net/Java/examples/Crypt.html">Manticore UFC Crypt</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
 <br>
 </td><td></td>
 </tr>
@@ -2637,12 +2632,12 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/freshcookies-security.jar</td><td nowrap>0.6</td><td nowrap><a href="http://freshcookies.org/freshcookies-security">Freshcookies</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/freshcookies-security.jar</td><td nowrap>0.60</td><td nowrap><a href="http://freshcookies.org/freshcookies-security">Freshcookies</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/gif89.jar</td><td nowrap></td><td nowrap><a href="http://jmge.net/java/gifenc">Gif89Encoder</a></td><td nowrap><a href="">GIF89 Public Domain</a>
+<td nowrap>lib/portal/gif89.jar</td><td nowrap>1.0</td><td nowrap><a href="http://jmge.net/java/gifenc">Gif89Encoder</a></td><td nowrap><a href="">GIF89 Public Domain</a>
 <br>
 <a href="http://en.wikipedia.org/wiki/BSD_licenses">BSD Style License</a>
 <br>
@@ -2656,7 +2651,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/hibernate-commons-annotations.jar</td><td nowrap>3.2.0</td><td nowrap><a href="http://www.hibernate.org">Hibernate</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
+<td nowrap>lib/portal/hibernate-commons-annotations.jar</td><td nowrap>3.2.0.Final</td><td nowrap><a href="http://www.hibernate.org">Hibernate</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
 <br>
 </td><td></td>
 </tr>
@@ -2693,7 +2688,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/ical4j.jar</td><td nowrap>1.0</td><td nowrap><a href="http://ical4j.sourceforge.net">iCal4j</a></td><td nowrap><a href="http://en.wikipedia.org/wiki/BSD_licenses">BSD Style License</a>
+<td nowrap>lib/portal/ical4j.jar</td><td nowrap>1.0 RC3</td><td nowrap><a href="http://ical4j.sourceforge.net">iCal4j</a></td><td nowrap><a href="http://en.wikipedia.org/wiki/BSD_licenses">BSD Style License</a>
 <br>
 <copyright-notice>Copyright (c) 2007, Ben Fortuna. All rights reserved.</copyright-notice>
 <br>
@@ -2754,7 +2749,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/javassist.jar</td><td nowrap>3.18.2</td><td nowrap><a href="http://www.csg.is.titech.ac.jp/~chiba/javassist">Javassist</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
+<td nowrap>lib/portal/javassist.jar</td><td nowrap>3.18.2 GA</td><td nowrap><a href="http://www.csg.is.titech.ac.jp/~chiba/javassist">Javassist</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
 <br>
 </td><td></td>
 </tr>
@@ -2796,7 +2791,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/jazzy.jar</td><td nowrap>0.5</td><td nowrap><a href="http://jazzy.sourceforge.net">Jazzy</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
+<td nowrap>lib/portal/jazzy.jar</td><td nowrap>0.5.2-rtext-1.4.1-2</td><td nowrap><a href="http://jazzy.sourceforge.net">Jazzy</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
 <br>
 </td><td></td>
 </tr>
@@ -2806,7 +2801,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/jcifs.jar</td><td nowrap>1.3.14</td><td nowrap><a href="http://jcifs.samba.org">jCIFS</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
+<td nowrap>lib/portal/jcifs.jar</td><td nowrap>1.3.14-kohsuke-1</td><td nowrap><a href="http://jcifs.samba.org">jCIFS</a></td><td nowrap><a href="http://www.gnu.org/licenses/lgpl-2.1.html">LGPL 2.1</a>
 <br>
 </td><td></td>
 </tr>
@@ -2862,7 +2857,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/jhlabs-filters.jar</td><td nowrap></td><td nowrap><a href="http://www.jhlabs.com/ip/filters">JH Labs Java Image Filters</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap>lib/portal/jhlabs-filters.jar</td><td nowrap>01012005</td><td nowrap><a href="http://www.jhlabs.com/ip/filters">JH Labs Java Image Filters</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td>
 					This JAR was bundled with SimpleCaptcha and originally named

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -145,12 +145,10 @@ public class LibraryReferenceTest {
 				jar);
 			String versionsJarsVersion = _versionsJarsVersions.get(jar);
 
-			Assert.assertTrue(
+			Assert.assertEquals(
 				StringBundler.concat(
-					_VERSIONS_EXT_FILE_NAME, " has a reference to ", jar,
-					" with a wrong version, it should be ",
-					libDependencyJarsVersion),
-				Objects.equals(libDependencyJarsVersion, versionsJarsVersion));
+					"Wrong version for ", jar, " in ", _VERSIONS_EXT_FILE_NAME),
+				libDependencyJarsVersion, versionsJarsVersion);
 		}
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -585,7 +585,7 @@ public class LibraryReferenceTest {
 
 		String numericVersion = matcher.group(1);
 		String separator = matcher.group(3);
-		String suffix = matcher.group(4);
+		String suffix = matcher.group(5);
 
 		if (Validator.isNull(numericVersion)) {
 			return suffix;
@@ -648,7 +648,7 @@ public class LibraryReferenceTest {
 		new HashSet<>();
 	private static Path _portalPath;
 	private static final Pattern _versionPattern = Pattern.compile(
-		"(\\d+(\\.\\d+)+)?(\\W)?(.*)");
+		"(\\d+(\\.\\d+)+)?(\\W)?(RELEASE)?(.*)");
 	private static final Set<String> _versionsExtJars = new HashSet<>();
 	private static final Set<String> _versionsJars = new HashSet<>();
 	private static final Map<String, String> _versionsJarsVersions =

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -584,7 +584,6 @@ public class LibraryReferenceTest {
 			matcher.matches());
 
 		String numericVersion = matcher.group(1);
-		String separator = matcher.group(3);
 		String suffix = matcher.group(5);
 
 		if (Validator.isNull(numericVersion)) {
@@ -595,13 +594,18 @@ public class LibraryReferenceTest {
 			return numericVersion;
 		}
 
-		if (!Objects.equals(separator, ".")) {
-			separator = StringPool.SPACE;
+		for (String normalizedVersionSuffix : _normalizedVersionSuffixes) {
+			if (suffix.regionMatches(
+					true, 0, normalizedVersionSuffix, 0,
+					normalizedVersionSuffix.length())) {
 
-			suffix = StringUtil.toUpperCase(suffix);
+				return StringBundler.concat(
+					numericVersion, StringPool.SPACE, normalizedVersionSuffix,
+					suffix.substring(normalizedVersionSuffix.length()));
+			}
 		}
 
-		return numericVersion + separator + suffix;
+		return version;
 	}
 
 	private static final String _ECLIPSE_FILE_NAME = ".classpath";
@@ -646,6 +650,8 @@ public class LibraryReferenceTest {
 	private static final Set<String> _netBeansJars = new HashSet<>();
 	private static final Set<String> _netBeansModuleSourceDirs =
 		new HashSet<>();
+	private static final List<String> _normalizedVersionSuffixes =
+		Arrays.asList("FCS", "GA", "RC");
 	private static Path _portalPath;
 	private static final Pattern _versionPattern = Pattern.compile(
 		"(\\d+(\\.\\d+)+)?(\\W)?(RELEASE)?(.*)");

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -579,7 +579,9 @@ public class LibraryReferenceTest {
 	private String _normalizeVersion(String version) {
 		Matcher matcher = _versionPattern.matcher(version);
 
-		matcher.matches();
+		Assert.assertTrue(
+			_versionPattern.pattern() + " does not match " + version,
+			matcher.matches());
 
 		String numericVersion = matcher.group(1);
 		String separator = matcher.group(3);

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -145,6 +145,10 @@ public class LibraryReferenceTest {
 
 			String libDependencyJarsVersion = _libDependencyJarsVersions.get(
 				jar);
+
+			Assert.assertNotNull(
+				jar + " does not have a version", libDependencyJarsVersion);
+
 			String versionsJarsVersion = _versionsJarsVersions.get(jar);
 
 			Assert.assertEquals(
@@ -573,10 +577,6 @@ public class LibraryReferenceTest {
 	}
 
 	private String _normalizeVersion(String version) {
-		if (Validator.isNull(version)) {
-			return StringPool.BLANK;
-		}
-
 		Matcher matcher = _versionPattern.matcher(version);
 
 		matcher.matches();

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -148,7 +150,8 @@ public class LibraryReferenceTest {
 			Assert.assertEquals(
 				StringBundler.concat(
 					"Wrong version for ", jar, " in ", _VERSIONS_EXT_FILE_NAME),
-				libDependencyJarsVersion, versionsJarsVersion);
+				_normalizeVersion(libDependencyJarsVersion),
+				versionsJarsVersion);
 		}
 	}
 
@@ -569,6 +572,36 @@ public class LibraryReferenceTest {
 		}
 	}
 
+	private String _normalizeVersion(String version) {
+		if (Validator.isNull(version)) {
+			return StringPool.BLANK;
+		}
+
+		Matcher matcher = _versionPattern.matcher(version);
+
+		matcher.matches();
+
+		String numericVersion = matcher.group(1);
+		String separator = matcher.group(2);
+		String suffix = matcher.group(3);
+
+		if (Validator.isNull(numericVersion)) {
+			return suffix;
+		}
+
+		if (Validator.isNull(suffix)) {
+			return numericVersion;
+		}
+
+		if (!Objects.equals(separator, ".")) {
+			separator = StringPool.SPACE;
+
+			suffix = StringUtil.toUpperCase(suffix);
+		}
+
+		return numericVersion + separator + suffix;
+	}
+
 	private static final String _ECLIPSE_FILE_NAME = ".classpath";
 
 	private static final String _GIT_IGNORE_FILE_NAME =
@@ -612,6 +645,8 @@ public class LibraryReferenceTest {
 	private static final Set<String> _netBeansModuleSourceDirs =
 		new HashSet<>();
 	private static Path _portalPath;
+	private static final Pattern _versionPattern = Pattern.compile(
+		"(\\d+(?:\\.\\d+)+)?(\\W)?(.*)");
 	private static final Set<String> _versionsExtJars = new HashSet<>();
 	private static final Set<String> _versionsJars = new HashSet<>();
 	private static final Map<String, String> _versionsJarsVersions =

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -582,8 +582,8 @@ public class LibraryReferenceTest {
 		matcher.matches();
 
 		String numericVersion = matcher.group(1);
-		String separator = matcher.group(2);
-		String suffix = matcher.group(3);
+		String separator = matcher.group(3);
+		String suffix = matcher.group(4);
 
 		if (Validator.isNull(numericVersion)) {
 			return suffix;
@@ -646,7 +646,7 @@ public class LibraryReferenceTest {
 		new HashSet<>();
 	private static Path _portalPath;
 	private static final Pattern _versionPattern = Pattern.compile(
-		"(\\d+(?:\\.\\d+)+)?(\\W)?(.*)");
+		"(\\d+(\\.\\d+)+)?(\\W)?(.*)");
 	private static final Set<String> _versionsExtJars = new HashSet<>();
 	private static final Set<String> _versionsJars = new HashSet<>();
 	private static final Map<String, String> _versionsJarsVersions =

--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -399,7 +399,8 @@ public class LibraryReferenceTest {
 							continue;
 						}
 
-						String[] dependencyArray = dependency.split(":");
+						String[] dependencyArray = StringUtil.split(
+							dependency, CharPool.COLON);
 
 						if (dependencyArray.length < 3) {
 							continue;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-104116

Same code than https://github.com/brianchandotcom/liferay-portal/pull/80618 but I have added following changes requested by Brian in following comment: https://github.com/brianchandotcom/liferay-portal/pull/80618#issuecomment-552680282

1. **Commit https://github.com/liferay/liferay-portal/commit/e7dd995883efd5975dad700f85669ece59371443** - "RELEASE" suffix is removed during version normalization, so for example Spring will be **4.1.9** in `version-ext.xml`, but it is **4.1.9.RELEASE** in `dependencies.properties`
2. **Commit https://github.com/liferay/liferay-portal/commit/53a7d198be61c02f3fb9bd6dc021f6bd7832b24e** - Only normalize the suffixes that are specified in `_normalizedVersionSuffixes` list (FCS, GA, and RC), so **1.5rc3** is changed to **1.5 RC3** but **1.1.4c** remains unmodified.