### PR TITLE
Escape language translation in javascript context in Asset Publisher

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
@@ -62,7 +62,7 @@ AssetListEntry assetListEntry = assetPublisherDisplayContext.fetchAssetListEntry
 					eventName:
 						'<%= assetPublisherDisplayContext.getSelectAssetListEventName() %>',
 					id: '<portlet:namespace />selectAssetList',
-					title: '<liferay-ui:message key="select-content-set" />',
+					title: '<liferay-ui:message key="select-content-set" unicode="true" />',
 					uri:
 						'<%= assetPublisherDisplayContext.getAssetListSelectorURL() %>'
 				},


### PR DESCRIPTION
In French the original file bugs and prevents administrators to select a content set in Asset Publisher configuration.
Escaping of the language translation in Javascript context (Unicode escaping) is needed.
Versions: 7.2.x, 7.3.x, master