### PR TITLE
LPS-118030 Add Saml Saas Configuration and Render Filer for SAML

### DIFF
--- a/modules/saas/apps/saml-saas/bnd.bnd
+++ b/modules/saas/apps/saml-saas/bnd.bnd
@@ -8,3 +8,4 @@ Provide-Capability:\
 		resource.bundle.base.name="content.Language";\
 		service.ranking="2";\
 		servlet.context.name=saml-web
+Web-ContextPath: /saml-saas

--- a/modules/saas/apps/saml-saas/build.gradle
+++ b/modules/saas/apps/saml-saas/build.gradle
@@ -1,0 +1,19 @@
+dependencies{
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":dxp:apps:saml:saml-api")
+	compileOnly project(":dxp:apps:saml:saml-persistence-api")
+	compileOnly project(":dxp:apps:saml:saml-web")
+	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-1"
+}

--- a/modules/saas/apps/saml-saas/src/main/java/com/liferay/saml/saas/internal/configuration/SamlSaasConfiguration.java
+++ b/modules/saas/apps/saml-saas/src/main/java/com/liferay/saml/saas/internal/configuration/SamlSaasConfiguration.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.saml.saas.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Marta Medio
+ */
+@ExtendedObjectClassDefinition(
+	generateUI = false, scope = ExtendedObjectClassDefinition.Scope.COMPANY
+)
+@Meta.OCD(id = "com.liferay.saml.saas.configuration.SamlSaasConfiguration")
+public interface SamlSaasConfiguration {
+
+	@Meta.AD(
+		deflt = "false", id = "saml.saas.production.environment",
+		required = false
+	)
+	public boolean productionEnvironment();
+
+	@Meta.AD(id = "saml.saas.pre.shared.key", required = false)
+	public String preSharedKey();
+
+	@Meta.AD(id = "saml.saas.target.instance.import.url", required = false)
+	public String targetInstanceImportURL();
+
+}

--- a/modules/saas/apps/saml-saas/src/main/java/com/liferay/saml/saas/internal/portlet/filter/SamlAdminRenderFilter.java
+++ b/modules/saas/apps/saml-saas/src/main/java/com/liferay/saml/saas/internal/portlet/filter/SamlAdminRenderFilter.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.saml.saas.internal.portlet.filter;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlPortletKeys;
+import com.liferay.saml.constants.SamlProviderConfigurationKeys;
+import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+import com.liferay.saml.runtime.credential.KeyStoreManager;
+import com.liferay.saml.saas.internal.configuration.SamlSaasConfiguration;
+
+import java.io.IOException;
+
+import java.util.Map;
+import java.util.Objects;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import javax.portlet.filter.FilterChain;
+import javax.portlet.filter.FilterConfig;
+import javax.portlet.filter.PortletFilter;
+import javax.portlet.filter.RenderFilter;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marta Medio
+ */
+@Component(
+	configurationPid = "com.liferay.saml.runtime.configuration.SamlKeyStoreManagerConfiguration",
+	immediate = true,
+	property = "javax.portlet.name=" + SamlPortletKeys.SAML_ADMIN, service = {}
+)
+public class SamlAdminRenderFilter implements RenderFilter {
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void doFilter(
+			RenderRequest renderRequest, RenderResponse renderResponse,
+			FilterChain chain)
+		throws IOException, PortletException {
+
+		chain.doFilter(renderRequest, renderResponse);
+
+		String mvcRenderCommandName = ParamUtil.getString(
+			renderRequest, "mvcRenderCommandName", null);
+		String tabs1 = ParamUtil.getString(renderRequest, "tabs1", "general");
+
+		if (((mvcRenderCommandName != null) &&
+			 !Objects.equals(mvcRenderCommandName, "/admin")) ||
+			!Objects.equals(tabs1, "general")) {
+
+			return;
+		}
+
+		try {
+			SamlSaasConfiguration samlSaasConfiguration =
+				ConfigurationProviderUtil.getCompanyConfiguration(
+					SamlSaasConfiguration.class,
+					_portal.getCompanyId(renderRequest));
+
+			if (samlSaasConfiguration.productionEnvironment() ||
+				Validator.isBlank(samlSaasConfiguration.preSharedKey()) ||
+				Validator.isBlank(
+					samlSaasConfiguration.targetInstanceImportURL())) {
+
+				return;
+			}
+		}
+		catch (ConfigurationException configurationException) {
+			_log.error(
+				"Unable to get SaaS instance configuration",
+				configurationException);
+
+			return;
+		}
+
+		SamlProviderConfiguration samlProviderConfiguration =
+			_samlProviderConfigurationHelper.getSamlProviderConfiguration();
+
+		if (!Objects.equals(
+				SamlProviderConfigurationKeys.SAML_ROLE_SP,
+				samlProviderConfiguration.role())) {
+
+			return;
+		}
+
+		RequestDispatcher requestDispatcher =
+			_servletContext.getRequestDispatcher("/export.jsp");
+
+		try {
+			requestDispatcher.include(
+				_portal.getHttpServletRequest(renderRequest),
+				_portal.getHttpServletResponse(renderResponse));
+		}
+		catch (Exception exception) {
+			throw new PortletException(
+				"Unable to include export.jsp", exception);
+		}
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws PortletException {
+	}
+
+	@Activate
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
+		if (Objects.equals(
+				_keyStoreManagerServiceReference.getProperty("component.name"),
+				_DL_KEYSTORE_MANAGER_CLASS_NAME)) {
+
+			_serviceRegistration = bundleContext.registerService(
+				PortletFilter.class, this, new HashMapDictionary<>(properties));
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	private static final String _DL_KEYSTORE_MANAGER_CLASS_NAME =
+		"com.liferay.saml.opensaml.integration.internal.credential." +
+			"DLKeyStoreManagerImpl";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SamlAdminRenderFilter.class);
+
+	@Reference(name = "KeyStoreManager")
+	private ServiceReference<KeyStoreManager> _keyStoreManagerServiceReference;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+	@Reference(target = "(osgi.web.symbolicname=com.liferay.saml.saas)")
+	private ServletContext _servletContext;
+
+}

--- a/modules/saas/apps/saml-saas/src/main/java/com/liferay/saml/saas/internal/settings/definition/SaasConfigurationBeanDeclaration.java
+++ b/modules/saas/apps/saml-saas/src/main/java/com/liferay/saml/saas/internal/settings/definition/SaasConfigurationBeanDeclaration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.saml.saas.internal.settings.definition;
+
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+import com.liferay.saml.saas.internal.configuration.SamlSaasConfiguration;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Marta Medio
+ */
+@Component(service = ConfigurationBeanDeclaration.class)
+public class SaasConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return SamlSaasConfiguration.class;
+	}
+
+}

--- a/modules/saas/apps/saml-saas/src/main/resources/META-INF/resources/export.jsp
+++ b/modules/saas/apps/saml-saas/src/main/resources/META-INF/resources/export.jsp
@@ -1,0 +1,39 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<portlet:actionURL name="/admin/saas/saml/export" var="exportSamlUrl">
+	<portlet:param name="mvcRenderCommandName" value="/admin" />
+</portlet:actionURL>
+
+<div class="container-fluid container-fluid-max-xl sheet">
+	<liferay-ui:error key="exportError" message="an-error-has-occurred-during-the-export-process" />
+
+	<div class="button-holder">
+		<h3 class="text-default">
+			<liferay-ui:message key="export-the-saml-configuration-from-this-instance-to-your-production-instance" />
+		</h3>
+
+		<div class="alert alert-warning">
+			<liferay-ui:message key="the-saml-configuration-of-your-production-instance-will-be-completely-overwritten" />
+		</div>
+
+		<aui:form action="<%= exportSamlUrl %>" method="post" name="fm">
+			<aui:button type="submit" value="export-saml-configuration" />
+		</aui:form>
+	</div>
+</div>

--- a/modules/saas/apps/saml-saas/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/saas/apps/saml-saas/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,26 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<liferay-frontend:defineObjects />
+
+<liferay-theme:defineObjects />

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator.
+export-saml-configuration=Export SAML Configuration
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance.
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten.

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_ar.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_ar.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=موفر الهوية غير مدعوم في وضع SaaS، لذا تم تعطيل الدور.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=دور موفر الهوية غير مدعوم في SaaS. يرجى الترحيل إلى حل موفر هوية بديل.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_bg.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_bg.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_ca.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_ca.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=El proveïdor d'identitat no s'admet en mode SaaS i, per tant, el rol s'ha deshabilitat.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=El rol de proveïdor d'identitat no s'admet en SaaS. Migreu a una solució de proveïdor d'identitat alternativa.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_cs.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_cs.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_da.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_da.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_de.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_de.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identitätsanbieter wird im SaaS-Modus nicht unterstützt, daher wurde die Rolle deaktiviert.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=Die Rolle Identitätsanbieter wird in SaaS nicht unterstützt. Bitte migrieren Sie zu einer alternativen Identitätsanbieterlösung.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_el.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_el.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_en.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_en.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator.
+export-saml-configuration=Export SAML Configuration
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance.
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten.

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_en_AU.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_en_AU.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_en_GB.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_en_GB.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_es.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_es.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=El proveedor de identidades no es compatible con el modo SaaS y, por lo tanto, se ha deshabilitado el rol.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=El rol del proveedor de identidades no se admite en SaaS. Migre a una solución alternativa de proveedor de identidades.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_et.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_et.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_eu.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_eu.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_fa.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_fa.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_fi.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_fi.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identiteetin tarjoaja ei ole tuettu SaaS-tilassa, joten rooli on poistettu käytöstä.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=Identiteetin tarjoajan roolia ei tueta SaaS:ssa. Siirry vaihtoehtoisen identiteetin tarjoajan ratkaisuun.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_fr.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_fr.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Le fournisseur d'identité n'est pas pris en charge en mode SaaS. Le rôle a donc été désactivé.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=Le rôle fournisseur d'identité n'est pas pris en charge en SaaS. Veuillez migrer vers une solution de fournisseur d'identité alternative.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_fr_CA.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_gl.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_gl.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_hi_IN.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_hr.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_hr.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_hu.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_hu.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Az identitásszolgáltató nincs támogatva SaaS módban, ezért a szerepkör le van tiltva.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=Az identitásszolgáltató nincs támogatva SaaS módban. Kérjük, váltson egy másik identitásszolgáltató megoldására.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_in.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_in.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_it.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_it.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_iw.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_iw.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_ja.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_ja.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=アイデンティティプロバイダーはSaaSモードではサポートされていませんので、ロールが無効化されました。
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=アイデンティティプロバイダーロールはSaaSではサポートされていません。別のアイデンティティプロバイダーソリューションに移行してください。
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_kk.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_kk.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_ko.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_ko.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_lo.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_lo.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_lt.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_lt.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_nb.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_nb.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_nl.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_nl.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=De identiteitsprovider is niet ondersteund in SaaS-modus, dus werd de rol gedeactiveerd.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=De rol van identiteitsprovider is niet ondersteund in SaaS-modus. Ga over naar een andere oplossing voor de identiteitsprovider.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_nl_BE.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_pl.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_pl.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_pt_BR.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Fornecedor de identidade não suportado no modo SaaS, então a função foi desativada.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=A função de fornecedor de identidade não é suportada em SaaS. Por favor, migre para uma solução de fornecedor de identidade alternativa.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_pt_PT.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_ro.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_ro.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_ru.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_ru.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_sk.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_sk.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_sl.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_sl.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_sr_RS.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_sv.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_sv.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identitetsleverantör stöds inte i SaaS-läge, så rollen har inaktiverats.
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=Roll för identitetsleverantör stöds inte i SaaS. Flytta till en alternativ lösning för identitetsleverantör.
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_ta_IN.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_th.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_th.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_tr.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_tr.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_uk.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_uk.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_vi.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_vi.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_zh_CN.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=SaaS 模式不支持身份提供程序，因此该角色已被禁用。
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=SaaS 不支持该身份提供程序角色。请迁移至备用身份提供程序解决方案。
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)

--- a/modules/saas/apps/saml-saas/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/saas/apps/saml-saas/src/main/resources/content/Language_zh_TW.properties
@@ -1,2 +1,6 @@
+an-error-has-occurred-during-the-export-process=An error has occurred during the export process. Please contact the system administrator. (Automatic Copy)
+export-saml-configuration=Export SAML Configuration (Automatic Copy)
+export-the-saml-configuration-from-this-instance-to-your-production-instance=Export the SAML configuration from this instance to your production instance. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-it-can-be-re-enabled-in-system-settings=Identity provider is not supported in SaaS mode, so the role has been disabled. (Automatic Copy)
 the-identity-provider-role-has-been-disabled-please-re-enable-it-in-system-settings=The identity provider role is not supported in SaaS. Please migrate to an alternate identity provider solution. (Automatic Copy)
+the-saml-configuration-of-your-production-instance-will-be-completely-overwritten=The SAML configuration of your production instance will be completely overwritten. (Automatic Copy)


### PR DESCRIPTION
Hey Brian

This is the first part of a series of PRs to merge our new module (only available for the SaaS Product) that allows export/import SAML configuration data from one environment to another. 
We're using `modules/saas` directory since it is not code that we want to include in the main build.

Thanks

cc/ @csierra 