### PR TITLE
LPS-127834 [Bug] Fix label: use displayType instead

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -195,8 +195,8 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 						%>
 
 							<clay:label
-								label="<%= StringUtil.toUpperCase(version.getLabel()) %>"
-								style="<%= version.getStyle() %>"
+								displayType="<%= version.getStyle() %>"
+								label="<%= version.getLabel() %>"
 							/>
 
 						<%


### PR DESCRIPTION
**Description**

Due to the changes in this PR [[7.4-only] LPS-125256 Remove deprecated tag attributes](https://github.com/brianchandotcom/liferay-portal/pull/98462), status label used in the Content Dashboard was broken.

**Solution**

The `style` attribute was removed (ant it was pointing at `displayType`) so I changed it and use `displayType` instead. Also, I removed the uppercase from the label.

**Screenshot**

<img width="1209" alt="Screenshot 2021-02-18 at 10 07 04" src="https://user-images.githubusercontent.com/15845466/108333756-92354400-71d1-11eb-8096-d7812369f416.png">