### PR TITLE
[TS] LPS-129055

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
@@ -194,13 +194,20 @@ public class KnowledgeBaseArticleResourceImpl
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
 
-				booleanFilter.add(
-					new TermFilter(
-						Field.FOLDER_ID,
-						String.valueOf(kbFolder.getKbFolderId())),
-					BooleanClauseOccur.MUST);
+				if (GetterUtil.getBoolean(flatten)) {
+					booleanFilter.add(
+						new TermFilter(
+							Field.TREE_PATH,
+							String.valueOf(kbFolder.getKbFolderId())),
+						BooleanClauseOccur.MUST);
+				}
+				else {
+					booleanFilter.add(
+						new TermFilter(
+							Field.FOLDER_ID,
+							String.valueOf(kbFolder.getKbFolderId())),
+						BooleanClauseOccur.MUST);
 
-				if (!GetterUtil.getBoolean(flatten)) {
 					booleanFilter.add(
 						new TermFilter(
 							"parentMessageId",

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticle.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticle.java
@@ -56,6 +56,9 @@ public interface KBArticle extends KBArticleModel, PersistedModel {
 
 		};
 
+	public String buildTreePath()
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public java.util.List<Long> getAncestorResourcePrimaryKeys()
 		throws com.liferay.portal.kernel.exception.PortalException;
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleWrapper.java
@@ -257,6 +257,13 @@ public class KBArticleWrapper
 	}
 
 	@Override
+	public String buildTreePath()
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.buildTreePath();
+	}
+
+	@Override
 	public java.util.List<Long> getAncestorResourcePrimaryKeys()
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/model/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -21,6 +21,7 @@ import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
 import com.liferay.knowledge.base.service.KBFolderLocalService;
 import com.liferay.knowledge.base.util.KnowledgeBaseUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -47,6 +48,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -138,6 +140,9 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 		document.addKeyword(
 			"parentMessageId", kbArticle.getParentResourcePrimKey());
 		document.addKeyword("titleKeyword", kbArticle.getTitle(), true);
+		document.addKeyword(
+			Field.TREE_PATH,
+			StringUtil.split(kbArticle.buildTreePath(), CharPool.SLASH));
 		document.addKeywordSortable("urlTitle", kbArticle.getUrlTitle());
 
 		return document;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -186,10 +186,22 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 
 	@Override
 	protected void doReindex(String className, long classPK) throws Exception {
-		KBArticle kbArticle = kbArticleLocalService.getLatestKBArticle(
+		KBArticle kbArticle = kbArticleLocalService.fetchLatestKBArticle(
 			classPK, WorkflowConstants.STATUS_ANY);
 
-		reindexKBArticles(kbArticle);
+		if (kbArticle != null) {
+			reindexKBArticles(kbArticle);
+
+			return;
+		}
+
+		long kbArticleId = classPK;
+
+		kbArticle = kbArticleLocalService.fetchKBArticle(kbArticleId);
+
+		if (kbArticle != null) {
+			reindexKBArticles(kbArticle);
+		}
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
@@ -23,7 +23,9 @@ import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBArticleLocalServiceUtil;
 import com.liferay.knowledge.base.service.KBArticleServiceUtil;
+import com.liferay.knowledge.base.service.KBFolderLocalServiceUtil;
 import com.liferay.knowledge.base.service.KBFolderServiceUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -48,6 +50,34 @@ import java.util.Locale;
 public class KBArticleImpl extends KBArticleBaseImpl {
 
 	public KBArticleImpl() {
+	}
+
+	@Override
+	public String buildTreePath() throws PortalException {
+		List<KBFolder> folders = new ArrayList<>();
+
+		KBFolder folder = KBFolderLocalServiceUtil.fetchKBFolder(
+			getParentResourcePrimKey());
+
+		while (folder != null) {
+			folders.add(folder);
+
+			folder = folder.getParentKBFolder();
+		}
+
+		StringBundler sb = new StringBundler((folders.size() * 2) + 1);
+
+		sb.append("/");
+
+		for (int i = folders.size() - 1; i >= 0; i--) {
+			folder = folders.get(i);
+
+			sb.append(folder.getKbFolderId());
+
+			sb.append("/");
+		}
+
+		return sb.toString();
 	}
 
 	@Override


### PR DESCRIPTION

From @jesseyeh-liferay 

> ```http://localhost:8080/o/headless-delivery/v1.0/knowledge-base-folders/{folderid}/knowledge-base-articles?flatten=true```
>
> [LPS-129055](https://issues.liferay.com/browse/LPS-129055) resolves an issue in which the `flatten` parameter, in queries such as the above, does not return all KBArticles located in the specified folder and its subfolders. Instead, only the articles in the immediate KBFolder are returned.
> 
> This issue occurs because KBArticles have no `treePath` with which to describe their location relative to the KBFolders that contain them. This is resolved by https://github.com/ChrisKian/liferay-portal/commit/7ef38d9e00b412e044098a7b0c56b132ab3f21c5, which constructs a `treePath` for each KBArticle. Example:
> 
> ```
> 38514
>   │
>   ├──►articleA
>   │
>   └──►38519
>         │
>         ├──►articleB
>         │
>         └──►38545
>               │
>               └──►articleC
> ```
> Given this hierarchy of KBFolder `folderId`s and KBArticles, each article and its `treePath` are as follows:
> | KBArticle | `treePath` |
> | --- | --- |
> | articleA | /38514/ |
> | articleB | /38514/38519/ |
> | articleC | /38514/38519/38545/ |
> 
> The `treePath`s are then handled as `/`-delimited arrays. As a result, specifying `38519` in the above query will now return both articleB and articleC since their `treePath`s both contain this value.
> 
> **Additional Notes**
> Moving a KBFolder requires a reindex in order to reconstruct the `treePath`s for all articles contained in the folder/subfolders being moved. See https://github.com/ChrisKian/liferay-portal/pull/286/commits/5e55f0f9532fde794e8783a214cb4e6039789575 and https://github.com/ChrisKian/liferay-portal/pull/286/commits/718c7ad39630ad1a86068e6d9427de9da8e9254a.