### PR TITLE
LPS-144395

### DIFF
--- a/modules/apps/analytics/analytics-message-sender-impl/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/analytics/analytics-message-sender-impl/src/main/resources/META-INF/module-log4j.xml
@@ -2,6 +2,6 @@
 
 <Configuration strict="true">
 	<Loggers>
-		<Logger level="ALL" name="com.liferay.analytics" />
+		<Logger level="INFO" name="com.liferay.analytics" />
 	</Loggers>
 </Configuration>


### PR DESCRIPTION
The default log level reports *a lot* of noise on a vanilla system that's not connected to AC - e.g. one message "DEBUG [BaseAnalyticsClientImpl:49] Analytics configuration tracker not active" _per http request_.