### PR TITLE
Line 170 should use startsWith() to match line 172

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java
@@ -167,7 +167,7 @@ public class AutoLoginFilter extends BasePortalFilter {
 			httpServletRequest.getRequestURI());
 
 		if (!contextPath.equals(StringPool.SLASH) &&
-			path.contains(contextPath)) {
+			path.startsWith(contextPath)) {
 
 			path = path.substring(contextPath.length());
 		}


### PR DESCRIPTION
Line 172 path.substring(contextPath.length()) only extract from the beginning of the string, no in the middle, which could happen if line 170 is path.startsWith(contextPath).