### PR TITLE
LPS-106908 We need the instanceId in non instanceable widgets because of personalization, so treat it like we do when adding the widgets through d&d. RuntimeTag handles instanceId with values 0

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -196,8 +196,14 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 
 			String id = element.attr("id");
 
-			String instanceId = _getInstanceId(
-				fragmentEntryLink.getNamespace(), id);
+			Portlet portlet = _portletLocalService.getPortletById(portletName);
+
+			String instanceId = String.valueOf(CharPool.NUMBER_0);
+
+			if (portlet.isInstanceable()) {
+				instanceId = _getInstanceId(
+					fragmentEntryLink.getNamespace(), id);
+			}
 
 			if (segmentsExperienceIdOptionalLong == null) {
 				segmentsExperienceIdOptionalLong =
@@ -221,9 +227,6 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 					StringPool.BLANK, fragmentEntryProcessorContext);
 			}
 			else {
-				Portlet portlet = _portletLocalService.getPortletById(
-					portletName);
-
 				defaultPreferences = portlet.getDefaultPreferences();
 			}
 


### PR DESCRIPTION
\cc @jkappler @ChrisKian