### PR TITLE
LPS-132509 Show Blogs as a valid Subtype

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardItemSubtypeItemSelectorView.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardItemSubtypeItemSelectorView.java
@@ -228,6 +228,24 @@ public class ContentDashboardItemSubtypeItemSelectorView
 				infoItemClassDetails.getClassName());
 
 		if (infoItemFormVariationsProvider == null) {
+			contentDashboardItemTypesJSONArray.put(
+				JSONUtil.put(
+					"icon", _getIcon(className)
+				).put(
+					"itemSubtypes", JSONFactoryUtil.createJSONArray()
+				).put(
+					"label",
+					() -> {
+						InfoLocalizedValue<String>
+							infoItemClassDetailsLabelInfoLocalizedValue =
+								infoItemClassDetails.
+									getLabelInfoLocalizedValue();
+
+						return infoItemClassDetailsLabelInfoLocalizedValue.
+							getValue(themeDisplay.getLocale());
+					}
+				));
+
 			return;
 		}
 


### PR DESCRIPTION
Motivation
=======
This pull is part of the bigger issue: Supports Blogs in the Content Dashboard

[Link to story or ticket](https://issues.liferay.com/browse/LPS-132509)

Proposed Solution
========
We need to filter by type even when there is no subtypes associated with the type.

Steps to Verify:
----------------
Unit tests are provided with this tests (no functional changes)
