### PR TITLE
Optimize countFieldRepetition() for getContent()

### DIFF
--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalConverterImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalConverterImpl.java
@@ -144,9 +144,14 @@ public class JournalConverterImpl implements JournalConverter {
 
 		DDMFieldsCounter ddmFieldsCounter = new DDMFieldsCounter();
 
+		Field fieldsDisplayField = ddmFields.get(DDMImpl.FIELDS_DISPLAY_NAME);
+
+		String[] fieldsDisplayValues = getDDMFieldsDisplayValues(
+			fieldsDisplayField);
+
 		for (String fieldName : ddmStructure.getRootFieldNames()) {
 			int repetitions = countFieldRepetition(
-				ddmFields, fieldName, null, -1);
+				ddmFields, fieldName, null, -1, fieldsDisplayValues);
 
 			for (int i = 0; i < repetitions; i++) {
 				Element dynamicElementElement = rootElement.addElement(
@@ -364,6 +369,7 @@ public class JournalConverterImpl implements JournalConverter {
 		}
 	}
 
+	@Deprecated
 	protected int countFieldRepetition(
 			Fields ddmFields, String fieldName, String parentFieldName,
 			int parentOffset)
@@ -373,6 +379,15 @@ public class JournalConverterImpl implements JournalConverter {
 
 		String[] fieldsDisplayValues = getDDMFieldsDisplayValues(
 			fieldsDisplayField);
+
+		return countFieldRepetition(ddmFields, fieldName, parentFieldName,
+				parentOffset, fieldsDisplayValues);
+	}
+
+	protected int countFieldRepetition(
+			Fields ddmFields, String fieldName, String parentFieldName,
+			int parentOffset, String[] fieldsDisplayValues)
+		throws Exception {
 
 		int offset = -1;
 


### PR DESCRIPTION
getContent() will take 30+ minutes to run on a 2024 field Web Content, because each call to countFieldRepetition() repeats the same call to getDDMFieldsDisplayValues(). This optimization calls getDDMFieldsDisplayValues() only once per getContent(), and the same 2024 field Web Content takes about 7 seconds.