### PR TITLE
LPS-112467 Updates Clay Link Tag to a Java-based tag

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -53,7 +53,8 @@
 													%>
 
 													<clay:link
-														buttonStyle="borderless"
+														borderless="<%= true %>"
+														button="<%= true %>"
 														href="<%= editVocabularyURL.toString() %>"
 														icon="plus"
 													/>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -33,10 +33,14 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 
 			<div class="btn-group-item">
 				<clay:link
-					elementClasses="btn btn-outline-borderless btn-outline-secondary btn-sm"
+					borderless="<%= true %>"
+					button="<%= true %>"
+					displayType="secondary"
 					href="<%= rssURL.toString() %>"
 					icon="rss-full"
-					label='<%= LanguageUtil.get(request, "rss") %>'
+					label="rss"
+					outline="<%= true %>"
+					small="<%= true %>"
 				/>
 			</div>
 
@@ -53,10 +57,11 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 					</portlet:actionURL>
 
 					<clay:link
-						buttonStyle="secondary"
-						elementClasses="btn-sm"
+						button="<%= true %>"
+						displayType="secondary"
 						href="<%= unsubscribeURL %>"
-						label='<%= LanguageUtil.get(request, "unsubscribe") %>'
+						label="unsubscribe"
+						small="<%= true %>"
 					/>
 				</c:when>
 				<c:otherwise>
@@ -65,10 +70,11 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 					</portlet:actionURL>
 
 					<clay:link
-						buttonStyle="secondary"
-						elementClasses="btn-sm"
+						button="<%= true %>"
+						displayType="secondary"
 						href="<%= subscribeURL %>"
-						label='<%= LanguageUtil.get(request, "subscribe") %>'
+						label="subscribe"
+						small="<%= true %>"
 					/>
 				</c:otherwise>
 			</c:choose>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -29,10 +29,13 @@ BlogsGroupServiceOverriddenConfiguration blogsGroupServiceOverriddenConfiguratio
 
 		<div class="btn-group-item">
 			<clay:link
-				elementClasses="btn btn-outline-borderless btn-outline-secondary btn-sm"
+				borderless="<%= true %>"
+				button="<%= true %>"
+				displayType="secondary"
 				href="<%= rssURL %>"
 				icon="rss-full"
-				label='<%= LanguageUtil.get(request, "rss") %>'
+				label="rss"
+				small="<%= true %>"
 			/>
 		</div>
 
@@ -55,10 +58,11 @@ BlogsGroupServiceOverriddenConfiguration blogsGroupServiceOverriddenConfiguratio
 					</portlet:actionURL>
 
 					<clay:link
-						buttonStyle="secondary"
-						elementClasses="btn-sm"
+						button="<%= true %>"
+						displayType="secondary"
 						href="<%= unsubscribeURL %>"
-						label='<%= LanguageUtil.get(request, "unsubscribe") %>'
+						label="unsubscribe"
+						small="<%= true %>"
 					/>
 				</c:when>
 				<c:otherwise>
@@ -68,10 +72,11 @@ BlogsGroupServiceOverriddenConfiguration blogsGroupServiceOverriddenConfiguratio
 					</portlet:actionURL>
 
 					<clay:link
-						buttonStyle="secondary"
-						elementClasses="btn-sm"
+						button="<%= true %>"
+						displayType="secondary"
 						href="<%= subscribeURL %>"
-						label='<%= LanguageUtil.get(request, "subscribe") %>'
+						label="subscribe"
+						small="<%= true %>"
 					/>
 				</c:otherwise>
 			</c:choose>
@@ -90,10 +95,11 @@ BlogsGroupServiceOverriddenConfiguration blogsGroupServiceOverriddenConfiguratio
 
 		<div class="btn-group-item">
 			<clay:link
-				buttonStyle="primary"
-				elementClasses="btn-sm"
+				button="<%= true %>"
+				displayType="primary"
 				href="<%= editEntryURL.toString() %>"
-				label='<%= LanguageUtil.get(request, "new-entry") %>'
+				label="new-entry"
+				small="<%= true %>"
 			/>
 		</div>
 	</c:if>

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -130,14 +130,9 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 
 									<clay:link
 										ariaLabel='<%= LanguageUtil.format(request, "in-reply-to-x", HtmlUtil.escape(parentDiscussionComment.getUserName()), false) %>'
-										data='<%=
-											HashMapBuilder.put(
-												"inreply-content", parentDiscussionComment.getBody()
-											).put(
-												"inreply-title", parentCommentUserBuffer
-											).build()
-										%>'
-										elementClasses="lfr-discussion-parent-link"
+										cssClass="lfr-discussion-parent-link"
+										data-inreply-content="<%= HtmlUtil.escapeAttribute(parentDiscussionComment.getBody()) %>"
+										data-inreply-title="<%= HtmlUtil.escapeAttribute(parentCommentUserBuffer) %>"
 										href='<%= "#" + randomNamespace + "message_" + parentDiscussionComment.getCommentId() %>'
 										icon="redo"
 										label="<%= HtmlUtil.escape(parentDiscussionComment.getUserName()) %>"

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -38,7 +38,6 @@ page import="com.liferay.portal.kernel.service.*" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.HttpUtil" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ct_display/render_file_version.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ct_display/render_file_version.jsp
@@ -42,11 +42,12 @@ DLFileVersion dlFileVersion = (DLFileVersion)request.getAttribute(WebKeys.DOCUME
 
 <p>
 	<clay:link
-		buttonStyle="primary"
-		elementClasses="btn-sm"
+		button="<%= true %>"
+		displayType="primary"
 		href="<%= displayContext.getDownloadURL(dlFileVersion.getVersion(), dlFileVersion.getSize(), dlFileVersion.getFileName()) %>"
 		icon="download"
-		label='<%= LanguageUtil.get(resourceBundle, "download") %>'
+		label="download"
+		small="<%= true %>"
 		title='<%= LanguageUtil.format(resourceBundle, "file-size-x", LanguageUtil.formatStorageSize(dlFileVersion.getSize(), locale), false) %>'
 	/>
 </p>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
@@ -69,20 +69,14 @@ FileVersion fileVersion = (FileVersion)request.getAttribute("file_entry_upper_tb
 
 				<c:if test="<%= dlViewFileVersionDisplayContext.isDownloadLinkVisible() %>">
 					<li class="d-none d-sm-flex tbar-item">
-
-						<%
-						Map<String, String> data = HashMapBuilder.put(
-							"analytics-file-entry-id", String.valueOf(fileEntry.getFileEntryId())
-						).build();
-						%>
-
 						<clay:link
-							buttonStyle="primary"
-							data="<%= data %>"
-							elementClasses="btn-sm"
+							button="<%= true %>"
+							data-analytics-file-entry-id="<%= fileEntry.getFileEntryId() %>"
+							displayType="primary"
 							href="<%= DLURLHelperUtil.getDownloadURL(fileEntry, fileVersion, themeDisplay, StringPool.BLANK, false, true) %>"
 							icon="download"
-							label='<%= LanguageUtil.get(resourceBundle, "download") %>'
+							label="download"
+							small="<%= true %>"
 							title='<%= LanguageUtil.format(resourceBundle, "file-size-x", LanguageUtil.formatStorageSize(fileVersion.getSize(), locale), false) %>'
 						/>
 					</li>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -179,20 +179,14 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 											</div>
 										</c:when>
 										<c:otherwise>
-
-											<%
-											Map<String, String> data = HashMapBuilder.put(
-												"analytics-file-entry-id", String.valueOf(fileEntry.getFileEntryId())
-											).build();
-											%>
-
 											<div class="btn-group-item">
 												<clay:link
-													buttonStyle="primary"
-													data="<%= data %>"
-													elementClasses="btn-sm"
+													button="<%= true %>"
+													data-analytics-file-entry-id="<%= fileEntry.getFileEntryId() %>"
+													displayType="primary"
 													href="<%= DLURLHelperUtil.getDownloadURL(fileEntry, fileVersion, themeDisplay, StringPool.BLANK, false, true) %>"
-													label='<%= LanguageUtil.get(resourceBundle, "download") %>'
+													label="download"
+													small="<%= true %>"
 													title='<%= LanguageUtil.format(resourceBundle, "file-size-x", LanguageUtil.formatStorageSize(fileVersion.getSize(), locale), false) %>'
 												/>
 											</div>
@@ -202,10 +196,11 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 								<c:otherwise>
 									<div class="btn-group-item" data-analytics-file-entry-id="<%= String.valueOf(fileEntry.getFileEntryId()) %>">
 										<clay:link
-											buttonStyle="primary"
-											elementClasses="btn-sm"
+											button="<%= true %>"
+											displayType="primary"
 											href="<%= DLURLHelperUtil.getDownloadURL(fileEntry, fileVersion, themeDisplay, StringPool.BLANK, false, true) %>"
-											label='<%= LanguageUtil.get(resourceBundle, "download") %>'
+											label="download"
+											small="<%= true %>"
 											title='<%= LanguageUtil.format(resourceBundle, "file-size-x", LanguageUtil.formatStorageSize(fileVersion.getSize(), locale), false) %>'
 										/>
 									</div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_location.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_location.jsp
@@ -43,10 +43,10 @@ long parentFolderId = (parentFolder == null) ? DLFolderConstants.DEFAULT_PARENT_
 		%>
 
 		<clay:link
+			displayType="secondary"
 			href="<%= viewFolderURL.toString() %>"
 			icon="folder"
-			label='<%= (parentFolderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) ? LanguageUtil.get(request, "home") : parentFolder.getName() %>'
-			style="secondary"
+			label='<%= (parentFolderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) ? "home" : parentFolder.getName() %>'
 		/>
 	</dd>
 </c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_info.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_info.jsp
@@ -75,21 +75,25 @@ List<Folder> mountFolders = DLAppServiceUtil.getMountFolders(scopeGroupId, DLFol
 
 			<c:if test="<%= (mountFolders.size() == 0) && (folder != null) %>">
 				<clay:link
-					buttonStyle="secondary"
-					elementClasses='<%= "btn-sm" + ((searchFolderId == rootFolderId) ? " active" : "") %>'
+					button="<%= true %>"
+					cssClass='<%= (searchFolderId == rootFolderId) ? "active" : "" %>'
+					displayType="secondary"
 					href="<%= searchEverywhereURL.toString() %>"
-					label='<%= LanguageUtil.get(resourceBundle, "everywhere") %>'
-					title='<%= LanguageUtil.get(resourceBundle, "everywhere") %>'
+					label="everywhere"
+					small="<%= true %>"
+					title="everywhere"
 				/>
 			</c:if>
 
 			<c:if test="<%= folder != null %>">
 				<clay:link
-					buttonStyle="secondary"
-					elementClasses='<%= "btn-sm" + ((searchFolderId == folder.getFolderId()) ? " active" : "") %>'
+					button="<%= true %>"
+					cssClass='<%= (searchFolderId == folder.getFolderId()) ? "active" : "" %>'
+					displayType="secondary"
 					href="<%= searchFolderURL.toString() %>"
 					icon="folder"
 					label="<%= folder.getName() %>"
+					small="<%= true %>"
 					title="<%= folder.getName() %>"
 				/>
 			</c:if>
@@ -104,12 +108,14 @@ List<Folder> mountFolders = DLAppServiceUtil.getMountFolders(scopeGroupId, DLFol
 				%>
 
 				<clay:link
-					buttonStyle="secondary"
-					elementClasses='<%= "btn-sm" + (((searchRepositoryId == scopeGroupId) && (searchFolderId == rootFolderId)) ? " active" : "") %>'
+					button="<%= true %>"
+					cssClass='<%= ((searchRepositoryId == scopeGroupId) && (searchFolderId == rootFolderId)) ? "active" : "" %>'
+					displayType="secondary"
 					href="<%= searchRepositoryURL.toString() %>"
 					icon="repository"
-					label='<%= LanguageUtil.get(request, "local") %>'
-					title='<%= LanguageUtil.get(request, "local") %>'
+					label="local"
+					small="<%= true %>"
+					title="local"
 				/>
 
 				<%
@@ -120,11 +126,13 @@ List<Folder> mountFolders = DLAppServiceUtil.getMountFolders(scopeGroupId, DLFol
 				%>
 
 					<clay:link
-						buttonStyle="secondary"
-						elementClasses='<%= "btn-sm" + ((mountFolder.getFolderId() == searchFolderId) ? " active" : "") %>'
+						button="<%= true %>"
+						cssClass='<%= (mountFolder.getFolderId() == searchFolderId) ? "active" : "" %>'
+						displayType="secondary"
 						href="<%= searchRepositoryURL.toString() %>"
 						icon="repository"
 						label="<%= mountFolder.getName() %>"
+						small="<%= true %>"
 						title="<%= mountFolder.getName() %>"
 					/>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_preview_error.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_preview_error.jsp
@@ -31,9 +31,10 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 			</p>
 
 			<clay:link
-				buttonStyle="secondary"
+				button="<%= true %>"
+				displayType="secondary"
 				href="<%= DLURLHelperUtil.getDownloadURL(fileVersion.getFileEntry(), fileVersion, themeDisplay, StringPool.BLANK) %>"
-				label='<%= LanguageUtil.get(resourceBundle, "download") %>'
+				label="download"
 				title='<%= LanguageUtil.format(resourceBundle, "file-size-x", LanguageUtil.formatStorageSize(fileVersion.getSize(), locale), false) %>'
 			/>
 		</div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
@@ -58,10 +58,11 @@ advancedPublishURL.setParameter("privateLayout", String.valueOf(privateLayout));
 	cssClass="mt-2 publish-navbar text-right"
 >
 	<clay:link
-		buttonStyle="link"
-		elementClasses="btn-sm"
+		button="<%= true %>"
+		displayType="link"
 		href="<%= advancedPublishURL.toString() %>"
-		label='<%= LanguageUtil.get(request, "switch-to-advanced-publication") %>'
+		label="switch-to-advanced-publication"
+		small="<%= true %>"
 	/>
 </clay:container-fluid>
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
@@ -159,10 +159,11 @@ simplePublishURL.setParameter("targetGroupId", String.valueOf(liveGroupId));
 
 			<clay:content-col>
 				<clay:link
-					buttonStyle="link"
-					elementClasses="btn-sm"
+					button="<%= true %>"
+					displayType="link"
 					href="<%= simplePublishURL.toString() %>"
-					label='<%= LanguageUtil.get(request, "switch-to-simple-publication") %>'
+					label="switch-to-simple-publication"
+					small="<%= true %>"
 				/>
 			</clay:content-col>
 		</clay:content-row>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/entries/fragment_entries_generator.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/entries/fragment_entries_generator.jsp
@@ -18,12 +18,14 @@
 
 <label class="align-baseline mb-0 mr-3">
 	<clay:link
-		buttonStyle="outline-secondary"
-		elementClasses="btn-sm"
+		button="<%= true %>"
+		displayTye="secondary"
 		href="https://github.com/liferay/generator-liferay-fragments#liferay-fragments-cli"
 		icon="download"
-		label='<%= LanguageUtil.get(resourceBundle, "fragments-toolkit") %>'
+		label="fragments-toolkit"
+		outline="<%= true %>"
+		small="<%= true %>"
 		target="_blank"
-		title='<%= LanguageUtil.get(resourceBundle, "fragments-toolkit") %>'
+		title="fragments-toolkit"
 	/>
 </label>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/entries/init.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/entries/init.jsp
@@ -17,6 +17,4 @@
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
-
 <liferay-frontend:defineObjects />

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -58,7 +58,8 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 											<li>
 												<c:if test="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) %>">
 													<clay:link
-														buttonStyle="borderless"
+														borderless="<%= true %>"
+														button="<%= true %>"
 														href="<%= editFragmentCollectionURL %>"
 														icon="plus"
 													/>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,12 +24,10 @@ page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.contex
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.DropdownsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ManagementToolbarsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.NavigationBarsDisplayContext" %><%@
-page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %>
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption" %>
 
 <%@ page import="java.util.ArrayList" %><%@
-page import="java.util.List" %><%@
-page import="java.util.Map" %>
+page import="java.util.List" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/links.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/links.jsp
@@ -26,14 +26,8 @@
 	<p>Used for stand-alone hyperlinks. Can be a text or an image.</p>
 </blockquote>
 
-<%
-Map<String, String> data = HashMapBuilder.put(
-	"customProperty", "customValue"
-).build();
-%>
-
 <clay:link
-	data="<%= data %>"
+	data-custom-property="customValue"
 	href="#"
 	label="link text"
 />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class LinkTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setContainerElement("a");
+
+		if (Validator.isNotNull(_ariaLabel)) {
+			setDynamicAttribute(StringPool.BLANK, "aria-label", _ariaLabel);
+		}
+
+		if (Validator.isNotNull(_href)) {
+			setDynamicAttribute(StringPool.BLANK, "href", _href);
+		}
+
+		if (Validator.isNotNull(_target)) {
+			setDynamicAttribute(StringPool.BLANK, "rel", "noreferrer noopener");
+			setDynamicAttribute(StringPool.BLANK, "target", _target);
+		}
+
+		if (Validator.isNotNull(_title)) {
+			setDynamicAttribute(
+				StringPool.BLANK, "title",
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_title));
+		}
+
+		return super.doStartTag();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getAriaLabel() {
+		return _ariaLabel;
+	}
+
+	public boolean getBorderless() {
+		return _borderless;
+	}
+
+	public boolean getButton() {
+		return _button;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getButtonStyle() {
+		return getDisplayType();
+	}
+
+	public String getDisplayType() {
+		return _displayType;
+	}
+
+	public String getDownload() {
+		return _download;
+	}
+
+	public String getHref() {
+		return _href;
+	}
+
+	public String getIcon() {
+		return _icon;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getIconAlignment() {
+		return _iconAlignment;
+	}
+
+	public String getLabel() {
+		return _label;
+	}
+
+	public boolean getMonospaced() {
+		return _monospaced;
+	}
+
+	public boolean getOutline() {
+		return _outline;
+	}
+
+	public boolean getSmall() {
+		return _small;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getStyle() {
+		return getDisplayType();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getTarget() {
+		return _target;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getTitle() {
+		return _title;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setAriaLabel(String ariaLabel) {
+		_ariaLabel = ariaLabel;
+	}
+
+	public void setBorderless(boolean borderless) {
+		_borderless = borderless;
+	}
+
+	public void setButton(boolean button) {
+		_button = button;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setButtonStyle(String buttonStyle) {
+		setButton(true);
+		setDisplayType(buttonStyle);
+	}
+
+	public void setDisplayType(String displayType) {
+		_displayType = displayType;
+	}
+
+	public void setDownload(String download) {
+		_download = download;
+	}
+
+	public void setHref(String href) {
+		_href = href;
+	}
+
+	public void setIcon(String icon) {
+		_icon = icon;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setIconAlignment(String iconAlignment) {
+		_iconAlignment = iconAlignment;
+	}
+
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	public void setMonospaced(boolean monospaced) {
+		_monospaced = monospaced;
+	}
+
+	public void setOutline(boolean outline) {
+		_outline = outline;
+	}
+
+	public void setSmall(boolean small) {
+		_small = small;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setStyle(String style) {
+		setDisplayType(style);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setTarget(String target) {
+		_target = target;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setTitle(String title) {
+		_title = title;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_ariaLabel = null;
+		_borderless = false;
+		_button = false;
+		_displayType = null;
+		_download = null;
+		_href = null;
+		_icon = null;
+		_iconAlignment = null;
+		_label = null;
+		_monospaced = false;
+		_outline = false;
+		_small = false;
+		_target = null;
+		_title = null;
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		String cssPrefix = "link-";
+
+		if (_button) {
+			cssPrefix = "btn-";
+
+			cssClasses.add("btn");
+		}
+
+		if (_borderless) {
+			cssClasses.add(cssPrefix + "outline-borderless");
+		}
+
+		if (_monospaced) {
+			cssClasses.add(cssPrefix + "monospaced");
+		}
+
+		if (_small) {
+			cssClasses.add(cssPrefix + "sm");
+		}
+
+		if (Validator.isNotNull(_displayType)) {
+			if (_outline || _borderless) {
+				cssClasses.add(cssPrefix + "outline-" + _displayType);
+			}
+			else {
+				cssClasses.add(cssPrefix + _displayType);
+			}
+		}
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		if (Validator.isNotNull(_icon) || Validator.isNotNull(_label)) {
+			JspWriter jspWriter = pageContext.getOut();
+
+			if (Validator.isNotNull(_icon)) {
+				IconTag iconTag = new IconTag();
+
+				if (Validator.isNotNull(_label)) {
+					iconTag.setCssClass("inline-item inline-item-before");
+				}
+
+				iconTag.setSymbol(_icon);
+
+				iconTag.doTag(pageContext);
+			}
+
+			if (Validator.isNotNull(_label)) {
+				jspWriter.write(
+					LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						_label));
+			}
+
+			return SKIP_BODY;
+		}
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:link:";
+
+	private String _ariaLabel;
+	private boolean _borderless;
+	private boolean _button;
+	private String _displayType;
+	private String _download;
+	private String _href;
+	private String _icon;
+	private String _iconAlignment;
+	private String _label;
+	private boolean _monospaced;
+	private boolean _outline;
+	private boolean _small;
+	private String _target;
+	private String _title;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1764,41 +1764,65 @@
 	<tag>
 		<description></description>
 		<name>link</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.LinkTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LinkTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>ariaLabel</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>borderless</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>button</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>buttonStyle</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>displayType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1809,7 +1833,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1827,7 +1851,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>iconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1846,28 +1870,47 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>monospaced</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>outline</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>small</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>target</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>title</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/search_info.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/search_info.jsp
@@ -60,10 +60,12 @@
 			<liferay-ui:message key="search" />
 
 			<clay:link
-				buttonStyle="secondary"
-				elementClasses='<%= "btn-sm" + (searchEverywhere ? " active" : "") %>'
+				button="<%= true %>"
+				cssClass='<%= searchEverywhere ? "active" : "" %>'
+				displayType="secondary"
 				href="<%= searchEverywhereURL.toString() %>"
-				label='<%= LanguageUtil.get(resourceBundle, "everywhere") %>'
+				label="everywhere"
+				small="<%= true %>"
 			/>
 
 			<%
@@ -71,8 +73,9 @@
 			%>
 
 			<clay:link
-				buttonStyle="secondary"
-				elementClasses='<%= "btn-sm" + (!searchEverywhere ? " active" : "") %>'
+				button="<%= true %>"
+				cssClass='<%= !searchEverywhere ? "active" : "" %>'
+				displayType="secondary"
 				href="<%= searchFolderURL.toString() %>"
 				icon="folder"
 				label="<%= folder.getName() %>"

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -64,7 +64,8 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 											<c:if test="<%= layoutPageTemplateDisplayContext.isShowAddButton(LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) %>">
 												<li>
 													<clay:link
-														buttonStyle="borderless"
+														borderless="<%= true %>"
+														button="<%= true %>"
 														href="<%= editLayoutPageTemplateCollectionURL.toString() %>"
 														icon="plus"
 													/>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
@@ -236,10 +236,11 @@ request.setAttribute("view.jsp-viewCategory", Boolean.TRUE.toString());
 
 									<div class="btn-group-item">
 										<clay:link
-											buttonStyle="secondary"
-											elementClasses="btn-sm"
+											button="<%= true %>"
+											displayType="secondary"
 											href="<%= editCategoryURL %>"
-											label='<%= LanguageUtil.get(request, "add-category[message-board]") %>'
+											label="add-category[message-board]"
+											small="<%= true %>"
 										/>
 									</div>
 								</c:if>
@@ -253,10 +254,11 @@ request.setAttribute("view.jsp-viewCategory", Boolean.TRUE.toString());
 
 									<div class="btn-group-item">
 										<clay:link
-											buttonStyle="primary"
-											elementClasses="btn-sm"
+											button="<%= true %>"
+											displayType="primary"
 											href="<%= editMessageURL %>"
-											label='<%= LanguageUtil.get(request, "new-thread") %>'
+											label="new-thread"
+											small="<%= true %>"
 										/>
 									</div>
 								</c:if>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -87,10 +87,10 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isDisplaySiteLink() %>">
 				<clay:link
-					elementClasses='<%= "list-group-heading navigation-link panel-header-link" + (siteAdministrationPanelCategoryDisplayContext.isFirstLayout() ? " first-layout" : "") %>'
+					cssClass='<%= "list-group-heading navigation-link panel-header-link" + (siteAdministrationPanelCategoryDisplayContext.isFirstLayout() ? " first-layout" : "") %>'
 					href="<%= siteAdministrationPanelCategoryDisplayContext.getGroupURL() %>"
 					icon="home"
-					label='<%= LanguageUtil.get(request, "home") %>'
+					label="home"
 				/>
 			</c:if>
 

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view_asset_entry_sharing_entry.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view_asset_entry_sharing_entry.jsp
@@ -53,9 +53,14 @@ else {
 			<c:if test="<%= !scopeGroup.equals(themeDisplay.getControlPanelGroup()) %>">
 				<li class="d-none d-sm-flex tbar-item">
 					<clay:link
-						elementClasses="btn btn-monospaced btn-outline-borderless btn-outline-secondary btn-sm"
+						borderless="<%= true %>"
+						button="<%= true %>"
+						displayType="secondary"
 						href="<%= redirect %>"
 						icon="angle-left"
+						monospaced="<%= true %>"
+						outline="<%= true %>"
+						small="<%= true %>"
 					/>
 				</li>
 			</c:if>

--- a/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-facebook/src/main/resources/META-INF/resources/page.jsp
@@ -23,9 +23,14 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 %>
 
 <clay:link
-	buttonStyle="outline-secondary"
-	elementClasses="btn-monospaced btn-outline-borderless btn-sm lfr-portal-tooltip"
+	borderless="<%= true %>"
+	button="<%= true %>"
+	cssClass="lfr-portal-tooltip"
+	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-facebook"
+	monospaced="<%= true %>"
+	outline="<%= true %>"
+	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"
 />

--- a/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/resources/META-INF/resources/page.jsp
@@ -23,9 +23,14 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 %>
 
 <clay:link
-	buttonStyle="outline-secondary"
-	elementClasses="btn-monospaced btn-outline-borderless btn-sm lfr-portal-tooltip"
+	borderless="<%= true %>"
+	button="<%= true %>"
+	cssClass="lfr-portal-tooltip"
+	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="social-linkedin"
+	monospaced="<%= true %>"
+	outline="<%= true %>"
+	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"
 />

--- a/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/social/social-bookmark-twitter/src/main/resources/META-INF/resources/page.jsp
@@ -23,9 +23,14 @@ String url = GetterUtil.getString((String)request.getAttribute("liferay-social-b
 %>
 
 <clay:link
-	buttonStyle="outline-secondary"
-	elementClasses="btn-monospaced btn-outline-borderless btn-sm lfr-portal-tooltip"
+	borderless="<%= true %>"
+	button="<%= true %>"
+	cssClass="lfr-portal-tooltip"
+	displayType="secondary"
 	href="<%= socialBookmark.getPostURL(title, url) %>"
 	icon="twitter"
+	monospaced="<%= true %>"
+	outline="<%= true %>"
+	small="<%= true %>"
 	title="<%= socialBookmark.getName(request.getLocale()) %>"
 />


### PR DESCRIPTION
Hopefully our last round of JSP Tags updates for this release.

This PR updates `clay:link` so that it renders directly from Java instead of our legacy `ClayLink.soy` component.

**Main concern** is the replacement of the old `buttonStyle` API with a combination of `<boolean>button` and `<string>displayType`. 

Some places to check (I'm adding more screenshots, but in the middle of an `ant all` right now, so opening this to start the tests going)

#### Fragments (`Design > Fragments > +`)

<img width="609" alt="Screen_Shot_2020-07-27_at_12_56_45" src="https://user-images.githubusercontent.com/905006/88539572-6a01b000-d009-11ea-8f86-c09c1f3d0f9d.png">

