### PR TITLE
LPS-144732 Fix Info Panel when the user has been deleted

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
@@ -258,22 +258,26 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 	private JSONObject _getUserJSONObject(
 		ContentDashboardItem contentDashboardItem, Locale locale) {
 
-		String authorProfileImage = null;
-
-		WebImage webImage = (WebImage)contentDashboardItem.getDisplayFieldValue(
-			"authorProfileImage", locale);
-
-		long portraitId = GetterUtil.getLong(
-			_http.getParameter(HtmlUtil.escape(webImage.getUrl()), "img_id"));
-
-		if (portraitId > 0) {
-			authorProfileImage = webImage.getUrl();
-		}
-
 		return JSONUtil.put(
-			"name", webImage.getAlt()
+			"name", contentDashboardItem.getUserName()
 		).put(
-			"url", authorProfileImage
+			"url",
+			Optional.ofNullable(
+				(WebImage)contentDashboardItem.getDisplayFieldValue(
+					"authorProfileImage", locale)
+			).filter(
+				webImage -> {
+					long portraitURL = GetterUtil.getLong(
+						_http.getParameter(
+							HtmlUtil.escape(webImage.getUrl()), "img_id"));
+
+					return portraitURL > 0;
+				}
+			).map(
+				WebImage::getUrl
+			).orElse(
+				null
+			)
 		).put(
 			"userId", contentDashboardItem.getUserId()
 		);


### PR DESCRIPTION
Motivation*
=======
Content Dashboard shows error when displaying details of article whose authors has been deleted

[Link to story or ticket](https://issues.liferay.com/browse/[LPS-XXXX](https://issues.liferay.com/browse/LPS-144732))

Proposed Solution*
========
Use the content dashboard user id instead the info framework authorPortraitURL

Steps to Verify*:
----------------
1. Go to Control Panel→Instance Settings→User Authentication
1. Uncheck Require password for email or screen name updates? → Save
1. Go to Control Panel → Users and Organizations and click +
1. Set the user's screen name to test-editor and fill the remaining required fields with random data
1. Go to Memberships tab and assign the user to the current site → Save
1. Go to Roles tab and assign the user a Site Administrator role of the current site → Save
1. Go to Password tab and set a random password that will be later used to log in
1. Open Incognito mode of your browser
1. Log in as the user test-editor
1. Enter a new password if asked
1. Go to Content & Data → Web Content, click + and select Basic Web Context
1. Fill the article with completely random data and publish
1. Log out as user test-editor and close the incognito mode tab
1. Go back to main browser (being logged as an administrator)
1. Go to Control Panel → Users and Organizations
1. Find the test-editor on the list, click on the context menu (3 dots) and click Deactivate
1. Click on Filter and Order and select the Inactive filter
1. Find the test-editor on the list, click on the context menu (3 dots) and click Delete
1. Go to Applications → CONTENT → Content Dashboard
1. Find the previously created article and click on the icon ℹ️
