### PR TITLE
Fix Notifications Configuration for unmodifiable Delivery Types

### DIFF
--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/configuration.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/configuration.jsp
@@ -111,8 +111,8 @@
 												UserNotificationDelivery userNotificationDelivery = UserNotificationDeliveryLocalServiceUtil.getUserNotificationDelivery(themeDisplay.getUserId(), entry.getKey(), userNotificationDefinition.getClassNameId(), userNotificationDefinition.getNotificationType(), userNotificationDeliveryType.getType(), userNotificationDeliveryType.isDefault());
 
 												if(userNotificationDeliveryType.isModifiable()) {
-                          userNotificationDeliveryIds.add(userNotificationDelivery.getUserNotificationDeliveryId());
-                        }
+													userNotificationDeliveryIds.add(userNotificationDelivery.getUserNotificationDeliveryId());
+												}
 											%>
 
 												<td class="lfr-<%= userNotificationDeliveryType.getName() %>-column">

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/configuration.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/configuration.jsp
@@ -110,7 +110,9 @@
 
 												UserNotificationDelivery userNotificationDelivery = UserNotificationDeliveryLocalServiceUtil.getUserNotificationDelivery(themeDisplay.getUserId(), entry.getKey(), userNotificationDefinition.getClassNameId(), userNotificationDefinition.getNotificationType(), userNotificationDeliveryType.getType(), userNotificationDeliveryType.isDefault());
 
-												userNotificationDeliveryIds.add(userNotificationDelivery.getUserNotificationDeliveryId());
+												if(userNotificationDeliveryType.isModifiable()) {
+                          userNotificationDeliveryIds.add(userNotificationDelivery.getUserNotificationDeliveryId());
+                        }
 											%>
 
 												<td class="lfr-<%= userNotificationDeliveryType.getName() %>-column">


### PR DESCRIPTION
When you create a custom UserNotificationDeliveryType which has `modifiable = false` and `defaultValue = true`, these show as turned on but not user modifiable in the Configuration for the Notifications portlet.

However, on saving the configuration form, the UserNotificationDeliveryType gets turned off, because the Liferay form has POSTed the delivery type ID but no checkbox value `true` as the form input is disabled. This should not happen as the user was not meant to be able to modify the delivery type.

It's difficult to explain, but the backend code is at: https://github.com/liferay/liferay-portal/blob/7.2.x/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java#L301

It loops through all delivery type IDs that were displayed on the page, gets the value for each delivery type ID, and updates that value into the DB. When a delivery type ID is not modifiable, its input checkbox is disabled, and therefore will never POST a `true` value even if it is turned on. Therefore the result is that it gets saved to a value of `false` no matter what the user wanted nor what they were allowed to do.

This patch checks whether the UserNotificationDeliveryType is modifiable before adding in to the list of delivery type IDs. Therefore only the delivery types that are modifiable will be added to the list, so only the modifiable ones can be updated in the DB.

Note that this fix helps against the normal user case; however an advanced user manipulating the POST response will still be able to change a non-modifiable UserNotificationDeliveryType. A backend fix will also be necessary to prevent that - where the UserNotificationDeliveryType `isModifiable()` method is checked prior to calling `_updateUserNotificationDelivery()`.