### PR TITLE
COMMERCE-7481 commerce-product-definitions-web price entry are never unpublished

### DIFF
--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/portlet/action/EditCPInstanceMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/portlet/action/EditCPInstanceMVCActionCommand.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.util.PropertiesParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.math.BigDecimal;
 
@@ -366,15 +367,15 @@ public class EditCPInstanceMVCActionCommand extends BaseMVCActionCommand {
 
 		_updateCommercePriceEntry(
 			cpInstance, CommercePriceListConstants.TYPE_PRICE_LIST, price,
-			serviceContext);
+			promoPrice, serviceContext);
 		_updateCommercePriceEntry(
-			cpInstance, CommercePriceListConstants.TYPE_PROMOTION, promoPrice,
-			serviceContext);
+			cpInstance, CommercePriceListConstants.TYPE_PROMOTION, price,
+			promoPrice, serviceContext);
 	}
 
 	private void _updateCommercePriceEntry(
 			CPInstance cpInstance, String type, BigDecimal price,
-			ServiceContext serviceContext)
+			BigDecimal promoPrice, ServiceContext serviceContext)
 		throws Exception {
 
 		CommercePriceList commercePriceList =
@@ -387,17 +388,19 @@ public class EditCPInstanceMVCActionCommand extends BaseMVCActionCommand {
 				commercePriceList.getCommercePriceListId(),
 				cpInstance.getCPInstanceUuid());
 
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
 		if (commercePriceEntry == null) {
 			CPDefinition cpDefinition = cpInstance.getCPDefinition();
 
 			_commercePriceEntryLocalService.addCommercePriceEntry(
 				cpDefinition.getCProductId(), cpInstance.getCPInstanceUuid(),
-				commercePriceList.getCommercePriceListId(), price, null,
+				commercePriceList.getCommercePriceListId(), price, promoPrice,
 				serviceContext);
 		}
 		else {
 			_commercePriceEntryLocalService.updateCommercePriceEntry(
-				commercePriceEntry.getCommercePriceEntryId(), price, null,
+				commercePriceEntry.getCommercePriceEntryId(), price, promoPrice,
 				serviceContext);
 		}
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/COMMERCE-7481

I've put workflow action as Published, because the price entries cannot be unpublished in the UI unless for expiration date, which cannot be changed in the SKU UI.