### PR TITLE
Lps 130642

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/util/test/AssetPublisherHelperTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/util/test/AssetPublisherHelperTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -323,6 +324,8 @@ public class AssetPublisherHelperTest {
 	public void testGetAssetTagNamesContainsAllTagName() throws Exception {
 		String assetTagName = RandomTestUtil.randomString();
 
+		assetTagName = StringUtil.toLowerCase(StringUtil.trim(assetTagName));
+
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			true, true, "assetTags", new String[] {assetTagName});
 
@@ -342,6 +345,9 @@ public class AssetPublisherHelperTest {
 	public void testGetAssetTagNamesContainsAllTagNames() throws Exception {
 		String assetTagName1 = RandomTestUtil.randomString();
 		String assetTagName2 = RandomTestUtil.randomString();
+
+		assetTagName1 = StringUtil.toLowerCase(StringUtil.trim(assetTagName1));
+		assetTagName2 = StringUtil.toLowerCase(StringUtil.trim(assetTagName2));
 
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			true, true, "assetTags",
@@ -364,6 +370,8 @@ public class AssetPublisherHelperTest {
 	public void testGetAssetTagNamesContainsAnyTagName() throws Exception {
 		String assetTagName = RandomTestUtil.randomString();
 
+		assetTagName = StringUtil.toLowerCase(StringUtil.trim(assetTagName));
+
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			true, false, "assetTags", new String[] {assetTagName});
 
@@ -384,6 +392,9 @@ public class AssetPublisherHelperTest {
 		String assetTagName1 = RandomTestUtil.randomString();
 		String assetTagName2 = RandomTestUtil.randomString();
 
+		assetTagName1 = StringUtil.toLowerCase(StringUtil.trim(assetTagName1));
+		assetTagName2 = StringUtil.toLowerCase(StringUtil.trim(assetTagName2));
+
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			true, false, "assetTags",
 			new String[] {assetTagName1, assetTagName2});
@@ -402,6 +413,8 @@ public class AssetPublisherHelperTest {
 	@Test
 	public void testGetAssetTagNamesNotContainsAllTagName() throws Exception {
 		String assetTagName = RandomTestUtil.randomString();
+
+		assetTagName = StringUtil.toLowerCase(StringUtil.trim(assetTagName));
 
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			false, true, "assetTags", new String[] {assetTagName});
@@ -422,6 +435,9 @@ public class AssetPublisherHelperTest {
 		String assetTagName1 = RandomTestUtil.randomString();
 		String assetTagName2 = RandomTestUtil.randomString();
 
+		assetTagName1 = StringUtil.toLowerCase(StringUtil.trim(assetTagName1));
+		assetTagName2 = StringUtil.toLowerCase(StringUtil.trim(assetTagName2));
+
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			false, true, "assetTags",
 			new String[] {assetTagName1, assetTagName2});
@@ -441,6 +457,8 @@ public class AssetPublisherHelperTest {
 	public void testGetAssetTagNamesNotContainsAnyTagName() throws Exception {
 		String assetTagName = RandomTestUtil.randomString();
 
+		assetTagName = StringUtil.toLowerCase(StringUtil.trim(assetTagName));
+
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			false, false, "assetTags", new String[] {assetTagName});
 
@@ -459,6 +477,9 @@ public class AssetPublisherHelperTest {
 	public void testGetAssetTagNamesNotContainsAnyTagNames() throws Exception {
 		String assetTagName1 = RandomTestUtil.randomString();
 		String assetTagName2 = RandomTestUtil.randomString();
+
+		assetTagName1 = StringUtil.toLowerCase(StringUtil.trim(assetTagName1));
+		assetTagName2 = StringUtil.toLowerCase(StringUtil.trim(assetTagName2));
 
 		AssetQueryRule assetQueryRule = new AssetQueryRule(
 			false, false, "assetTags",

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -86,6 +86,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
@@ -520,7 +521,13 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 			}
 		}
 
-		return allAssetTagNames.toArray(new String[0]);
+		Stream<String> stream = allAssetTagNames.stream();
+
+		return stream.map(
+			String::toLowerCase
+		).toArray(
+			String[]::new
+		);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -392,6 +392,8 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<Long> tagIds = new ArrayList<>(names.length);
 
 		for (String name : names) {
+			name = StringUtil.toLowerCase(StringUtil.trim(name));
+
 			AssetTag tag = fetchTag(groupId, name);
 
 			if (tag == null) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130642

In Liferay 6.2, when fetching and finding AssetTags by name and groupId we cast the name passed in from PortletPreferences to lower case. The method was changed from 6.2 in [LPS-52588](https://issues.liferay.com/browse/LPS-52588) to simplify some of the calls for asset tags. However the method AssetTagFinderImpl.doFindByG_N used prior to LPS-52588 [cast the name passed in to lower case](https://github.com/brianchandotcom/liferay-portal/pull/23223/commits/b02d2ac41e6345c66ab3bd96cbfe96aad5808d97#diff-0cca6d98caade78feb402775c9a8267db01974d99bd490cd563d83728ff081d8L350), the methods now used do not however, so we should cast to lower case prior to passing into the persistence layer.

b2a1e8bab150d51c8d15dc234fad71d9c0ea4766 addresses test failures noted  in https://github.com/liferay-echo/liferay-portal/pull/4265#issuecomment-822355954.