### PR TITLE
[TS] LPS-141200

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -570,7 +570,7 @@ public class JournalArticleLocalServiceImpl
 		friendlyURLMap = _checkFriendlyURLMap(locale, friendlyURLMap, titleMap);
 
 		Map<String, String> urlTitleMap = _getURLTitleMap(
-			groupId, resourcePrimKey, friendlyURLMap, titleMap);
+			groupId, resourcePrimKey, friendlyURLMap, titleMap, content);
 
 		article.setUuid(serviceContext.getUuid());
 		article.setResourcePrimKey(resourcePrimKey);
@@ -1136,7 +1136,8 @@ public class JournalArticleLocalServiceImpl
 			locale, new HashMap(), newTitleMap);
 
 		Map<String, String> newUrlTitleMap = _getURLTitleMap(
-			groupId, resourcePrimKey, friendlyURLMap, newUniqueURLTitleMap);
+			groupId, resourcePrimKey, friendlyURLMap, newUniqueURLTitleMap,
+			oldArticle.getContent());
 
 		updateFriendlyURLs(newArticle, newUrlTitleMap, serviceContext);
 
@@ -5717,7 +5718,8 @@ public class JournalArticleLocalServiceImpl
 		Locale locale = getArticleDefaultLocale(content);
 
 		Map<String, String> urlTitleMap = _getURLTitleMap(
-			groupId, article.getResourcePrimKey(), friendlyURLMap, titleMap);
+			groupId, article.getResourcePrimKey(), friendlyURLMap, titleMap,
+			content);
 
 		String urlTitle = urlTitleMap.get(LocaleUtil.toLanguageId(locale));
 
@@ -8988,7 +8990,7 @@ public class JournalArticleLocalServiceImpl
 
 	private Map<String, String> _getURLTitleMap(
 		long groupId, long resourcePrimKey, Map<Locale, String> friendlyURLMap,
-		Map<Locale, String> titleMap) {
+		Map<Locale, String> titleMap, String content) {
 
 		Map<String, String> urlTitleMap = new HashMap<>();
 
@@ -9028,6 +9030,33 @@ public class JournalArticleLocalServiceImpl
 						resourcePrimKey, value, languageId);
 
 				urlTitleMap.put(languageId, urlTitle);
+			}
+		}
+
+		try {
+			Document document = SAXReaderUtil.read(content);
+
+			Element rootElement = document.getRootElement();
+
+			String availableLocales = GetterUtil.getString(
+				rootElement.attributeValue("available-locales"));
+			String defaultLocale = GetterUtil.getString(
+				rootElement.attributeValue("default-locale"));
+
+			String[] availableLocalesArray = availableLocales.split(
+				StringPool.COMMA);
+
+			String defaultTitle = urlTitleMap.get(defaultLocale);
+
+			for (String availableLocale : availableLocalesArray) {
+				if (Validator.isNull(urlTitleMap.get(availableLocale))) {
+					urlTitleMap.put(availableLocale, defaultTitle);
+				}
+			}
+		}
+		catch (DocumentException documentException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Invalid content:\n" + content);
 			}
 		}
 


### PR DESCRIPTION
Hi Balazs,

could you please review my fix?

**Steps to reproduce**

1) Create a Content page, put an Asset publisher on it
2) Configure the AP, so it will be 'Full content' and the default AP
3) Create a web content, put 'EN-title-translated' in the title and content fields
4) Add a French translation, put 'FR-title-translated' in the title and content fields
5) Set the Content page as the display page then publish
6) Create another web content, put 'EN-title-not-translated' in the title and content fields
7) Add a French translation, don't change the title, put 'FR-title-not-translated' in the content field, publish
8) Set the Content page as the display page then publish
9) Create a Widget page, put an Asset Publisher and a Language selector on it
10) Change the language to French
11) Open the 'EN-title-translated' web content
12) You will see the French translation in both the title and content
13) Open the 'FR-title-not-translated' web content

**Current behavior:** You will see the 'EN-title-not-translated' content

**Expected behavior:** You should see the 'FR-title-not-translated' content

**Root cause:**
In case the title has no translation beside the default locale, then no titleMapAsXML parameter with the default locale translation  is sent to the backend for the translations. 
In the reproduction no titleMapAsXML_fr_FR=EN-title-not-translated is sent to the backend.

**Solution:**
On the backend we can retrive this information from the content. 

Thanks, Roland

https://issues.liferay.com/browse/LPS-141200