### PR TITLE
[TS] LPS-128028 Preventing curParam from being removed in the URL, so it can ensure independent pagination between Search Container

### DIFF
--- a/portal-web/docroot/html/taglib/ui/search_paginator/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_paginator/lexicon/page.jsp
@@ -33,7 +33,6 @@ String type = (String)request.getAttribute("liferay-ui:search:type");
 PortletURL iteratorURL = searchContainer.getIteratorURL();
 
 if (iteratorURL != null) {
-	iteratorURL.setParameter(searchContainer.getCurParam(), (String)null);
 	iteratorURL.setParameter("resetCur", Boolean.FALSE.toString());
 }
 %>

--- a/portal-web/docroot/html/taglib/ui/search_paginator/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_paginator/page.jsp
@@ -32,7 +32,6 @@ String type = (String)request.getAttribute("liferay-ui:search:type");
 PortletURL iteratorURL = searchContainer.getIteratorURL();
 
 if (iteratorURL != null) {
-	iteratorURL.setParameter(searchContainer.getCurParam(), (String)null);
 	iteratorURL.setParameter("resetCur", Boolean.FALSE.toString());
 }
 %>


### PR DESCRIPTION
Hi Team,

Search containers do not ensure independent pagination currently, however different _curParam_ variables are included in the search containers _liferay-ui:search-container_ taglib for example [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp#L75) .

**Root cause** analysis: _curParam_, that ensures independent pagination, is not included in the _iteratorURL_ when multiple search container pagination is being used on a site. Therefore, the cur value will be reset and set to the default value.
The _curParam_ is set to null [here ](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/search_paginator/lexicon/page.jsp#L36) that prevents the parameter being included in the URL.

**Fix**:   _curParam_ will be included in the URL by removing the code from search_paginator.

I tested the solution with good result.

Please see more information on PTR: https://issues.liferay.com/browse/PTR-2221

LPS: https://issues.liferay.com/browse/LPS-128028

Cc. @antonio-ortega 