### PR TITLE
LPS-124021 Use 'mouseover'/'mouseout' instead of 'mouseenter'/'mouseleave'

### DIFF
--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
@@ -58,14 +58,14 @@ const SELECTOR_TRIGGER = `
 `;
 
 const TRIGGER_HIDE_EVENTS = [
-	'mouseleave',
+	'mouseout',
 	'mouseup',
 	'MSPointerUp',
 	'pointerup',
 	'touchend',
 ];
 const TRIGGER_SHOW_EVENTS = [
-	'mouseenter',
+	'mouseover',
 	'mouseup',
 	'MSPointerDown',
 	'pointerdown',
@@ -174,14 +174,14 @@ const TooltipProvider = () => {
 
 		const TOOLTIP_ENTER = delegate(
 			document.body,
-			'mouseenter',
+			'mouseover',
 			SELECTOR_TOOLTIP,
 			() => dispatch({target: state.target, type: 'show'})
 		);
 
 		const TOOLTIP_LEAVE = delegate(
 			document.body,
-			'mouseleave',
+			'mouseout',
 			SELECTOR_TOOLTIP,
 			() => dispatch({type: 'hide'})
 		);

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/delegate/delegate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/delegate/delegate.es.js
@@ -181,4 +181,61 @@ describe('delegate', () => {
 
 		expect(delegateTarget).toBe(document.querySelector('.match'));
 	});
+
+	it('works with multiple selectors', () => {
+		document.body.innerHTML = `<div class="match" data-testid="match">
+				<div>
+					<div class="one" data-testid="one"></div>
+					<div class="two" data-testid="two"></div>
+				</div>
+			</div >`;
+
+		const listener = jest.fn();
+
+		const selector = '.one,.two';
+
+		delegate(document.body, 'mouseover', selector, listener);
+
+		const event = new Event('mouseover', {
+			bubbles: true,
+			cancelable: true,
+		});
+
+		let element = getByTestId(document, 'one');
+		element.dispatchEvent(event);
+
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		element = getByTestId(document, 'two');
+		element.dispatchEvent(event);
+
+		expect(listener).toHaveBeenCalledTimes(2);
+	});
+
+	it('delegateTarget returns the correct selector', () => {
+		document.body.innerHTML = `<div class="match" data-testid="match">
+				<div>
+					<div class="one" data-testid="one"></div>
+					<div class="two" data-testid="two"></div>
+				</div>
+			</div >`;
+
+		let delegateTarget;
+
+		const listener = (event) => {
+			delegateTarget = event.delegateTarget;
+		};
+
+		const selector = '.one,.two';
+
+		delegate(document.body, 'click', selector, listener);
+
+		userEvent.click(getByTestId(document, 'one'));
+
+		expect(delegateTarget).toBe(document.querySelector('.one'));
+
+		userEvent.click(getByTestId(document, 'two'));
+
+		expect(delegateTarget).toBe(document.querySelector('.two'));
+	});
 });


### PR DESCRIPTION
With metal's `dom.delegate`, `mouseenter` and `mouseleave` events are
[mapped to `mouseover` and `mouseout`](https://github.com/metal/metal.js/blob/5b5032dd840bc3364894776c8bb2fb82517e2553/packages/metal-dom/src/events.js#L11-L34),
so applying the same logic here for tool tips which fixed the issue.

Additionally, two new test cases were added for the `delegate` function.