### PR TITLE
COMMERCE-2623 Added possibility to remove all order items from CommerceOrderContentPortlet

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/edit_order.jsp
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/edit_order.jsp
@@ -279,6 +279,17 @@ List<CommerceAddress> billingAddresses = commerceOrderContentDisplayContext.getB
 				message="delete"
 				url="<%= deleteURL %>"
 			/>
+
+			<portlet:actionURL name="/commerce_open_order_content/edit_commerce_order_item" var="deleteOrderContentURL">
+				<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESET %>" />
+				<portlet:param name="redirect" value="<%= currentURL %>" />
+				<portlet:param name="commerceOrderId" value="<%= String.valueOf(commerceOrder.getCommerceOrderId()) %>" />
+			</portlet:actionURL>
+
+			<liferay-ui:icon-delete
+				message="remove-all-items"
+				url="<%= deleteOrderContentURL %>"
+			/>
 		</c:if>
 	</liferay-ui:icon-menu>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49437061/114205014-2910b800-995a-11eb-983c-396880035e62.png)

As per screenshot, added the "Remove All Items" action item remove all of the order items, though leaving the order intact.