### PR TITLE
COMMERCE-6395 commerce-product-definitions-web reinitialize serviceContext for PriceEntry

### DIFF
--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/portlet/action/EditCPInstanceMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/portlet/action/EditCPInstanceMVCActionCommand.java
@@ -292,6 +292,8 @@ public class EditCPInstanceMVCActionCommand extends BaseMVCActionCommand {
 				_getCommercePricingConfigurationKey(),
 				CommercePricingConstants.VERSION_2_0)) {
 
+			serviceContext = ServiceContextFactory.getInstance(actionRequest);
+
 			_updateCommercePriceEntry(
 				cpInstance, CommercePriceListConstants.TYPE_PRICE_LIST, price,
 				serviceContext);


### PR DESCRIPTION
https://issues.liferay.com/browse/COMMERCE-6395

@brianikim I think this is the right fix, because PriceEntry has the custom fields.

fix of this https://github.com/liferay-commerce/liferay-portal/pull/1762