### PR TITLE
[TS] LPS-122231 portal-search-web: increase to full span when facet menu i…

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -44,7 +44,7 @@ Hits hits = searchDisplayContext.getHits();
 
 	<clay:col
 		cssClass="result"
-		md="9"
+		md="<%= searchDisplayContext.isShowMenu() ? String.valueOf(9) : String.valueOf(12) %>"
 	>
 		<%@ include file="/main_search_suggest.jspf" %>
 


### PR DESCRIPTION
…s absent

https://issues.liferay.com/browse/LPS-122231
https://issues.liferay.com/browse/LPP-39156

LPS-122231 Search Widget doesn't span width when Facets are hidden

Author: @joshuacords 