### PR TITLE
LPS-107191 Deploying recharts module on ant all

### DIFF
--- a/modules/modules.properties
+++ b/modules/modules.properties
@@ -50,6 +50,7 @@ bundle.symbolic.name[frontend-js-lodash-web]=com.liferay.frontend.js.lodash.web
 bundle.symbolic.name[frontend-js-metal-web]=com.liferay.frontend.js.metal.web
 bundle.symbolic.name[frontend-js-node-shims]=com.liferay.frontend.js.node.shims
 bundle.symbolic.name[frontend-js-react-web]=com.liferay.frontend.js.react.web
+bundle.symbolic.name[frontend-js-recharts]=com.liferay.frontend.js.recharts
 bundle.symbolic.name[frontend-js-spa-web]=com.liferay.frontend.js.spa.web
 bundle.symbolic.name[frontend-js-tabs-support-web]=com.liferay.frontend.js.tabs.support.web
 bundle.symbolic.name[frontend-js-tooltip-support-web]=com.liferay.frontend.js.tooltip.support.web


### PR DESCRIPTION
We were not deploying `frontend-js-recharts` when _ant-all_ing.
It's not a big deal because the only module using it, `analytics-reports-web`, is not deployed with the ant all.

This tries to solve that.

Does this make any sense.


cc/ @darquesdev @wincent 