### PR TITLE
LPS-127825 Version comparison does not work if the user who created the version has been deleted

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/DiffVersionComparatorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/DiffVersionComparatorTag.java
@@ -17,6 +17,7 @@ package com.liferay.frontend.taglib.servlet.taglib;
 import com.liferay.frontend.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.diff.DiffVersion;
 import com.liferay.portal.kernel.diff.DiffVersionsInfo;
+import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -89,15 +90,26 @@ public class DiffVersionComparatorTag extends IncludeTag {
 
 		diffVersionJSONObject.put("targetURL", targetURL.toString());
 
-		User user = UserLocalServiceUtil.getUser(diffVersion.getUserId());
+		try {
+			User user = UserLocalServiceUtil.getUser(diffVersion.getUserId());
 
-		diffVersionJSONObject.put(
-			"userInitials", user.getInitials()
-		).put(
-			"userName", user.getFullName()
-		).put(
-			"version", diffVersionString
-		);
+			diffVersionJSONObject.put(
+				"userInitials", user.getInitials()
+			).put(
+				"userName", user.getFullName()
+			).put(
+				"version", diffVersionString
+			);
+		}
+		catch (NoSuchUserException noSuchUserException) {
+			diffVersionJSONObject.put(
+				"userInitials", "Deleted User"
+			).put(
+				"userName", "Deleted User"
+			).put(
+				"version", diffVersionString
+			);
+		}
 
 		return diffVersionJSONObject;
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/DiffVersionComparatorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/DiffVersionComparatorTag.java
@@ -15,9 +15,9 @@
 package com.liferay.frontend.taglib.servlet.taglib;
 
 import com.liferay.frontend.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.diff.DiffVersion;
 import com.liferay.portal.kernel.diff.DiffVersionsInfo;
-import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -90,9 +90,9 @@ public class DiffVersionComparatorTag extends IncludeTag {
 
 		diffVersionJSONObject.put("targetURL", targetURL.toString());
 
-		try {
-			User user = UserLocalServiceUtil.getUser(diffVersion.getUserId());
+		User user = UserLocalServiceUtil.fetchUser(diffVersion.getUserId());
 
+		if (user != null) {
 			diffVersionJSONObject.put(
 				"userInitials", user.getInitials()
 			).put(
@@ -101,11 +101,11 @@ public class DiffVersionComparatorTag extends IncludeTag {
 				"version", diffVersionString
 			);
 		}
-		catch (NoSuchUserException noSuchUserException) {
+		else {
 			diffVersionJSONObject.put(
-				"userInitials", "Deleted User"
+				"userInitials", StringPool.BLANK
 			).put(
-				"userName", "Deleted User"
+				"userName", StringPool.BLANK
 			).put(
 				"version", diffVersionString
 			);


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

Although the title of LPS in JIRA may suggest this is only affecting WEM is more general since that taglib can be used by many components and we need to consider the case when the user have been deleted.

Thanks.

Regards.

/cc @laszlopap 