### PR TITLE
LPS-128744 Fix broken DOM structure caused by LPS-120600

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -82,9 +82,9 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 					</c:choose>
 				</p>
 
-				<span class="d-inline-flex">
+				<div class="d-inline-flex">
 					<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-				</span>
+				</div>
 			</div>
 
 			<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -80,11 +80,11 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 							</span>
 						</c:otherwise>
 					</c:choose>
-
-					<span class="d-inline-flex">
-						<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-					</span>
 				</p>
+
+				<span class="d-inline-flex">
+					<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
+				</span>
 			</div>
 
 			<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -82,9 +82,17 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 					</c:choose>
 				</p>
 
-				<div class="d-inline-flex">
+				<liferay-util:buffer
+					var="assetActions"
+				>
 					<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-				</div>
+				</liferay-util:buffer>
+
+				<c:if test="<%= Validator.isNotNull(assetActions) %>">
+					<div class="d-inline-flex">
+						<%= assetActions %>
+					</div>
+				</c:if>
 			</div>
 
 			<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -96,9 +96,17 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 			request.setAttribute("view.jsp-fullContentRedirect", fullContentRedirect);
 			%>
 
-			<div class="d-inline-flex">
+			<liferay-util:buffer
+				var="assetActions"
+			>
 				<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-			</div>
+			</liferay-util:buffer>
+
+			<c:if test="<%= Validator.isNotNull(assetActions) %>">
+				<div class="d-inline-flex">
+					<%= assetActions %>
+				</div>
+			</c:if>
 		</c:if>
 	</div>
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -96,9 +96,9 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 			request.setAttribute("view.jsp-fullContentRedirect", fullContentRedirect);
 			%>
 
-			<span class="d-inline-flex">
+			<div class="d-inline-flex">
 				<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-			</span>
+			</div>
 		</c:if>
 	</div>
 


### PR DESCRIPTION
LPS-128744 Fix broken DOM structure caused by LPS-120600, DOM contains an empty element p and asset-actions.jsp content places outside his parent element span. Change asset_actions.jsp parent element span with div for markup validity as actions contain a div and span can't be parent of a div.

Resend from frontend review to echo team as per request liferay-frontend#870 (comment)