### PR TITLE
LPS-143349 Fix logic to get the correct results regardless of the checks order

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BaseJSPTermsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BaseJSPTermsCheck.java
@@ -316,7 +316,8 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 
 			if ((z == -1) ||
 				(getLineNumber(content, y) != getLineNumber(content, z)) ||
-				!ToolsUtil.isInsideQuotes(content.substring(y, z), x - y)) {
+				!ToolsUtil.isInsideQuotes(
+					content.substring(y, z), x - y, false)) {
 
 				count++;
 			}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLStylingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLStylingCheck.java
@@ -23,6 +23,10 @@ public class YMLStylingCheck extends BaseFileCheck {
 	protected String doProcess(
 		String fileName, String absolutePath, String content) {
 
+		if (content.startsWith("---\n")) {
+			content = content.substring(4);
+		}
+
 		content = content.replaceAll(
 			"(\\A|\n)( *)(description:) (?!\\|-)(.+)(\\Z|\n)",
 			"$1$2$3\n    $2$4$5");

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLWhitespaceCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLWhitespaceCheck.java
@@ -67,7 +67,7 @@ public class YMLWhitespaceCheck extends WhitespaceCheck {
 			contentBlock = super.doProcess(
 				fileName, absolutePath, contentBlock);
 
-			if (contentBlock.startsWith("---")) {
+			if (contentBlock.startsWith("---") && (i != 0)) {
 				contentBlock = StringPool.NEW_LINE + contentBlock;
 			}
 


### PR DESCRIPTION
Hey Hugo,

**Issue 1: Jsp**
Without this changes, if `JSPUnusedTermsCheck` goes first, it will remove `String cssClass = "cssClass";`

Before enforcing checks order you made before, other jsp check(`JSPTag..check`? I forgot) will change
`cssClass='<%= \"language-value \" + cssClass %>'
`to
`cssClass='<%= "language-value " + cssClass %>'
` first, then go into `JSPUnusedTermsCheck`


```
<%--
/**
 * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
 *
 * This library is free software; you can redistribute it and/or modify it under
 * the terms of the GNU Lesser General Public License as published by the Free
 * Software Foundation; either version 2.1 of the License, or (at your option)
 * any later version.
 *
 * This library is distributed in the hope that it will be useful, but WITHOUT
 * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
 * details.
 */
--%>

<%@ include file="/init.jsp" %>

<%@ taglib uri="http://liferay.com/tld/aui" prefix="liferay-ui" %>

<%
String cssClass = "cssClass";
String editorName = "editorName";
String inputEditorName = "inputEditorName";
String randomNamespace = "randomNamespace";
String placeholder = "placeholder";
String toolbarSet = "toolbarSet";

boolean portletTitleBasedNavigation = true;
%>

<liferay-ui:input-editor
	contents="<%= mainLanguageValue %>"
	contentsLanguageId="<%= languageId %>"
	cssClass='<%= \"language-value \" + cssClass %>'
	editorName="<%= editorName %>"
	name='<%= inputEditorName %>'
	onChangeMethod='<%= randomNamespace + \"onChangeEditor\" %>'
	placeholder="<%= placeholder %>"
	toolbarSet="<%= toolbarSet %>"
/>

<div <%= portletTitleBasedNavigation ? "class=\"container-fluid-1280\"" : StringPool.BLANK %>>
</div>
```

**Issue 2: yaml**
Fixed in this pull.