### PR TITLE
Use tooltip-support-web as global tooltip provider and remove unneccessary ClayTooltipProvider components

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/package.json
+++ b/modules/apps/commerce/commerce-frontend-js/package.json
@@ -20,11 +20,11 @@
 		"@clayui/shared": "3.5.1",
 		"@clayui/sticker": "3.3.0",
 		"@clayui/table": "3.1.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",
-		"prop-types": "15.7.2"
+		"prop-types": "15.7.2",
+		"react-dom": "16.12.0"
 	},
 	"devDependencies": {
 		"clay-css": "^2.16.2",

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/data_renderers/TooltipPriceRenderer.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/data_renderers/TooltipPriceRenderer.js
@@ -13,7 +13,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
+import ReactDOMServer from 'react-dom/server';
 import Proptypes from 'prop-types';
 import React from 'react';
 
@@ -58,17 +58,15 @@ function TooltipPriceRenderer(props) {
 		<>
 			{props.value.final.value}
 			{props.value.details && (
-				<ClayTooltipProvider
-					contentRenderer={() => <TooltipTable {...props} />}
-					delay={0}
+				<span
+					className="tooltip-provider"
+					title={ReactDOMServer.renderToString(
+						<TooltipTable {...props} />
+					)}
+					data-tooltip-delay="0"
 				>
-					<span
-						className="tooltip-provider"
-						title={Liferay.Language.get('price-summary')}
-					>
-						<ClayIcon symbol="info-circle" />
-					</span>
-				</ClayTooltipProvider>
+					<ClayIcon symbol="info-circle" />
+				</span>
 			)}
 		</>
 	);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
@@ -17,7 +17,6 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classnames from 'classnames';
 import React, {useEffect, useState} from 'react';
 import {useDrag} from 'react-dnd';
@@ -89,97 +88,95 @@ const FieldType = (props) => {
 	const fieldIcon = ICONS[icon] ? ICONS[icon] : icon;
 
 	return (
-		<ClayTooltipProvider>
-			<ClayLayout.ContentRow
-				className={classnames(className, 'field-type', {
-					active,
-					disabled,
-					dragging,
-					loading,
+		<ClayLayout.ContentRow
+			className={classnames(className, 'field-type', {
+				active,
+				disabled,
+				dragging,
+				loading,
+			})}
+			data-field-type-name={name}
+			onClick={onClick && handleOnClick}
+			onDoubleClick={handleOnDoubleClick}
+			ref={drag}
+			title={label}
+			verticalAlign="center"
+		>
+			{draggable && dragAlignment === 'left' && (
+				<ClayLayout.ContentCol className="pl-2 pr-2">
+					<ClayIcon symbol="drag" />
+				</ClayLayout.ContentCol>
+			)}
+
+			<ClayLayout.ContentCol
+				className={classnames('pr-2', {
+					'pl-2': dragAlignment === 'right',
 				})}
-				data-field-type-name={name}
-				onClick={onClick && handleOnClick}
-				onDoubleClick={handleOnDoubleClick}
-				ref={drag}
-				title={label}
-				verticalAlign="center"
 			>
-				{draggable && dragAlignment === 'left' && (
-					<ClayLayout.ContentCol className="pl-2 pr-2">
-						<ClayIcon symbol="drag" />
-					</ClayLayout.ContentCol>
-				)}
-
-				<ClayLayout.ContentCol
-					className={classnames('pr-2', {
-						'pl-2': dragAlignment === 'right',
-					})}
+				<ClaySticker
+					className="data-layout-builder-field-sticker"
+					displayType="light"
+					size="md"
 				>
-					<ClaySticker
-						className="data-layout-builder-field-sticker"
-						displayType="light"
-						size="md"
-					>
-						<ClayIcon symbol={fieldIcon} />
-					</ClaySticker>
-				</ClayLayout.ContentCol>
-				<ClayLayout.ContentCol className="pr-2" expand>
-					<div className="d-flex list-group-title">
-						<span className="text-truncate">{label}</span>
-						{required && (
-							<span className="reference-mark">
-								<ClayIcon symbol="asterisk" />
-							</span>
-						)}
-					</div>
-					{description && (
-						<p className="list-group-subtitle text-truncate">
-							<small>{description}</small>
-						</p>
+					<ClayIcon symbol={fieldIcon} />
+				</ClaySticker>
+			</ClayLayout.ContentCol>
+			<ClayLayout.ContentCol className="pr-2" expand>
+				<div className="d-flex list-group-title">
+					<span className="text-truncate">{label}</span>
+					{required && (
+						<span className="reference-mark">
+							<ClayIcon symbol="asterisk" />
+						</span>
 					)}
-				</ClayLayout.ContentCol>
-
-				<div className="autofit-col pr-2">
-					{actions && <DropDown actions={actions} />}
 				</div>
-
-				{draggable && dragAlignment === 'right' && (
-					<ClayLayout.ContentCol className="pr-2">
-						<ClayIcon symbol="drag" />
-					</ClayLayout.ContentCol>
+				{description && (
+					<p className="list-group-subtitle text-truncate">
+						<small>{description}</small>
+					</p>
 				)}
+			</ClayLayout.ContentCol>
 
-				{onDelete && (
-					<div className="field-type-remove-icon">
-						{loading ? (
-							<ClayLoadingIndicator />
-						) : (
-							<ClayButtonWithIcon
-								borderless
-								data-tooltip-align="right"
-								data-tooltip-delay="200"
-								displayType="secondary"
-								onClick={(event) => {
-									event.stopPropagation();
+			<div className="autofit-col pr-2">
+				{actions && <DropDown actions={actions} />}
+			</div>
 
-									setLoading(true);
+			{draggable && dragAlignment === 'right' && (
+				<ClayLayout.ContentCol className="pr-2">
+					<ClayIcon symbol="drag" />
+				</ClayLayout.ContentCol>
+			)}
 
-									onDelete(name)
-										.then(() => setLoading(false))
-										.catch((error) => {
-											setLoading(false);
+			{onDelete && (
+				<div className="field-type-remove-icon">
+					{loading ? (
+						<ClayLoadingIndicator />
+					) : (
+						<ClayButtonWithIcon
+							borderless
+							data-tooltip-align="right"
+							data-tooltip-delay="200"
+							displayType="secondary"
+							onClick={(event) => {
+								event.stopPropagation();
 
-											throw error;
-										});
-								}}
-								symbol="times-circle"
-								title={deleteLabel}
-							/>
-						)}
-					</div>
-				)}
-			</ClayLayout.ContentRow>
-		</ClayTooltipProvider>
+								setLoading(true);
+
+								onDelete(name)
+									.then(() => setLoading(false))
+									.catch((error) => {
+										setLoading(false);
+
+										throw error;
+									});
+							}}
+							symbol="times-circle"
+							title={deleteLabel}
+						/>
+					)}
+				</div>
+			)}
+		</ClayLayout.ContentRow>
 	);
 };
 

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"@clayui/icon": "3.1.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-state-web": "*",
 		"classnames": "2.2.6",
 		"formik": "2.1.4",

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -13,7 +13,6 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -83,11 +82,9 @@ export default function render(
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(
-			<ClayTooltipProvider>
-				<ClayIconSpriteContext.Provider value={spritemap}>
-					{Component ? <Component {...renderData} /> : renderable}
-				</ClayIconSpriteContext.Provider>
-			</ClayTooltipProvider>,
+			<ClayIconSpriteContext.Provider value={spritemap}>
+				{Component ? <Component {...renderData} /> : renderable}
+			</ClayIconSpriteContext.Provider>,
 			container
 		);
 	}

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
@@ -4,6 +4,7 @@
 		"@liferay/frontend-js-react-web": "*",
 		"react": "16.12.0"
 	},
+	"main": "index.js",
 	"name": "frontend-js-tooltip-support-web",
 	"private": true,
 	"scripts": {

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
@@ -14,6 +14,10 @@
 
 import ClayTooltip from '@clayui/tooltip';
 import {render, useTimeout} from '@liferay/frontend-js-react-web';
+
+// Hack to get around frontend-js-web not being in TS
+// @ts-ignore
+
 import {ALIGN_POSITIONS as POSITIONS, align, delegate} from 'frontend-js-web';
 import React, {
 	useEffect,
@@ -34,7 +38,7 @@ const ALIGN_POSITIONS = [
 	'bottom-left',
 	'left',
 	'right',
-];
+] as const;
 
 const SELECTOR_TOOLTIP = '.tooltip[role="tooltip"]';
 const SELECTOR_TRIGGER = `
@@ -108,7 +112,7 @@ const TooltipProvider = () => {
 		return dispose;
 	}, [delay, state]);
 
-	const saveTitle = (element) => {
+	const saveTitle = (element: HTMLElement) => {
 		if (element) {
 			const title = element.getAttribute('title');
 
@@ -131,7 +135,7 @@ const TooltipProvider = () => {
 		}
 	};
 
-	const restoreTitle = (element) => {
+	const restoreTitle = (element?: HTMLElement) => {
 		if (element) {
 			const title = element.getAttribute('data-restore-title');
 
@@ -158,7 +162,7 @@ const TooltipProvider = () => {
 				document.body,
 				eventName,
 				SELECTOR_TRIGGER,
-				(event) => {
+				(event: MouseEvent & {delegateTarget: HTMLElement}) => {
 					saveTitle(event.delegateTarget);
 
 					dispatch({target: event.delegateTarget, type: 'show'});
@@ -217,7 +221,8 @@ const TooltipProvider = () => {
 					__html:
 						state.target.title ||
 						state.target.dataset.restoreTitle ||
-						state.target.dataset.title,
+						state.target.dataset.title ||
+						'',
 				}}
 			/>
 		</ClayTooltip>

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.tsx
@@ -42,6 +42,8 @@ const ALIGN_POSITIONS = [
 
 const SELECTOR_TOOLTIP = '.tooltip[role="tooltip"]';
 const SELECTOR_TRIGGER = `
+	[title]:not(data-tooltip-disable),
+	[data-title]:not(data-tooltip-disable),
 	.lfr-portal-tooltip,
 	.manage-collaborators-dialog .lexicon-icon[data-title]:not(.lfr-portal-tooltip),
 	.manage-collaborators-dialog .lexicon-icon[title]:not(.lfr-portal-tooltip),

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/reducer.ts
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/reducer.ts
@@ -22,7 +22,20 @@ const STATES = {
 
 export {STATES};
 
-export default function reducer(state, action) {
+interface State {
+	current: {show: boolean};
+	nextTarget?: HTMLElement;
+	target?: HTMLElement;
+	timestamp?: number;
+}
+
+type Action =
+	| {type: 'hide'}
+	| {type: 'hideDelayCompleted'}
+	| {type: 'showDelayCompleted'}
+	| {type: 'show'; target?: HTMLElement};
+
+export default function reducer(state: State, action: Action): State {
 	switch (action.type) {
 		case 'show':
 			if (state.current === STATES.IDLE) {

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/tsconfig.json
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/tsconfig.json
@@ -1,0 +1,38 @@
+{
+	"@generated": "8ae8dc877032bcba179f5ba5280f23976d8b77cf",
+	"@overrides": {
+	},
+	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
+	"@see": "https://git.io/JY2EA",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"baseUrl": ".",
+		"composite": true,
+		"jsx": "react",
+		"module": "es6",
+		"moduleResolution": "node",
+		"outDir": "./types",
+		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			]
+		},
+		"sourceMap": false,
+		"strict": true,
+		"target": "es6",
+		"tsBuildInfoFile": "tmp/tsconfig.tsbuildinfo",
+		"typeRoots": [
+			"../../../node_modules/@types",
+			"./node_modules/@types"
+		]
+	},
+	"include": [
+		"src/**/*",
+		"test/**/*"
+	],
+	"references": [
+		{
+			"path": "../frontend-js-react-web"
+		}
+	]
+}

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare const _default: () => void;
+export default _default;

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/types/src/main/resources/META-INF/resources/reducer.d.ts
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/types/src/main/resources/META-INF/resources/reducer.d.ts
@@ -38,8 +38,18 @@ interface State {
 	target?: HTMLElement;
 	timestamp?: number;
 }
-declare type Action = {
-	target?: HTMLElement;
-	type: string;
-};
+declare type Action =
+	| {
+			type: 'hide';
+	  }
+	| {
+			type: 'hideDelayCompleted';
+	  }
+	| {
+			type: 'showDelayCompleted';
+	  }
+	| {
+			type: 'show';
+			target?: HTMLElement;
+	  };
 export default function reducer(state: State, action: Action): State;

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/types/src/main/resources/META-INF/resources/reducer.d.ts
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/types/src/main/resources/META-INF/resources/reducer.d.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare const STATES: {
+	IDLE: {
+		show: boolean;
+	};
+	SHOW: {
+		show: boolean;
+	};
+	WAIT_HIDE: {
+		show: boolean;
+	};
+	WAIT_RESHOW: {
+		show: boolean;
+	};
+	WAIT_SHOW: {
+		show: boolean;
+	};
+};
+export {STATES};
+interface State {
+	current: {
+		show: boolean;
+	};
+	nextTarget?: HTMLElement;
+	target?: HTMLElement;
+	timestamp?: number;
+}
+declare type Action = {
+	target?: HTMLElement;
+	type: string;
+};
+export default function reducer(state: State, action: Action): State;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Multiselect.js
@@ -14,7 +14,6 @@
 
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayMultiSelect from '@clayui/multi-select';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
 export default function Multiselect({
@@ -43,40 +42,36 @@ export default function Multiselect({
 	const [selectedItems, setSelectedItems] = useState(_selectedItems);
 
 	return (
-		<ClayTooltipProvider>
-			<ClayForm.Group className={!isValid ? 'has-error' : ''}>
-				{label && <label htmlFor={id}>{label}</label>}
+		<ClayForm.Group className={!isValid ? 'has-error' : ''}>
+			{label && <label htmlFor={id}>{label}</label>}
 
-				<ClayInput.Group>
-					<ClayInput.GroupItem>
-						<ClayMultiSelect
-							className={cssClass}
-							clearAllTitle={clearAllTitle}
-							closeButtonAriaLabel={Liferay.Language.get(
-								'remove-x'
-							)}
-							disabled={disabled}
-							disabledClearAll={disabledClearAll}
-							id={id}
-							inputName={inputName}
-							inputValue={inputValue}
-							isValid={isValid}
-							items={selectedItems}
-							locator={multiselectLocator}
-							onChange={setInputValue}
-							onItemsChange={setSelectedItems}
-							sourceItems={sourceItems}
-							{...otherProps}
-						/>
+			<ClayInput.Group>
+				<ClayInput.GroupItem>
+					<ClayMultiSelect
+						className={cssClass}
+						clearAllTitle={clearAllTitle}
+						closeButtonAriaLabel={Liferay.Language.get('remove-x')}
+						disabled={disabled}
+						disabledClearAll={disabledClearAll}
+						id={id}
+						inputName={inputName}
+						inputValue={inputValue}
+						isValid={isValid}
+						items={selectedItems}
+						locator={multiselectLocator}
+						onChange={setInputValue}
+						onItemsChange={setSelectedItems}
+						sourceItems={sourceItems}
+						{...otherProps}
+					/>
 
-						{helpText && (
-							<ClayForm.FeedbackGroup>
-								<ClayForm.Text>{helpText}</ClayForm.Text>
-							</ClayForm.FeedbackGroup>
-						)}
-					</ClayInput.GroupItem>
-				</ClayInput.Group>
-			</ClayForm.Group>
-		</ClayTooltipProvider>
+					{helpText && (
+						<ClayForm.FeedbackGroup>
+							<ClayForm.Text>{helpText}</ClayForm.Text>
+						</ClayForm.FeedbackGroup>
+					)}
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+		</ClayForm.Group>
 	);
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/TooltipSummaryRenderer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/data_renderers/TooltipSummaryRenderer.js
@@ -13,10 +13,10 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import Proptypes from 'prop-types';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 import {getDataRendererById} from '../utils/dataRenderers';
 import {getSchemaString} from '../utils/index';
@@ -84,8 +84,10 @@ function TooltipSummaryRenderer({itemData, options, value}) {
 		<>
 			{value}
 			{tooltipTableRows.length && (
-				<ClayTooltipProvider
-					contentRenderer={() => (
+				<span
+					className="tooltip-provider"
+					data-tooltip-delay="0"
+					title={ReactDOMServer.renderToString(
 						<table className="tooltip-table">
 							<tbody>
 								{tooltipTableRows.map((rowData) => (
@@ -97,15 +99,9 @@ function TooltipSummaryRenderer({itemData, options, value}) {
 							</tbody>
 						</table>
 					)}
-					delay={0}
 				>
-					<span
-						className="tooltip-provider"
-						title={Liferay.Language.get('info')}
-					>
-						<ClayIcon symbol="info-circle" />
-					</span>
-				</ClayTooltipProvider>
+					<ClayIcon symbol="info-circle" />
+				</span>
 			)}
 		</>
 	);

--- a/modules/apps/journal/journal-web/package.json
+++ b/modules/apps/journal/journal-web/package.json
@@ -7,7 +7,6 @@
 		"@clayui/icon": "3.1.0",
 		"@clayui/label": "3.4.1",
 		"@clayui/panel": "3.25.0",
-		"@clayui/tooltip": "3.4.5",
 		"codemirror": "^5.52.2",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template_editor/components/Button.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template_editor/components/Button.js
@@ -13,7 +13,6 @@
  */
 
 import ClayButton from '@clayui/button';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -21,24 +20,18 @@ const noop = () => {};
 
 export const Button = ({label, onClick = noop, tooltip}) => {
 	return (
-		<ClayTooltipProvider
-			contentRenderer={({title}) => (
-				<div dangerouslySetInnerHTML={{__html: title}} />
-			)}
-			delay={0}
+		<ClayButton
+			borderless
+			className="font-weight-normal text-left text-truncate w-100"
+			data-tooltip-align="right"
+			data-tooltip-delay="0"
+			displayType="unstyled"
+			key={label}
+			onClick={onClick}
+			title={tooltip}
 		>
-			<ClayButton
-				borderless
-				className="font-weight-normal text-left text-truncate w-100"
-				data-tooltip-align="right"
-				displayType="unstyled"
-				key={label}
-				onClick={onClick}
-				title={tooltip}
-			>
-				{label}
-			</ClayButton>
-		</ClayTooltipProvider>
+			{label}
+		</ClayButton>
 	);
 };
 

--- a/modules/apps/layout/layout-reports-web/package.json
+++ b/modules/apps/layout/layout-reports-web/package.json
@@ -7,7 +7,6 @@
 		"@clayui/label": "3.4.1",
 		"@clayui/layout": "3.3.0",
 		"@clayui/loading-indicator": "3.2.0",
-		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -13,7 +13,6 @@
  */
 
 import ClayLayout from '@clayui/layout';
-import {ClayTooltipProvider} from '@clayui/tooltip';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -54,30 +53,26 @@ export default function BasicInformation({canonicalURLs, defaultLanguageId}) {
 			</ClayLayout.ContentCol>
 			<ClayLayout.ContentCol expand>
 				<ClayLayout.ContentRow>
-					<ClayTooltipProvider>
-						<span className="font-weight-semi-bold text-truncate-inline">
-							<span
-								className="text-truncate"
-								data-tooltip-align="bottom"
-								title={selectedCanonicalURL.title}
-							>
-								{selectedCanonicalURL.title}
-							</span>
+					<span className="font-weight-semi-bold text-truncate-inline">
+						<span
+							className="text-truncate"
+							data-tooltip-align="bottom"
+							title={selectedCanonicalURL.title}
+						>
+							{selectedCanonicalURL.title}
 						</span>
-					</ClayTooltipProvider>
+					</span>
 				</ClayLayout.ContentRow>
 				<ClayLayout.ContentRow>
-					<ClayTooltipProvider>
-						<span
-							className="text-truncate text-truncate-reverse"
-							data-tooltip-align="bottom"
-							title={selectedCanonicalURL.canonicalURL}
-						>
-							<bdi className="text-secondary">
-								{selectedCanonicalURL.canonicalURL}
-							</bdi>
-						</span>
-					</ClayTooltipProvider>
+					<span
+						className="text-truncate text-truncate-reverse"
+						data-tooltip-align="bottom"
+						title={selectedCanonicalURL.canonicalURL}
+					>
+						<bdi className="text-secondary">
+							{selectedCanonicalURL.canonicalURL}
+						</bdi>
+					</span>
 				</ClayLayout.ContentRow>
 			</ClayLayout.ContentCol>
 		</ClayLayout.ContentRow>


### PR DESCRIPTION
cc @matuzalemsteles @wincent @markocikos

I was taking a look at tooltips in DXP and I think we can get away with purely using the `tooltip-support-web` module instead of making changes to how the ClayTooltipProvider component works.

1. I added `[title]:not(data-tooltip-disable)` and `[data-title]:not(data-tooltip-disable)` as selectors for our global tooltip.
2. I removed any use of just `<ClayTooltipProvider>` where we didn't need any customization.
3. Some uses were only using it for the `delay` prop, so I just added that as a `data-tooltip-delay` attribute
4. For uses of a custom `contentRenderer`, I replaced those titles with the html version of that custom component by utilizing `ReactDOMServer.renderToString`.

The last part is the one I am must unsure about. Anyone have any concerns or see issues with this?