### PR TITLE
LPS-143549 Modify the logic so that we always call

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
@@ -76,30 +76,29 @@ public class UserBagFactoryImpl implements UserBagFactory {
 			allGroupIds.add(groupId);
 		}
 
-		long[] userGroupIds = null;
+		long[] userGroupIds = UserLocalServiceUtil.getGroupPrimaryKeys(userId);
 
-		if (userOrgs.isEmpty() && userUserGroups.isEmpty()) {
-			userGroupIds = UserLocalServiceUtil.getGroupPrimaryKeys(userId);
+		Set<Long> userGroupIdsSet = new HashSet<>();
 
-			for (long userGroupId : userGroupIds) {
-				allGroupIds.add(userGroupId);
-			}
+		for (long userGroupId : userGroupIds) {
+			userGroupIdsSet.add(userGroupId);
+
+			allGroupIds.add(userGroupId);
 		}
-		else {
+
+		if (!userOrgs.isEmpty() || !userUserGroups.isEmpty()) {
 			List<Group> userGroups = GroupLocalServiceUtil.getUserGroups(
 				userId, true);
 
-			userGroupIds = new long[userGroups.size()];
-
-			for (int i = 0; i < userGroups.size(); i++) {
-				Group userGroup = userGroups.get(i);
-
+			for (Group userGroup : userGroups) {
 				long groupId = userGroup.getGroupId();
 
-				userGroupIds[i] = groupId;
+				userGroupIdsSet.add(groupId);
 
 				allGroupIds.add(groupId);
 			}
+
+			userGroupIds = ArrayUtil.toLongArray(userGroupIdsSet);
 		}
 
 		if (allGroupIds.isEmpty()) {


### PR DESCRIPTION
Hey @drewbrokke,

This wasn't one of the fixes you suggested, but it should be fairly straightforward and should be regression-proof. Basically the change in logic is this:

**Before This Change**
No Orgs/UserGroups: `UserLocalServiceUtil.getGroupPrimaryKeys(userId)`
Else: `GroupLocalServiceUtil.getUserGroups`

**After This Change**
No Orgs/UserGroups: `UserLocalServiceUtil.getGroupPrimaryKeys(userId)`
Else: `GroupLocalServiceUtil.getUserGroups UNION UserLocalServiceUtil.getGroupPrimaryKeys(userId)`

So the only difference is now in the else case, where the user has at least 1 org or user group, we are UNIONING the result of the else case with the result of the No Orgs/UserGroups case.

Let me know what you think of this.