### PR TITLE
Lps 109525

### DIFF
--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -57,13 +57,6 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 			MBDiscussion.class.getName() + StringPool.UNDERLINE +
 				_oldSubscriptionClassName;
 
-		int count = _subscriptionLocalService.getSubscriptionsCount(
-			newSubscriptionClassName);
-
-		if (count > 0) {
-			return;
-		}
-
 		List<Subscription> subscriptions =
 			_subscriptionLocalService.getSubscriptions(
 				_oldSubscriptionClassName);

--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:bulk:bulk-selection-api")
 	compileOnly project(":apps:changeset:changeset-api")
+	compileOnly project(":apps:comment:comment-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:document-library:document-library-file-rank-api")
 	compileOnly project(":apps:document-library:document-library-sync-api")

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.internal.upgrade;
 
+import com.liferay.comment.upgrade.UpgradeDiscussionSubscriptionClassName;
 import com.liferay.document.library.internal.upgrade.v1_0_0.UpgradeDocumentLibrary;
 import com.liferay.document.library.internal.upgrade.v1_0_1.UpgradeDLConfiguration;
 import com.liferay.document.library.internal.upgrade.v1_0_1.UpgradeDLFileEntryConfiguration;
@@ -23,8 +24,10 @@ import com.liferay.document.library.internal.upgrade.v2_0_0.UpgradeCompanyId;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeViewCount;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.subscription.service.SubscriptionLocalService;
 import com.liferay.view.count.service.ViewCountEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
@@ -56,6 +59,13 @@ public class DLServiceUpgrade implements UpgradeStepRegistrator {
 			"2.0.0", "3.0.0",
 			new UpgradeViewCount(
 				"DlFileEntry", DLFileEntry.class, "fileEntryId", "readCount"));
+
+		registry.register(
+			"3.0.0", "3.0.1",
+			new UpgradeDiscussionSubscriptionClassName(
+				_subscriptionLocalService, DLFileEntry.class.getName(),
+				UpgradeDiscussionSubscriptionClassName.DeletionMode.
+					DELETE_OLD));
 	}
 
 	@Reference
@@ -64,6 +74,9 @@ public class DLServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Reference(target = "(dl.store.upgrade=true)")
 	private Store _store;
+
+	@Reference
+	private SubscriptionLocalService _subscriptionLocalService;
 
 	@Reference
 	private ViewCountEntryLocalService _viewCountEntryLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
@@ -53,7 +53,9 @@ public class DLServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register("1.0.2", "1.1.0", new UpgradeSchema());
 
-		registry.register("1.1.0", "2.0.0", new UpgradeCompanyId());
+		registry.register("1.1.0", "1.1.1", new DummyUpgradeStep());
+
+		registry.register("1.1.1", "2.0.0", new UpgradeCompanyId());
 
 		registry.register(
 			"2.0.0", "3.0.0",


### PR DESCRIPTION
Hello @robertoDiaz 

https://issues.liferay.com/browse/LPS-109525

This adds an upgrade for Document Library comment subscriptions that were added in LPS-85419.

4e13e23 - This commit is needed in cases when a database has been upgraded and new subscriptions have been added before this upgrade is added. In situations like this, we will never upgrade the old subscriptions as at least 1 subscription with the new className exists. I have added a database backup on LPS-109525 demonstrating this. I want to also note when adding a subscription, we first try to fetch an existing subscription with the same parameters, if one exists, we do not add a new subscription so we do not have a chance of a duplicate value exception without the code I removed

/cc @achaparro 