### PR TITLE
Adds JS escape on getCanonicalURL

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -194,7 +194,7 @@
 				String completeURL = PortalUtil.getCurrentCompleteURL(request);
 				%>
 
-				return '<%= PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout, false, false) %>';
+				return '<%= HtmlUtil.escapeJS(PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout, false, false)) %>';
 			},
 			getCDNBaseURL: function() {
 				return '<%= themeDisplay.getCDNBaseURL() %>';


### PR DESCRIPTION
Protection against XSS vulnerability (JavaScript injections) on friendly urls like this one: http://localhost:8080/web/guest/-/unknownpage'.substring(0,1);x='