### PR TITLE
LPS-107933 Blacklist modules with null symbolicName to avoid NPEs

### DIFF
--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklist.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklist.java
@@ -183,6 +183,21 @@ public class BundleBlacklist {
 	private boolean _processBundle(Bundle bundle) {
 		String symbolicName = bundle.getSymbolicName();
 
+		if (symbolicName == null) {
+			_log.error(
+				bundle.getLocation() +
+					" has a null symbolicName, it will be blacklisted");
+
+			try {
+				bundle.uninstall();
+			}
+			catch (Exception exception) {
+				_log.error("Unable to uninstall " + bundle, exception);
+			}
+
+			return true;
+		}
+
 		if (_blacklistBundleSymbolicNames.contains(symbolicName)) {
 			if (_log.isInfoEnabled()) {
 				_log.info("Stopping blacklisted bundle " + bundle);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-107933

Several NPE exceptions are thrown during startup in case a non-osgi jar is deployed to Liferay

This problem is caused only in case the jar file has a valid /META-INF/MANIFEST.MF file but it doesn't have any of the OSGI information entries (Bundle-SymbolicName, Bundle-Name, etc...)

So at the end we have a jar file deployed without Bundle-SymbolicName, that causes lots of NPEs

As a solution, I think we can blacklist those loaded osgi modules that are not correct.