### PR TITLE
LPS-132212 Fieldset links are duplicated on the Propagation and Delete dialogs

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/schema/DataDefinition.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/schema/DataDefinition.es.js
@@ -22,6 +22,7 @@ export class DataDefinitionSchema extends Schema {
 		'availableLanguageIds',
 		'dataDefinition',
 		'defaultLanguageId',
+		'id',
 		'name',
 		'pages',
 	];
@@ -70,6 +71,14 @@ export class DataDefinitionSchema extends Schema {
 		return this[SYMBOL_RAW].defaultLanguageId;
 	}
 
+	get id() {
+		const {
+			dataDefinition: {id},
+		} = this[SYMBOL_RAW];
+
+		return id;
+	}
+
 	get name() {
 		return this[SYMBOL_RAW].name;
 	}
@@ -80,6 +89,7 @@ export class DataDefinitionSchema extends Schema {
 			contentType: this.contentType,
 			dataDefinitionFields: this.dataDefinitionFields,
 			defaultLanguageId: this.defaultLanguageId,
+			id: this.id,
 			name: this.name,
 		};
 	}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/schema/DataLayout.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/schema/DataLayout.es.js
@@ -66,7 +66,7 @@ export class DataLayoutPageSchema extends Schema {
 }
 
 export class DataLayoutSchema extends Schema {
-	static props = ['dataLayout', 'name', 'pages', 'rules'];
+	static props = ['dataLayout', 'id', 'name', 'pages', 'rules'];
 
 	constructor(raw) {
 		super('data_engine', 'dataLayout', raw);
@@ -95,6 +95,16 @@ export class DataLayoutSchema extends Schema {
 		return this[SYMBOL_RAW].name;
 	}
 
+	get id() {
+		const {
+			dataLayout: {
+				dataLayout: {id},
+			},
+		} = this[SYMBOL_RAW];
+
+		return id;
+	}
+
 	serialize() {
 		return {
 			dataLayoutFields: this.dataLayoutFields,
@@ -102,6 +112,7 @@ export class DataLayoutSchema extends Schema {
 				page.serialize()
 			),
 			dataRules: this.dataRules,
+			id,
 			name: this.name,
 		};
 	}


### PR DESCRIPTION
This changes are for add the property id in:

- `DataDefinitionSchema`
- `DataLayoutSchema`

This property is used in `usePropagateFieldSet.es.js` for filter the [dataLayout](https://github.com/liferay/liferay-portal/blob/6e25ad1e3cdcd4c6657caad6adef34ec3fbd64c6/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-sets/actions/usePropagateFieldSet.es.js#L89) and [dataDefinition](https://github.com/liferay/liferay-portal/blob/6e25ad1e3cdcd4c6657caad6adef34ec3fbd64c6/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-sets/actions/usePropagateFieldSet.es.js#L80).
