### PR TITLE
workflowContext should be a unmodifiable map

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-scripting-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/scripting/internal/util/ScriptingContextBuilderImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-scripting-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/scripting/internal/util/ScriptingContextBuilderImpl.java
@@ -61,7 +61,8 @@ public class ScriptingContextBuilderImpl implements ScriptingContextBuilder {
 		inputObjects.putAll(workflowContext);
 		inputObjects.put(
 			"kaleoInstanceToken", executionContext.getKaleoInstanceToken());
-		inputObjects.put("workflowContext", workflowContext);
+		inputObjects.put("workflowContext",
+			java.util.Collections.unmodifiableMap(workflowContext));
 
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
 			executionContext.getKaleoTaskInstanceToken();


### PR DESCRIPTION
The design of workflowContext in KaleoInstance is not fork/thread/cluster safe. There is no database row level locking to prevent dirty reads from and competing writes to workflowContext as a Map or as a string. This also applies to Java code and KaleoTaskInstanceToken.workflowContext and KaleoTimerInstanceToken.workflowContext. Liferay should add explicit declaration of this design and behavior in documentations like https://help.liferay.com/hc/en-us/articles/360028818852-Leveraging-the-Script-Engine-in-Workflow