### PR TITLE
[TECHNICAL-SUPPORT] LPS-131983 WCAG error for missing label association with input fields in Liferay Forms

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -224,11 +224,13 @@ const DatePicker = ({
 		<>
 			<input
 				aria-hidden="true"
+				id={name + '_fieldDetails'}
 				name={name}
 				type="hidden"
 				value={getValueForHidden(value)}
 			/>
 			<ClayDatePicker
+				aria-labelledby={name + '_fieldDetails'}
 				dateFormat={dateMask}
 				disabled={disabled}
 				expanded={expanded}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -139,6 +139,7 @@ function FieldBase({
 	displayErrors,
 	errorMessage,
 	fieldName,
+	id,
 	label,
 	localizedValue = {},
 	name,
@@ -193,7 +194,7 @@ function FieldBase({
 			type === 'paragraph' ||
 			type === 'radio');
 
-	const fieldDetailsId = name + '_fieldDetails';
+	const fieldDetailsId = id ? id + '_fieldDetails' : name + '_fieldDetails';
 	const hasError = displayErrors && errorMessage && !valid;
 
 	let fieldDetails = '';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -88,6 +88,7 @@ const Text = ({
 
 	return (
 		<ClayInput
+			aria-labelledby={id}
 			className="ddm-field-text"
 			dir={Liferay.Language.direction[editingLanguageId]}
 			disabled={disabled}
@@ -140,6 +141,7 @@ const Textarea = ({
 
 	return (
 		<textarea
+			aria-labelledby={id}
 			className="ddm-field-text form-control"
 			dir={Liferay.Language.direction[editingLanguageId]}
 			disabled={disabled}
@@ -243,6 +245,7 @@ const Autocomplete = ({
 	return (
 		<ClayAutocomplete>
 			<ClayAutocomplete.Input
+				aria-labelledby={id}
 				dir={Liferay.Language.direction[editingLanguageId]}
 				disabled={disabled}
 				id={id}
@@ -363,6 +366,8 @@ const Main = ({
 				: `singleline`
 		];
 
+	const fieldDetailsId = id ? id + '_fieldDetails' : name + '_fieldDetails';
+
 	return (
 		<FieldBase
 			{...otherProps}
@@ -377,7 +382,7 @@ const Main = ({
 				disabled={readOnly}
 				editingLanguageId={editingLanguageId}
 				fieldName={fieldName}
-				id={id}
+				id={fieldDetailsId}
 				localizable={localizable}
 				localizedValue={localizedValue}
 				name={name}


### PR DESCRIPTION
Hey,
[LPS-131983](https://issues.liferay.com/browse/LPS-131983),

The WCAG test fails on our inputs due they are not having the aria-labelledby attribute, and neither the labels targeting the correct id's with aria-describedby attributes. This issue was discovered with the text and date picker fields.
Please review my changes,

Thanks!