### PR TITLE
LPS-115061 Cannot submit Dynamic Data List with a required field in a non-default language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorImpl.java
@@ -232,12 +232,16 @@ public class DDMFormValuesValidatorImpl implements DDMFormValuesValidator {
 		DDMFormFieldValueAccessor<?> ddmFormFieldValueAccessor =
 			getDDMFormFieldValueAccessor(ddmFormField.getType());
 
-		for (Locale availableLocale : value.getAvailableLocales()) {
-			if (ddmFormFieldValueAccessor.isEmpty(
-					ddmFormFieldValue, availableLocale)) {
+		if (value.getAvailableLocales().size() != 0) {
+			for (Locale availableLocale : value.getAvailableLocales()) {
+				if (!ddmFormFieldValueAccessor.isEmpty(
+						ddmFormFieldValue, availableLocale)) {
 
-				return true;
+					return false;
+				}
 			}
+
+			return true;
 		}
 
 		return false;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/test/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/test/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorTest.java
@@ -508,7 +508,7 @@ public class DDMFormValuesValidatorTest {
 
 		LocalizedValue localizedValue = new LocalizedValue(LocaleUtil.US);
 
-		localizedValue.addString(LocaleUtil.US, StringUtil.randomString());
+		localizedValue.addString(LocaleUtil.US, StringPool.BLANK);
 		localizedValue.addString(LocaleUtil.BRAZIL, StringPool.BLANK);
 
 		DDMFormFieldValue ddmFormFieldValue =


### PR DESCRIPTION
Hi @natocesarrego ,
Could you please review this pull request?
In LPS-112800 The concept of null had changed. Now you can send a form with empty default locale value if you enabled localisation, but I forget to update the tests and checks .
Thank you and best regards,
Marci