### PR TITLE
LSP-121755 useResource.es.js

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/hooks/useResource.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/hooks/useResource.es.js
@@ -17,7 +17,7 @@ import {fetch} from 'frontend-js-web';
 
 import {useStorage} from './useStorage.es';
 
-const ENDPOINT_FIELD_TYPES = `${window.location.origin}/o/dynamic-data-mapping-form-field-types`;
+const ENDPOINT_FIELD_TYPES = `${window.location.origin}${themeDisplay.getPathContext()}/o/dynamic-data-mapping-form-field-types`;
 
 const HEADERS = {
 	Accept: 'application/json',


### PR DESCRIPTION
When running Liferay in another context than ROOT, (ex. /portal) the input fields not load because URL not contain the context.