### PR TITLE
LPS-127869 Check data limit quotas at persistence level instead of local service level

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -94,7 +94,6 @@ import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.diff.DiffHtmlUtil;
-import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -178,7 +177,6 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.validation.ModelValidator;
 import com.liferay.portal.validation.ModelValidatorRegistryUtil;
 import com.liferay.social.kernel.model.SocialActivityConstants;
@@ -350,14 +348,6 @@ public class JournalArticleLocalServiceImpl
 		// Article
 
 		User user = userLocalService.getUser(userId);
-
-		if ((PropsValues.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT > 0) &&
-			(journalArticlePersistence.countByCompanyId(user.getCompanyId()) >=
-				PropsValues.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT)) {
-
-			throw new DataLimitException(
-				"Unable to exceed maximum number of allowed journal articles");
-		}
 
 		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -33,7 +33,6 @@ import com.liferay.journal.util.JournalValidator;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
-import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -100,14 +99,6 @@ public class JournalFolderLocalServiceImpl
 		// Folder
 
 		User user = userLocalService.getUser(userId);
-
-		if ((PropsValues.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT > 0) &&
-			(journalFolderPersistence.countByCompanyId(user.getCompanyId()) >=
-				PropsValues.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT)) {
-
-			throw new DataLimitException(
-				"Unable to exceed maximum number of allowed journal folders");
-		}
 
 		parentFolderId = getParentFolderId(groupId, parentFolderId);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateGroupException;
 import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
 import com.liferay.portal.kernel.exception.GroupInheritContentException;
@@ -254,14 +253,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		// Group
 
 		User user = userPersistence.findByPrimaryKey(userId);
-
-		if (site && (PropsValues.DATA_LIMIT_MAX_SITE_COUNT > 0) &&
-			(groupPersistence.countByC_S(user.getCompanyId(), site) >=
-				PropsValues.DATA_LIMIT_MAX_SITE_COUNT)) {
-
-			throw new DataLimitException(
-				"Unable to exceed maximum number of allowed sites");
-		}
 
 		className = GetterUtil.getString(className);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -18,7 +18,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateOrganizationException;
 import com.liferay.portal.kernel.exception.OrganizationNameException;
 import com.liferay.portal.kernel.exception.OrganizationParentException;
@@ -246,14 +245,6 @@ public class OrganizationLocalServiceImpl
 		// Organization
 
 		User user = userPersistence.findByPrimaryKey(userId);
-
-		if ((PropsValues.DATA_LIMIT_MAX_ORGANIZATION_COUNT > 0) &&
-			(organizationPersistence.countByCompanyId(user.getCompanyId()) >=
-				PropsValues.DATA_LIMIT_MAX_ORGANIZATION_COUNT)) {
-
-			throw new DataLimitException(
-				"Unable to exceed maximum number of allowed organizations");
-		}
 
 		parentOrganizationId = getParentOrganizationId(
 			user.getCompanyId(), parentOrganizationId);

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -130,14 +130,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 
 		User user = userPersistence.findByPrimaryKey(userId);
 
-		if ((PropsValues.DATA_LIMIT_MAX_ROLE_COUNT > 0) &&
-			(rolePersistence.countByCompanyId(user.getCompanyId()) >=
-				PropsValues.DATA_LIMIT_MAX_ROLE_COUNT)) {
-
-			throw new DataLimitException(
-				"Unable to exceed maximum number of allowed roles");
-		}
-
 		className = GetterUtil.getString(className);
 
 		long classNameId = classNameLocalService.getClassNameId(className);

--- a/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portal.service.impl;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateTeamException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.TeamNameException;
@@ -34,7 +33,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.TeamLocalServiceBaseImpl;
-import com.liferay.portal.util.PropsValues;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,14 +51,6 @@ public class TeamLocalServiceImpl extends TeamLocalServiceBaseImpl {
 		// Team
 
 		User user = userPersistence.findByPrimaryKey(userId);
-
-		if ((PropsValues.DATA_LIMIT_MAX_TEAM_COUNT > 0) &&
-			(teamPersistence.countByCompanyId(user.getCompanyId()) >=
-				PropsValues.DATA_LIMIT_MAX_TEAM_COUNT)) {
-
-			throw new DataLimitException(
-				"Unable to exceed maximum number of allowed teams");
-		}
 
 		validate(0, groupId, name);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.CompanyMaxUsersException;
 import com.liferay.portal.kernel.exception.ContactBirthdayException;
 import com.liferay.portal.kernel.exception.ContactNameException;
-import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateGoogleUserIdException;
 import com.liferay.portal.kernel.exception.DuplicateOpenIdException;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -1005,14 +1004,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		throws PortalException {
 
 		// User
-
-		if ((PropsValues.DATA_LIMIT_MAX_USER_COUNT > 0) &&
-			(userPersistence.countByCompanyId(companyId) >=
-				PropsValues.DATA_LIMIT_MAX_USER_COUNT)) {
-
-			throw new DataLimitException(
-				"Unable to exceed maximum number of allowed users");
-		}
 
 		Company company = companyPersistence.findByPrimaryKey(companyId);
 		screenName = getLogin(screenName);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -623,27 +623,55 @@ public class PropsValues {
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_DL_STORAGE_SIZE));
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final long DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT));
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final long DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT));
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final long DATA_LIMIT_MAX_ORGANIZATION_COUNT =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_ORGANIZATION_COUNT));
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final long DATA_LIMIT_MAX_ROLE_COUNT = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_ROLE_COUNT));
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final long DATA_LIMIT_MAX_SITE_COUNT = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_SITE_COUNT));
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final long DATA_LIMIT_MAX_TEAM_COUNT = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_TEAM_COUNT));
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final long DATA_LIMIT_MAX_USER_COUNT = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_USER_COUNT));
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1488,22 +1488,6 @@
     data.limit.max.dl.storage.size=0
 
     #
-    # Set the maximum allowed journal articles per company. Set this to 0 or a
-    # negative value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_JOURNAL_PERIOD_ARTICLE_PERIOD_COUNT
-    #
-    data.limit.max.journal.article.count=0
-
-    #
-    # Set the maximum allowed journal folders per company. Set this to 0 or a
-    # negative value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_JOURNAL_PERIOD_FOLDER_PERIOD_COUNT
-    #
-    data.limit.max.journal.folder.count=0
-
-    #
     # Set the maximum allowed mail messages per company within a period. Set
     # this to 0 or a negative value to disable this limit.
     #
@@ -1518,46 +1502,6 @@
     # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_MAIL_PERIOD_MESSAGE_PERIOD_PERIOD
     #
     data.limit.max.mail.message.period=0
-
-    #
-    # Set the maximum allowed organizations per company. Set this to 0 or a
-    # negative value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_ORGANIZATION_PERIOD_COUNT
-    #
-    data.limit.max.organization.count=0
-
-    #
-    # Set the maximum allowed roles per company. Set this to 0 or a negative
-    # value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_ROLE_PERIOD_COUNT
-    #
-    data.limit.max.role.count=0
-
-    #
-    # Set the maximum allowed sites per company. Set this to 0 or a negative
-    # value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_SITE_PERIOD_COUNT
-    #
-    data.limit.max.site.count=0
-
-    #
-    # Set the maximum allowed teams per company. Set this to 0 or a negative
-    # value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_TEAM_PERIOD_COUNT
-    #
-    data.limit.max.team.count=0
-
-    #
-    # Set the maximum allowed users per company. Set this to 0 or a negative
-    # value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_USER_PERIOD_COUNT
-    #
-    data.limit.max.user.count=0
 
 ##
 ## Database

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/DataLimitExceededException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/DataLimitExceededException.java
@@ -15,25 +15,22 @@
 package com.liferay.portal.kernel.exception;
 
 /**
- * @author     Javier de Arcos
- * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
- *             DataLimitExceededException}
+ * @author Javier de Arcos
  */
-@Deprecated
-public class DataLimitException extends PortalException {
+public class DataLimitExceededException extends SystemException {
 
-	public DataLimitException() {
+	public DataLimitExceededException() {
 	}
 
-	public DataLimitException(String msg) {
+	public DataLimitExceededException(String msg) {
 		super(msg);
 	}
 
-	public DataLimitException(String msg, Throwable throwable) {
+	public DataLimitExceededException(String msg, Throwable throwable) {
 		super(msg, throwable);
 	}
 
-	public DataLimitException(Throwable throwable) {
+	public DataLimitExceededException(Throwable throwable) {
 		super(throwable);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -661,9 +661,17 @@ public interface PropsKeys {
 	public static final String DATA_LIMIT_MAX_DL_STORAGE_SIZE =
 		"data.limit.max.dl.storage.size";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT =
 		"data.limit.max.journal.article.count";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT =
 		"data.limit.max.journal.folder.count";
 
@@ -673,18 +681,38 @@ public interface PropsKeys {
 	public static final String DATA_LIMIT_MAX_MAIL_MESSAGE_PERIOD =
 		"data.limit.max.mail.message.period";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String DATA_LIMIT_MAX_ORGANIZATION_COUNT =
 		"data.limit.max.organization.count";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String DATA_LIMIT_MAX_ROLE_COUNT =
 		"data.limit.max.role.count";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String DATA_LIMIT_MAX_SITE_COUNT =
 		"data.limit.max.site.count";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String DATA_LIMIT_MAX_TEAM_COUNT =
 		"data.limit.max.team.count";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String DATA_LIMIT_MAX_USER_COUNT =
 		"data.limit.max.user.count";
 


### PR DESCRIPTION
Check the data limit quotas at BasePersistenceImpl class.

Remove the old code that check data limit quotas at LocalServiceImpl classes

Deprecate old properties at PropsValues and PropsKeys

Remove old properties from portal.properties file