### PR TITLE
LPS-117494 Unescape HTML content in search results

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexerPostProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexerPostProcessor.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.search;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.IndexerPostProcessor;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jesse Yeh
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.journal.model.JournalArticle",
+	service = IndexerPostProcessor.class
+)
+public class JournalArticleIndexerPostProcessor
+	implements IndexerPostProcessor {
+
+	@Override
+	public void postProcessContextBooleanFilter(
+			BooleanFilter booleanFilter, SearchContext searchContext)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessDocument(Document document, Object object)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessFullQuery(
+			BooleanQuery fullQuery, SearchContext searchContext)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessSearchQuery(
+			BooleanQuery searchQuery, BooleanFilter booleanFilter,
+			SearchContext searchContext)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessSummary(
+		Summary summary, Document document, Locale locale, String snippet) {
+
+		summary.setContent(
+			HtmlUtil.unescape(
+				StringUtil.replace(
+					summary.getContent(), "<br />", StringPool.NEW_LINE)));
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -1056,6 +1056,8 @@ public class HtmlImpl implements Html {
 	).put(
 		"lt", "<"
 	).put(
+		"nbsp", " "
+	).put(
 		"rsquo", "\u2019"
 	).build();
 


### PR DESCRIPTION
[**LPS-117494**](https://issues.liferay.com/browse/LPS-117494)

**Previous Pull Request**
https://github.com/ChrisKian/liferay-portal/pull/244

**Changelog**
* Use indexer post-processor approach to unescape content as suggested in [PTR-1842](https://issues.liferay.com/browse/PTR-1842?focusedCommentId=2205410&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2205410)
* Allow `&nbsp;` to be unescaped