### PR TITLE
LPS-125135 Remove usages of Align from the metal-position package

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/popover/Popover.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/popover/Popover.es.js
@@ -13,7 +13,7 @@
  */
 
 import classNames from 'classnames';
-import {Align} from 'metal-position';
+import {Align, align} from 'frontend-js-web';
 import {PropTypes} from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -46,11 +46,7 @@ const getAlignPosition = (source, target, suggestedPosition) => {
 		suggestedPosition = 'top';
 	}
 
-	const position = Align.align(
-		source,
-		target,
-		ALIGNMENTS_MAP[suggestedPosition]
-	);
+	const position = align(source, target, ALIGNMENTS_MAP[suggestedPosition]);
 
 	return POSITIONS[position];
 };

--- a/modules/apps/app-builder/app-builder-web/test/js/components/popover/Popover.es.js
+++ b/modules/apps/app-builder/app-builder-web/test/js/components/popover/Popover.es.js
@@ -13,7 +13,7 @@
  */
 
 import {cleanup, render} from '@testing-library/react';
-import {Align} from 'metal-position';
+import {align} from 'frontend-js-web';
 import React from 'react';
 
 import Popover from '../../../../src/main/resources/META-INF/resources/js/components/popover/Popover.es';
@@ -22,6 +22,10 @@ const getTitle = () => <h1>Title</h1>;
 const getContent = () => <p>Content</p>;
 const getFooter = () => <span>Footer</span>;
 
+const alignMock = {
+	align,
+};
+
 describe('Popover', () => {
 	afterEach(() => {
 		cleanup();
@@ -29,7 +33,7 @@ describe('Popover', () => {
 	});
 
 	it('renders popover on top', () => {
-		jest.spyOn(Align, 'align').mockImplementation(() => 0);
+		jest.spyOn(alignMock, 'align').mockImplementation(() => 0);
 
 		const {container, queryByText} = render(
 			<Popover
@@ -49,7 +53,7 @@ describe('Popover', () => {
 	});
 
 	it('renders popover on the right with children', () => {
-		jest.spyOn(Align, 'align').mockImplementation(() => 2);
+		jest.spyOn(alignMock, 'align').mockImplementation(() => 2);
 
 		const {container, queryByText} = render(
 			<Popover
@@ -76,7 +80,7 @@ describe('Popover', () => {
 	});
 
 	it('renders popover with no ref', () => {
-		jest.spyOn(Align, 'align').mockImplementation(() => 0);
+		jest.spyOn(alignMock, 'align').mockImplementation(() => 0);
 
 		const {container, queryByText} = render(
 			<Popover title={getTitle} visible />

--- a/modules/apps/app-builder/app-builder-web/test/js/pages/custom-object/ListCustomObjects.es.js
+++ b/modules/apps/app-builder/app-builder-web/test/js/pages/custom-object/ListCustomObjects.es.js
@@ -26,6 +26,21 @@ import {RESPONSES} from '../../constants.es';
 const mockFetch = fetch;
 
 jest.mock('frontend-js-web', () => ({
+	Align: {
+		Bottom: 4,
+		BottomCenter: 4,
+		BottomLeft: 5,
+		BottomRight: 3,
+		Left: 6,
+		LeftCenter: 6,
+		Right: 2,
+		RightCenter: 2,
+		Top: 0,
+		TopCenter: 0,
+		TopLeft: 7,
+		TopRight: 1,
+	},
+	align: () => jest.fn(),
 	createResourceURL: jest.fn(() => 'http://resource_url?'),
 	debounce: jest.fn().mockResolvedValue(),
 	fetch: (...args) => mockFetch(...args),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
@@ -7,7 +7,6 @@
 		"metal-drag-drop": "3.3.1",
 		"metal-events": "2.16.8",
 		"metal-jsx": "2.16.8",
-		"metal-position": "2.1.2",
 		"metal-state": "2.16.8"
 	},
 	"jest": {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -15,7 +15,6 @@
 		"map-openstreetmap": "*",
 		"metal-component": "2.16.8",
 		"metal-drag-drop": "3.3.1",
-		"metal-position": "2.1.2",
 		"metal-soy": "2.16.9",
 		"moment": "^2.22.2",
 		"text-mask-addons": "^3.7.1",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/components/Tooltip/Tooltip.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/components/Tooltip/Tooltip.es.js
@@ -17,8 +17,8 @@
 import '../FormPortal/FormPortal.es';
 
 import 'clay-icon';
+import {Align, align} from 'frontend-js-web';
 import Component from 'metal-component';
-import {Align} from 'metal-position';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
 
@@ -43,11 +43,7 @@ class Tooltip extends Component {
 	_handleTooltipRendered() {
 		const {tooltipSource, tooltipTarget} = this.refs;
 		const {element} = tooltipSource;
-		const suggestedPosition = Align.align(
-			element,
-			tooltipTarget,
-			Align.Right
-		);
+		const suggestedPosition = align(element, tooltipTarget, Align.Right);
 
 		this.position = POSITIONS[suggestedPosition];
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
@@ -9,7 +9,6 @@
 		"metal-drag-drop": "3.3.1",
 		"metal-events": "2.16.8",
 		"metal-jsx": "2.16.8",
-		"metal-position": "2.1.2",
 		"metal-state": "2.16.8",
 		"object-hash": "^1.3.0"
 	},

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"@clayui/tooltip": "3.4.2",
 		"frontend-js-react-web": "*",
-		"metal-position": "2.1.2",
+		"frontend-js-web": "*",
 		"react": "16.12.0"
 	},
 	"name": "frontend-js-tooltip-support-web",

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
@@ -14,8 +14,7 @@
 
 import ClayTooltip from '@clayui/tooltip';
 import {render, useTimeout} from 'frontend-js-react-web';
-import {delegate} from 'frontend-js-web';
-import {Align} from 'metal-position';
+import {Align, align, delegate} from 'frontend-js-web';
 import React, {
 	useEffect,
 	useLayoutEffect,
@@ -202,11 +201,7 @@ const TooltipProvider = () => {
 	useLayoutEffect(() => {
 		if (state.target && tooltipRef.current) {
 			setAlignment(
-				Align.align(
-					tooltipRef.current,
-					state.target,
-					Align.BottomCenter
-				)
+				align(tooltipRef.current, state.target, Align.BottomCenter)
 			);
 		}
 	}, [state.target]);

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -22,7 +22,8 @@
 			"<rootDir>/test/liferay/portlet/mock/setup.es.js"
 		],
 		"testPathIgnorePatterns": [
-			"<rootDir>/test/liferay/portlet/mock/setup.es.js"
+			"<rootDir>/test/liferay/portlet/mock/setup.es.js",
+			"<rootDir>/test/liferay/position/helpers.js"
 		]
 	},
 	"main": "index.es.js",

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -60,6 +60,16 @@ export {default as createRenderURL} from './liferay/util/portlet_url/create_rend
 
 export {default as createResourceURL} from './liferay/util/portlet_url/create_resource_url.es';
 
+// Align API
+
+export {
+	Align,
+	align,
+	getAlignBestRegion,
+	getAlignRegion,
+	suggestAlignBestRegion,
+} from './liferay/position/align';
+
 // Session API
 
 export {getSessionValue, setSessionValue} from './liferay/util/session.es';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/position/align.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/position/align.js
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	getOffsetLeft,
+	getOffsetTop,
+	getRegion,
+	insideViewport,
+	intersectRegion,
+	intersection,
+} from './position';
+
+/**
+ * Align utility. Computes region or best region to align an element with
+ * another. Regions are relative to viewport, make sure to use element with
+ * position fixed, or position absolute when the element first positioned
+ * parent is the body element.
+ */
+
+/**
+ * Constants that represent the supported positions for `Align`.
+ */
+const Align = {
+	BottomCenter: 4,
+	BottomLeft: 5,
+	BottomRight: 3,
+	LeftCenter: 6,
+	RightCenter: 2,
+	TopCenter: 0,
+	TopLeft: 7,
+	TopRight: 1,
+};
+
+/**
+ * Aliases for position constants.
+ */
+Align.Bottom = Align.BottomCenter;
+Align.Left = Align.LeftCenter;
+Align.Right = Align.RightCenter;
+Align.Top = Align.TopCenter;
+
+/**
+ * Aligns the element with the best region around alignElement. The best
+ * region is defined by clockwise rotation starting from the specified
+ * `position`. The element is always aligned in the middle of alignElement
+ * axis.
+ * @param {!Element} element Element to be aligned.
+ * @param {!Element} alignElement Element to align with.
+ * @param {Align.Top|Align.Right|Align.Bottom|Align.Left} position
+ *     The initial position to try. Options `Align.Top`, `Align.Right`,
+ *     `Align.Bottom`, `Align.Left`.
+ * @param {boolean} autoBestAlign Option to suggest or not the best region
+ *      to align.
+ * @return {string} The final chosen position for the aligned element.
+ */
+function align(element, alignElement, position, autoBestAlign = true) {
+	let bestRegion;
+
+	if (autoBestAlign) {
+		const suggestion = suggestAlignBestRegion(
+			element,
+			alignElement,
+			position
+		);
+		position = suggestion.position;
+		bestRegion = suggestion.region;
+	}
+	else {
+		bestRegion = getAlignRegion(element, alignElement, position);
+	}
+
+	const computedStyle = window.getComputedStyle(element);
+	if (computedStyle.getPropertyValue('position') !== 'fixed') {
+		bestRegion.top += window.pageYOffset;
+		bestRegion.left += window.pageXOffset;
+
+		let offsetParent = element;
+		while ((offsetParent = offsetParent.offsetParent)) {
+			bestRegion.top -= getOffsetTop(offsetParent);
+			bestRegion.left -= getOffsetLeft(offsetParent);
+		}
+	}
+
+	element.style.top = bestRegion.top + 'px';
+	element.style.left = bestRegion.left + 'px';
+
+	return position;
+}
+
+/**
+ * Returns the best region to align element with alignElement. This is similar
+ * to `Align.suggestAlignBestRegion`, but it only returns the region information,
+ * while `Align.suggestAlignBestRegion` also returns the chosen position.
+ * @param {!Element} element Element to be aligned.
+ * @param {!Element} alignElement Element to align with.
+ * @param {Align.Top|Align.Right|Align.Bottom|Align.Left} position
+ *     The initial position to try. Options `Align.Top`, `Align.Right`,
+ *     `Align.Bottom`, `Align.Left`.
+ * @return {DOMRect} Best region to align element.
+ */
+function getAlignBestRegion(element, alignElement, position) {
+	return suggestAlignBestRegion(element, alignElement, position).region;
+}
+
+/**
+ * Returns the region to align element with alignElement. The element is
+ * always aligned in the middle of alignElement axis.
+ * @param {!Element} element Element to be aligned.
+ * @param {!Element} alignElement Element to align with.
+ * @param {Align.Top|Align.Right|Align.Bottom|Align.Left} position
+ *     The position to align. Options `Align.Top`, `Align.Right`,
+ *     `Align.Bottom`, `Align.Left`.
+ * @return {DOMRect} Region to align element.
+ */
+function getAlignRegion(element, alignElement, position) {
+	const targetRectangle = getRegion(alignElement);
+	const sourceRectangle = getRegion(element);
+	let top = 0;
+	let left = 0;
+
+	switch (position) {
+		case Align.TopCenter:
+			top = targetRectangle.top - sourceRectangle.height;
+			left =
+				targetRectangle.left +
+				targetRectangle.width / 2 -
+				sourceRectangle.width / 2;
+			break;
+		case Align.RightCenter:
+			top =
+				targetRectangle.top +
+				targetRectangle.height / 2 -
+				sourceRectangle.height / 2;
+			left = targetRectangle.left + targetRectangle.width;
+			break;
+		case Align.BottomCenter:
+			top = targetRectangle.bottom;
+			left =
+				targetRectangle.left +
+				targetRectangle.width / 2 -
+				sourceRectangle.width / 2;
+			break;
+		case Align.LeftCenter:
+			top =
+				targetRectangle.top +
+				targetRectangle.height / 2 -
+				sourceRectangle.height / 2;
+			left = targetRectangle.left - sourceRectangle.width;
+			break;
+		case Align.TopRight:
+			top = targetRectangle.top - sourceRectangle.height;
+			left = targetRectangle.right - sourceRectangle.width;
+			break;
+		case Align.BottomRight:
+			top = targetRectangle.bottom;
+			left = targetRectangle.right - sourceRectangle.width;
+			break;
+		case Align.BottomLeft:
+			top = targetRectangle.bottom;
+			left = targetRectangle.left;
+			break;
+		case Align.TopLeft:
+			top = targetRectangle.top - sourceRectangle.height;
+			left = targetRectangle.left;
+			break;
+		default:
+			break;
+	}
+
+	return {
+		bottom: top + sourceRectangle.height,
+		height: sourceRectangle.height,
+		left,
+		right: left + sourceRectangle.width,
+		top,
+		width: sourceRectangle.width,
+	};
+}
+
+/**
+ * Looks for the best region for aligning the given element. The best
+ * region is defined by clockwise rotation starting from the specified
+ * `position`. The element is always aligned in the middle of alignElement
+ * axis.
+ * @param {!Element} element Element to be aligned.
+ * @param {!Element} alignElement Element to align with.
+ * @param {Align.Top|Align.Right|Align.Bottom|Align.Left} position
+ *     The initial position to try. Options `Align.Top`, `Align.Right`,
+ *     `Align.Bottom`, `Align.Left`.
+ * @return {{position: string, region: DOMRect}} Best region to align element.
+ */
+function suggestAlignBestRegion(element, alignElement, position) {
+	let bestArea = 0;
+	let bestPosition = position;
+	let bestRegion = getAlignRegion(element, alignElement, bestPosition);
+	let tryPosition = bestPosition;
+	let tryRegion = bestRegion;
+	const viewportRegion = getRegion(window);
+
+	for (let i = 0; i < 8; ) {
+		if (intersectRegion(viewportRegion, tryRegion)) {
+			const visibleRegion = intersection(viewportRegion, tryRegion);
+			const area = visibleRegion.width * visibleRegion.height;
+			if (area > bestArea) {
+				bestArea = area;
+				bestRegion = tryRegion;
+				bestPosition = tryPosition;
+			}
+			if (insideViewport(tryRegion)) {
+				break;
+			}
+		}
+		tryPosition = (position + ++i) % 8;
+		tryRegion = getAlignRegion(element, alignElement, tryPosition);
+	}
+
+	return {
+		position: bestPosition,
+		region: bestRegion,
+	};
+}
+
+export {
+	Align,
+	align,
+	getAlignBestRegion,
+	getAlignRegion,
+	suggestAlignBestRegion,
+};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/position/position.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/position/position.js
@@ -1,0 +1,384 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/**
+ * Returns true if value is a document.
+ * @param {*} val
+ * @return {boolean}
+ */
+function isDocument(val) {
+	return val && typeof val === 'object' && val.nodeType === 9;
+}
+
+/**
+ * Returns true if value is a window.
+ * @param {*} val
+ * @return {boolean}
+ */
+function isWindow(val) {
+	return val && val === val.window;
+}
+
+/**
+ * Gets the client height or width of the specified node. Scroll height is
+ * not included.
+ * @param {Element|Document|Window=} node
+ * @param {string} property `Width` or `Height` property.
+ * @return {number}
+ */
+function getClientSize(node, property) {
+	let element = node;
+
+	if (isWindow(node)) {
+		element = node.document.documentElement;
+	}
+	if (isDocument(node)) {
+		element = node.documentElement;
+	}
+
+	return element[`client${property}`];
+}
+
+/**
+ * Gets the region of the element, document or window.
+ * @param {Element|Document|Window=} element Optional element to test.
+ * @return {!DOMRect} The returned value is a simulated DOMRect object which
+ *     is the union of the rectangles returned by getClientRects() for the
+ *     element, i.e., the CSS border-boxes associated with the element.
+ */
+function getDocumentRegion(element) {
+	const height = getHeight(element);
+	const width = getWidth(element);
+
+	return makeRegion(height, height, 0, width, 0, width);
+}
+
+/**
+ * Gets the height of the specified node. Scroll height is included.
+ * @param {Element|Document|Window=} node
+ * @return {number}
+ */
+function getHeight(node) {
+	return getSize(node, 'Height');
+}
+
+/**
+ * Gets the top offset position of the given node. This fixes the `offsetLeft` value of
+ * nodes that were translated, which don't take that into account at all. That makes
+ * the calculation more expensive though, so if you don't want that to be considered
+ * either pass `ignoreTransform` as true or call `offsetLeft` directly on the node.
+ * @param {!Element} node
+ * @param {boolean=} ignoreTransform When set to true will ignore transform css
+ *   when calculating the position. Defaults to false.
+ * @return {number}
+ */
+function getOffsetLeft(node, ignoreTransform) {
+	return node.offsetLeft + (ignoreTransform ? 0 : getTranslation(node).left);
+}
+
+/**
+ * Gets the top offset position of the given node. This fixes the `offsetTop` value of
+ * nodes that were translated, which don't take that into account at all. That makes
+ * the calculation more expensive though, so if you don't want that to be considered
+ * either pass `ignoreTransform` as true or call `offsetTop` directly on the node.
+ * @param {!Element} node
+ * @param {boolean=} ignoreTransform When set to true will ignore transform css
+ *   when calculating the position. Defaults to false.
+ * @return {number}
+ */
+function getOffsetTop(node, ignoreTransform) {
+	return node.offsetTop + (ignoreTransform ? 0 : getTranslation(node).top);
+}
+
+/**
+ * Gets the size of an element and its position relative to the viewport.
+ * @param {!Document|Element|Window} node
+ * @param {boolean=} includeScroll Flag indicating if the document scroll
+ *   position should be considered in the element's region coordinates. Defaults
+ *   to false.
+ * @return {!DOMRect} The returned value is a DOMRect object which is the
+ *     union of the rectangles returned by getClientRects() for the element,
+ *     i.e., the CSS border-boxes associated with the element.
+ */
+function getRegion(node, includeScroll) {
+	if (!node) {
+		return {bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0};
+	}
+
+	if (isDocument(node) || isWindow(node)) {
+		return getDocumentRegion(node);
+	}
+
+	return makeRegionFromBoundingRect(
+		node.getBoundingClientRect(),
+		includeScroll
+	);
+}
+
+/**
+ * Gets the scroll left position of the specified node.
+ * @param {Element|Document|Window=} node
+ * @return {number}
+ */
+function getScrollLeft(node) {
+	if (isWindow(node)) {
+		return node.pageXOffset;
+	}
+	if (isDocument(node)) {
+		return node.defaultView.pageXOffset;
+	}
+
+	return node.scrollLeft;
+}
+
+/**
+ * Gets the scroll top position of the specified node.
+ * @param {Element|Document|Window=} node
+ * @return {number}
+ */
+function getScrollTop(node) {
+	if (isWindow(node)) {
+		return node.pageYOffset;
+	}
+	if (isDocument(node)) {
+		return node.defaultView.pageYOffset;
+	}
+
+	return node.scrollTop;
+}
+
+/**
+ * Gets the height or width of the specified node. Scroll height is
+ * included.
+ * @param {Element|Document|Window=} node
+ * @param {string} prop `Width` or `Height` property.
+ * @return {number}
+ */
+function getSize(node, property) {
+	if (isWindow(node)) {
+		return getClientSize(node, property);
+	}
+	if (isDocument(node)) {
+		const documentElement = node.documentElement;
+
+		return Math.max(
+			node.body[`scroll${property}`],
+			documentElement[`scroll${property}`],
+			node.body[`offset${property}`],
+			documentElement[`offset${property}`],
+			documentElement[`client${property}`]
+		);
+	}
+
+	return Math.max(
+		node[`client${property}`],
+		node[`scroll${property}`],
+		node[`offset${property}`]
+	);
+}
+
+/**
+ * Gets the transform matrix values for the given node.
+ * @param {!Element} node
+ * @return {Array<number>}
+ */
+function getTransformMatrixValues(node) {
+	const style = getComputedStyle(node);
+
+	const transform =
+		style.mozTransform || style.msTransform || style.transform;
+
+	if (transform !== 'none') {
+		const values = [];
+		const regex = /([\d-.\s]+)/g;
+		let matches = regex.exec(transform);
+
+		while (matches) {
+			values.push(matches[1]);
+			matches = regex.exec(transform);
+		}
+
+		return values;
+	}
+}
+
+/**
+ * Gets the number of translated pixels for the given node, for both the top and
+ * left positions.
+ * @param {!Element} node
+ * @return {number}
+ */
+function getTranslation(node) {
+	const values = getTransformMatrixValues(node);
+	const translation = {
+		left: 0,
+		top: 0,
+	};
+	if (values) {
+		translation.left = parseFloat(
+			values.length === 6 ? values[4] : values[13]
+		);
+		translation.top = parseFloat(
+			values.length === 6 ? values[5] : values[14]
+		);
+	}
+
+	return translation;
+}
+
+/**
+ * Gets the width of the specified node. Scroll width is included.
+ * @param {Element|Document|Window=} node
+ * @return {number}
+ */
+function getWidth(node) {
+	return getSize(node, 'Width');
+}
+
+/**
+ * Tests if a region intersects with another.
+ * @param {DOMRect} sourceRectangle
+ * @param {DOMRect} targetRectangle
+ * @return {boolean}
+ */
+function intersectRegion(sourceRectangle, targetRectangle) {
+	return intersectRect(
+		sourceRectangle.top,
+		sourceRectangle.left,
+		sourceRectangle.bottom,
+		sourceRectangle.right,
+		targetRectangle.top,
+		targetRectangle.left,
+		targetRectangle.bottom,
+		targetRectangle.right
+	);
+}
+
+/**
+ * Tests if a rectangle intersects with another.
+ *
+ * Note that coordinates starts from top to down (y), left to right (x):
+ *
+ * @param {number} x0 Horizontal coordinate of P0.
+ * @param {number} y0 Vertical coordinate of P0.
+ * @param {number} x1 Horizontal coordinate of P1.
+ * @param {number} y1 Vertical coordinate of P1.
+ * @param {number} x2 Horizontal coordinate of P2.
+ * @param {number} y2 Vertical coordinate of P2.
+ * @param {number} x3 Horizontal coordinate of P3.
+ * @param {number} y3 Vertical coordinate of P3.
+ * @return {boolean}
+ */
+function intersectRect(x0, y0, x1, y1, x2, y2, x3, y3) {
+	return !(x2 > x1 || x3 < x0 || y2 > y1 || y3 < y0);
+}
+
+/**
+ * Tests if a region is inside another.
+ * @param {DOMRect} sourceRectangle
+ * @param {DOMRect} targetRectangle
+ * @return {boolean}
+ */
+function insideRegion(sourceRectangle, targetRectangle) {
+	return (
+		targetRectangle.top >= sourceRectangle.top &&
+		targetRectangle.bottom <= sourceRectangle.bottom &&
+		targetRectangle.right <= sourceRectangle.right &&
+		targetRectangle.left >= sourceRectangle.left
+	);
+}
+
+/**
+ * Tests if a region is inside viewport region.
+ * @param {DOMRect} region
+ * @return {boolean}
+ */
+function insideViewport(region) {
+	return insideRegion(getRegion(window), region);
+}
+
+/**
+ * Computes the intersection region between two regions.
+ * @param {DOMRect} sourceRectangle
+ * @param {DOMRect} targetRectangle
+ * @return {?DOMRect} Intersection region or null if regions doesn't
+ *     intersects.
+ */
+function intersection(sourceRectangle, targetRectangle) {
+	if (!intersectRegion(sourceRectangle, targetRectangle)) {
+		return null;
+	}
+	const bottom = Math.min(sourceRectangle.bottom, targetRectangle.bottom);
+	const right = Math.min(sourceRectangle.right, targetRectangle.right);
+	const left = Math.max(sourceRectangle.left, targetRectangle.left);
+	const top = Math.max(sourceRectangle.top, targetRectangle.top);
+
+	return makeRegion(bottom, bottom - top, left, right, top, right - left);
+}
+
+/**
+ * Makes a region object. It's a writable version of DOMRect.
+ * @param {number} bottom
+ * @param {number} height
+ * @param {number} left
+ * @param {number} right
+ * @param {number} top
+ * @param {number} width
+ * @return {!DOMRect} The returned value is a DOMRect object which is the
+ *     union of the rectangles returned by getClientRects() for the element,
+ *     i.e., the CSS border-boxes associated with the element.
+ */
+function makeRegion(bottom, height, left, right, top, width) {
+	return {
+		bottom,
+		height,
+		left,
+		right,
+		top,
+		width,
+	};
+}
+
+/**
+ * Makes a region from a DOMRect result from `getBoundingClientRect`.
+ * @param  {!DOMRect} rectangle The returned value is a DOMRect object which is the
+ *     union of the rectangles returned by getClientRects() for the element,
+ *     i.e., the CSS border-boxes associated with the element.
+ * @param {boolean=} includeScroll Flag indicating if the document scroll
+ *   position should be considered in the element's region coordinates. Defaults
+ *   to false.
+ * @return {DOMRect} Writable version of DOMRect.
+ */
+function makeRegionFromBoundingRect(rectangle, includeScroll = false) {
+	const deltaX = includeScroll ? getScrollLeft(document) : 0;
+	const deltaY = includeScroll ? getScrollTop(document) : 0;
+
+	return makeRegion(
+		rectangle.bottom + deltaY,
+		rectangle.height,
+		rectangle.left + deltaX,
+		rectangle.right + deltaX,
+		rectangle.top + deltaY,
+		rectangle.width
+	);
+}
+
+export {
+	getOffsetLeft,
+	getOffsetTop,
+	getRegion,
+	insideViewport,
+	intersection,
+	intersectRegion,
+};

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/position/align.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/position/align.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	Align,
+	align,
+} from '../../../src/main/resources/META-INF/resources/liferay/position/align';
+import {enterDocument, exitDocument} from './helpers';
+
+let center;
+let element;
+let mutable;
+let offsetParent;
+
+window.scrollTo = jest.fn();
+
+describe('Align', () => {
+	afterEach(() => {
+		exitDocument(center);
+		exitDocument(element);
+		exitDocument(mutable);
+		exitDocument(offsetParent);
+		window.scrollTo(0, 0);
+	});
+
+	beforeEach(() => {
+		enterDocument(
+			'<div id="center" style="position:absolute;top:100px;left:100px;width:50px;height:50px;"></div>'
+		);
+		enterDocument(
+			'<div id="element" style="position:absolute;height:25px;width:25px;"></div>'
+		);
+		enterDocument(
+			'<div id="mutable" style="position:absolute;width:50px;height:50px;"></div>'
+		);
+		enterDocument(
+			'<div id="offsetParent" style="position:absolute;width:500px;height:500px;top:100px;left:100px;"></div>'
+		);
+
+		center = document.getElementById('center');
+		element = document.getElementById('element');
+
+		mutable = document.getElementById('mutable');
+		mutable.style.top = '100px';
+		mutable.style.left = '100px';
+		mutable.style.bottom = '';
+		mutable.style.right = '';
+
+		offsetParent = document.getElementById('offsetParent');
+	});
+
+	it('defines constants and aliases', () => {
+		expect(Align.BottomCenter).toBeDefined();
+		expect(Align.BottomLeft).toBeDefined();
+		expect(Align.BottomRight).toBeDefined();
+		expect(Align.LeftCenter).toBeDefined();
+		expect(Align.RightCenter).toBeDefined();
+		expect(Align.TopCenter).toBeDefined();
+		expect(Align.TopLeft).toBeDefined();
+		expect(Align.TopRight).toBeDefined();
+
+		expect(Align.Bottom).toBeDefined();
+		expect(Align.Bottom).toBe(Align.BottomCenter);
+
+		expect(Align.Left).toBeDefined();
+		expect(Align.Left).toBe(Align.LeftCenter);
+
+		expect(Align.Right).toBeDefined();
+		expect(Align.Right).toBe(Align.RightCenter);
+
+		expect(Align.Top).toBeDefined();
+		expect(Align.Top).toBe(Align.TopCenter);
+	});
+
+	it('align to the bottom', () => {
+		const position = align(element, center, Align.Bottom);
+		expect(position).toBe(Align.Bottom);
+	});
+
+	it('does not try to find a better region to align', () => {
+		mutable.style.left = '0px';
+
+		const position = align(element, mutable, Align.Left, false);
+		expect(position).toBe(Align.Left);
+	});
+
+	it('aligns to the right', () => {
+		const position = align(element, center, Align.Right);
+		expect(position).toBe(Align.Right);
+	});
+
+	it('aligns to the top', () => {
+		const position = align(element, center, Align.Top);
+		expect(position).toBe(Align.Top);
+	});
+
+	it('aligns to the left', () => {
+		const position = align(element, center, Align.Left);
+		expect(position).toBe(Align.Left);
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/position/helpers.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/position/helpers.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+function append(parent, child) {
+	if (typeof child === 'string') {
+		child = buildFragment(child);
+	}
+	if (isNodeListLike(child)) {
+		const childArr = Array.prototype.slice.call(child);
+		for (let i = 0; i < childArr.length; i++) {
+			parent.appendChild(childArr[i]);
+		}
+	}
+	else {
+		parent.appendChild(child);
+	}
+
+	return child;
+}
+
+/**
+ * Helper for converting a HTML string into a document fragment.
+ * @param {string} htmlString The HTML string to convert.
+ * @return {!Element} The resulting document fragment.
+ */
+export function buildFragment(htmlString) {
+	const tempDiv = document.createElement('div');
+	tempDiv.innerHTML = `<br>${htmlString}`;
+	tempDiv.removeChild(tempDiv.firstChild);
+
+	const fragment = document.createDocumentFragment();
+	while (tempDiv.firstChild) {
+		fragment.appendChild(tempDiv.firstChild);
+	}
+
+	return fragment;
+}
+
+/**
+ * Inserts node in document as last element.
+ * @param {Element} node Element to remove children from.
+ */
+export function enterDocument(node) {
+	return node && append(document.body, node);
+}
+
+/**
+ * Removes node from document.
+ * @param {Element} node Element to remove children from.
+ */
+export function exitDocument(node) {
+	if (node && node.parentNode) {
+		node.parentNode.removeChild(node);
+	}
+}
+
+/**
+ * Returns true if the specified value is a NodeList or like one.
+ * @param {?} val Variable to test.
+ * @return {boolean} Whether variable is like a NodeList.
+ */
+function isNodeListLike(val) {
+	return (
+		val && typeof val.length === 'number' && typeof val.item === 'function'
+	);
+}

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -16,7 +16,6 @@
 		"metal-component": "2.16.8",
 		"metal-drag-drop": "3.3.1",
 		"metal-events": "2.16.8",
-		"metal-position": "2.1.2",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -21,7 +21,6 @@
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",
 		"metal-events": "2.16.8",
-		"metal-position": "2.1.2",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dnd": "11.1.1",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
@@ -14,7 +14,7 @@
 
 import ClayPopover from '@clayui/popover';
 import {useEventListener} from 'frontend-js-react-web';
-import {Align} from 'metal-position';
+import {Align, align, suggestAlignBestRegion} from 'frontend-js-web';
 import React, {
 	useCallback,
 	useEffect,
@@ -133,7 +133,7 @@ const DisabledArea = () => {
 
 	useLayoutEffect(() => {
 		if (popoverRef.current && currentElementClicked && show) {
-			const suggestedAlign = Align.suggestAlignBestRegion(
+			const suggestedAlign = suggestAlignBestRegion(
 				popoverRef.current,
 				currentElementClicked,
 				Align.TopCenter
@@ -144,7 +144,7 @@ const DisabledArea = () => {
 					? Align.BottomCenter
 					: Align.TopCenter;
 
-			Align.align(
+			align(
 				popoverRef.current,
 				currentElementClicked,
 				bestPosition,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/Popover.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/Popover.js
@@ -13,7 +13,7 @@
  */
 
 import ClayPopover from '@clayui/popover';
-import {Align} from 'metal-position';
+import {Align, align} from 'frontend-js-web';
 import Proptypes from 'prop-types';
 import React, {useRef} from 'react';
 import ReactDOM from 'react-dom';
@@ -35,7 +35,7 @@ const PopoverComponent = ({anchor, children, ...rest}) => {
 	const popRef = useRef(null);
 
 	React.useLayoutEffect(() => {
-		Align.align(popRef.current, anchor, Align.Right, false);
+		align(popRef.current, anchor, Align.Right, false);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/package.json
+++ b/modules/apps/site-navigation/site-navigation-admin-web/package.json
@@ -6,7 +6,6 @@
 		"@clayui/layout": "3.2.0",
 		"frontend-js-web": "*",
 		"metal-drag-drop": "3.3.1",
-		"metal-position": "2.1.2",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"

--- a/modules/apps/style-book/style-book-web/package.json
+++ b/modules/apps/style-book/style-book-web/package.json
@@ -9,7 +9,6 @@
 		"@clayui/popover": "3.5.2",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",
-		"metal-position": "2.1.2",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/PreviewInfoBar.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/PreviewInfoBar.js
@@ -14,7 +14,7 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayPopover from '@clayui/popover';
-import {Align} from 'metal-position';
+import {Align, align} from 'frontend-js-web';
 import React, {useLayoutEffect, useRef, useState} from 'react';
 
 import LayoutSelector from './LayoutSelector';
@@ -26,7 +26,7 @@ export default function PreviewInfoBar() {
 
 	useLayoutEffect(() => {
 		if (isShowPopover) {
-			Align.align(
+			align(
 				popoverRef.current,
 				helpIconRef.current,
 				Align.BottomRight,


### PR DESCRIPTION
All references to `Align` from the `metal-position` package have been
replaced with functions placed in
`modules/apps/frontend-js-web/src/main/resources/META-INF/resources/liferay/position`,
that have the same name and signatures as those found in the
`metal-position` package.

Only the required code has been kept and some variables have been
renamed to match our [frontend guidelines](https://github.com/liferay/liferay-frontend-guidelines).

References to the `metal-position` package in `package.json` files have
also been removed.

*Submitting this as a draft as we might want to discuss the changes
before forwarding.*