### PR TITLE
LPS-109080 Incorrect localisation suffix of search index for Documents and Media

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -406,6 +406,7 @@ renderResponse.setTitle(headerTitle);
 													classNameId="<%= PortalUtil.getClassNameId(com.liferay.dynamic.data.mapping.model.DDMStructure.class) %>"
 													classPK="<%= ddmStructure.getPrimaryKey() %>"
 													ddmFormValues="<%= ddmFormValues %>"
+													defaultLocale="<%= LocaleUtil.fromLanguageId(ddmStructure.getDefaultLanguageId()) %>"
 													fieldsNamespace="<%= String.valueOf(ddmStructure.getPrimaryKey()) %>"
 													groupId="<%= (fileEntry != null) ? fileEntry.getGroupId() : 0 %>"
 													localizable="<%= localizable %>"


### PR DESCRIPTION
Hi @robertoDiaz 
Could you please review this pull request?
The parameter defaultLocale on the taglib invoked on edit_file_entry.jsp will make the value of this parameter be the default locale of the DDMForm, as you can see on

 https://github.com/liferay/liferay-portal/blob/1dd97af5f9231440440e430ab0984555c50b7a3e/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp#L139-L140.

Therefore, probably, this is the locale being used to perform the indexation, but it would be important to confirm it. Consequently, this could be a solution.
Thank you and best regards,
Marci