### PR TITLE
LPS-122725 fix input-date prefilling on mobile

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -104,7 +104,7 @@ else {
 <span class="lfr-input-date" id="<%= randomNamespace %>displayDate">
 	<c:choose>
 		<c:when test="<%= BrowserSnifferUtil.isMobile(request) %>">
-			<input class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="date" value="<%= format.format(calendar.getTime()) %>" />
+			<input class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="date" value="<%= dateString %>" />
 		</c:when>
 		<c:otherwise>
 			<aui:input cssClass="<%= cssClass %>" disabled="<%= disabled %>" id="<%= HtmlUtil.getAUICompatibleId(name) %>" label="" name="<%= name %>" placeholder="<%= StringUtil.toLowerCase(placeholderValue) %>" required="<%= required %>" title="" type="text" value="<%= dateString %>" wrappedField="<%= true %>">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122725 

**Problem overview:**
liferay-ui: input-date is pre-filled when viewed from a mobile device

**Steps to Reproduce:**
- Place the liferay-ui: input-date tag with an empty value on the jsp page
- Deploy portlet with jsp page
- Open page with portlet on a mobile device

**Expected Results:**
Input contain empty value

**Actual Results:**
input is prefilled