### PR TITLE
LPS-119207 Updates the ClayModal package version to 3.7.0

### DIFF
--- a/modules/apps/app-builder/app-builder-web/package.json
+++ b/modules/apps/app-builder/app-builder-web/package.json
@@ -10,7 +10,7 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/list": "3.3.1",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-step-nav": "3.2.5",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/pagination-bar": "3.1.9",

--- a/modules/apps/data-engine/data-engine-taglib/package.json
+++ b/modules/apps/data-engine/data-engine-taglib/package.json
@@ -10,7 +10,7 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/list": "3.3.1",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-step-nav": "3.2.5",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/pagination-bar": "3.1.9",

--- a/modules/apps/depot/depot-web/package.json
+++ b/modules/apps/depot/depot-web/package.json
@@ -7,7 +7,7 @@
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.1",
 		"@clayui/layout": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/table": "3.0.7",
 		"frontend-js-web": "*",
 		"metal-dom": "2.16.8",

--- a/modules/apps/document-library/document-library-web/package.json
+++ b/modules/apps/document-library/document-library-web/package.json
@@ -6,7 +6,7 @@
 		"@clayui/form": "3.10.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"asset-taglib": "*",
 		"clay-button": "2.21.4",
 		"clay-multi-select": "2.21.4",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -3,7 +3,7 @@
 		"@clayui/button": "3.4.0",
 		"@clayui/form": "3.10.0",
 		"@clayui/layout": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/table": "3.0.7",
 		"classnames": "2.2.6",
 		"clay-button": "2.21.4",

--- a/modules/apps/flags/flags-taglib/package.json
+++ b/modules/apps/flags/flags-taglib/package.json
@@ -3,7 +3,7 @@
 		"@clayui/alert": "3.4.1",
 		"@clayui/button": "3.4.0",
 		"@clayui/icon": "3.0.5",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"clay-button": "2.21.4",
 		"clay-icon": "2.21.4",
 		"frontend-js-web": "*",

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -3,7 +3,7 @@
 		"@clayui/alert": "3.4.1",
 		"@clayui/form": "3.10.0",
 		"@clayui/icon": "3.0.5",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"clay": "2.18.1",
 		"clay-alert": "2.21.4",
 		"liferay-amd-loader": "4.3.0",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -21,7 +21,7 @@
 		"@clayui/list": "3.3.1",
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/management-toolbar": "3.2.3",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-select": "3.6.2",
 		"@clayui/multi-step-nav": "3.2.5",
 		"@clayui/nav": "3.2.2",

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -7,7 +7,7 @@
 		"@clayui/form": "3.10.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/list": "3.3.1",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/tabs": "3.2.3",
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
@@ -8,7 +8,7 @@
 		"@clayui/icon": "3.0.5",
 		"@clayui/layout": "3.2.0",
 		"@clayui/link": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/panel": "3.2.3",
 		"@clayui/tabs": "3.2.3",

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -9,7 +9,7 @@
 		"@clayui/layout": "3.2.0",
 		"@clayui/link": "3.2.0",
 		"@clayui/list": "3.3.1",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"classnames": "2.2.6",
 		"clay-badge": "2.21.4",
 		"clay-checkbox": "2.21.4",

--- a/modules/apps/questions/questions-web/package.json
+++ b/modules/apps/questions/questions-web/package.json
@@ -9,7 +9,7 @@
 		"@clayui/label": "3.3.1",
 		"@clayui/link": "3.2.0",
 		"@clayui/loading-indicator": "3.1.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/popover": "3.4.5",
 		"@clayui/sticker": "3.2.0",

--- a/modules/apps/sharing/sharing-web/package.json
+++ b/modules/apps/sharing/sharing-web/package.json
@@ -8,7 +8,7 @@
 		"@clayui/form": "3.10.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/layout": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-select": "3.6.2",
 		"@clayui/sticker": "3.2.0",
 		"frontend-js-react-web": "*",

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/package.json
@@ -6,7 +6,7 @@
 		"@clayui/form": "3.10.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/link": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/popover": "3.4.5",
 		"@clayui/tooltip": "3.3.3",
 		"classnames": "2.2.6",

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
@@ -9,7 +9,7 @@
 		"@clayui/link": "3.2.0",
 		"@clayui/loading-indicator": "3.1.0",
 		"@clayui/management-toolbar": "3.2.3",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/multi-select": "3.6.2",
 		"@clayui/pagination-bar": "3.1.9",
 		"@clayui/tabs": "3.2.3",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
@@ -10,7 +10,7 @@
 		"@clayui/layout": "3.2.0",
 		"@clayui/list": "3.3.1",
 		"@clayui/management-toolbar": "3.2.3",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/navigation-bar": "3.2.3",
 		"@clayui/panel": "3.2.3",
 		"@clayui/progress-bar": "3.1.0",

--- a/modules/dxp/apps/segments/segments-experiment-web/package.json
+++ b/modules/dxp/apps/segments/segments-experiment-web/package.json
@@ -7,7 +7,7 @@
 		"@clayui/icon": "3.0.5",
 		"@clayui/layout": "3.2.0",
 		"@clayui/link": "3.2.0",
-		"@clayui/modal": "3.6.5",
+		"@clayui/modal": "3.7.0",
 		"@clayui/tabs": "3.2.3",
 		"@clayui/tooltip": "3.3.3",
 		"classnames": "2.2.6",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1284,10 +1284,10 @@
     "@clayui/layout" "^3.2.0"
     classnames "^2.2.6"
 
-"@clayui/modal@3.6.5":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.6.5.tgz#10cce5c10a479995590af4955e8773ce0cad3a97"
-  integrity sha512-TBBRfcMrxlX5GGKt+TjZAryY+mmyL/7LUKV8gWezAmoSFM4Ukej6hCUcadgKgQkV5Up9HotFcxzDQ7rzVVujmg==
+"@clayui/modal@3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.7.0.tgz#f67ac09f681ffe73f54dfb1297f8855d73ab2302"
+  integrity sha512-LgYKgGuCkJ7H0VpzxXLKqQ+Pv9dzDVakSMaws+kL1qnNeBbQBOMwIYL0Ehl4FRrsAiNhPyVU0eDW4fh0F2UFow==
   dependencies:
     "@clayui/button" "^3.4.0"
     "@clayui/icon" "^3.0.5"


### PR DESCRIPTION
This new version only introduces the new `zIndex` API. Check https://github.com/liferay/clay/pull/3644 for more information.

cc @jbalsas 