### PR TITLE
LPS-139482 Fix UnicodePropertiesBuilder check

### DIFF
--- a/modules/apps/analytics/analytics-message-sender-api/src/main/java/com/liferay/analytics/message/sender/model/listener/BaseEntityModelListener.java
+++ b/modules/apps/analytics/analytics-message-sender-api/src/main/java/com/liferay/analytics/message/sender/model/listener/BaseEntityModelListener.java
@@ -55,7 +55,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -559,14 +559,15 @@ public abstract class BaseEntityModelListener<T extends BaseModel<T>>
 		modelIds = ArrayUtil.remove(modelIds, modelId);
 
 		if (Validator.isNotNull(preferencePropertyName)) {
-			UnicodeProperties unicodeProperties = new UnicodeProperties(true);
-
-			unicodeProperties.setProperty(
-				preferencePropertyName,
-				StringUtil.merge(modelIds, StringPool.COMMA));
-
 			try {
-				companyService.updatePreferences(companyId, unicodeProperties);
+				companyService.updatePreferences(
+					companyId,
+					UnicodePropertiesBuilder.create(
+						true
+					).put(
+						preferencePropertyName,
+						StringUtil.merge(modelIds, StringPool.COMMA)
+					).build());
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {

--- a/modules/apps/analytics/analytics-message-sender-impl/src/main/java/com/liferay/analytics/message/sender/internal/AnalyticsMessageSenderClientImpl.java
+++ b/modules/apps/analytics/analytics-message-sender-impl/src/main/java/com/liferay/analytics/message/sender/internal/AnalyticsMessageSenderClientImpl.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsDescriptor;
 import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.UnknownHostException;
@@ -191,15 +191,16 @@ public class AnalyticsMessageSenderClientImpl
 				return;
 			}
 
-			UnicodeProperties unicodeProperties = new UnicodeProperties(true);
-
-			unicodeProperties.setProperty(
-				"liferayAnalyticsEndpointURL", liferayAnalyticsEndpointURL);
-			unicodeProperties.setProperty(
-				"liferayAnalyticsFaroBackendURL",
-				liferayAnalyticsFaroBackendURL);
-
-			companyLocalService.updatePreferences(companyId, unicodeProperties);
+			companyLocalService.updatePreferences(
+				companyId,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"liferayAnalyticsEndpointURL", liferayAnalyticsEndpointURL
+				).put(
+					"liferayAnalyticsFaroBackendURL",
+					liferayAnalyticsFaroBackendURL
+				).build());
 
 			Dictionary<String, Object> configurationProperties =
 				_getConfigurationProperties(companyId);

--- a/modules/apps/analytics/analytics-message-sender-impl/src/main/java/com/liferay/analytics/message/sender/internal/BaseAnalyticsClientImpl.java
+++ b/modules/apps/analytics/analytics-message-sender-impl/src/main/java/com/liferay/analytics/message/sender/internal/BaseAnalyticsClientImpl.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -102,20 +102,28 @@ public abstract class BaseAnalyticsClientImpl {
 	protected UserLocalService userLocalService;
 
 	private void _disconnectDataSource(long companyId) {
-		UnicodeProperties unicodeProperties = new UnicodeProperties(true);
-
-		unicodeProperties.setProperty("liferayAnalyticsConnectionType", "");
-		unicodeProperties.setProperty("liferayAnalyticsDataSourceId", "");
-		unicodeProperties.setProperty("liferayAnalyticsEndpointURL", "");
-		unicodeProperties.setProperty(
-			"liferayAnalyticsFaroBackendSecuritySignature", "");
-		unicodeProperties.setProperty("liferayAnalyticsFaroBackendURL", "");
-		unicodeProperties.setProperty("liferayAnalyticsGroupIds", "");
-		unicodeProperties.setProperty("liferayAnalyticsProjectId", "");
-		unicodeProperties.setProperty("liferayAnalyticsURL", "");
-
 		try {
-			companyLocalService.updatePreferences(companyId, unicodeProperties);
+			companyLocalService.updatePreferences(
+				companyId,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"liferayAnalyticsConnectionType", ""
+				).put(
+					"liferayAnalyticsDataSourceId", ""
+				).put(
+					"liferayAnalyticsEndpointURL", ""
+				).put(
+					"liferayAnalyticsFaroBackendSecuritySignature", ""
+				).put(
+					"liferayAnalyticsFaroBackendURL", ""
+				).put(
+					"liferayAnalyticsGroupIds", ""
+				).put(
+					"liferayAnalyticsProjectId", ""
+				).put(
+					"liferayAnalyticsURL", ""
+				).build());
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/portlet/action/AddChannelMVCActionCommand.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/portlet/action/AddChannelMVCActionCommand.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Arrays;
@@ -244,14 +245,14 @@ public class AddChannelMVCActionCommand extends BaseAnalyticsMVCActionCommand {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		UnicodeProperties unicodeProperties = new UnicodeProperties(true);
-
-		unicodeProperties.setProperty(
-			"liferayAnalyticsGroupIds",
-			StringUtil.merge(liferayAnalyticsGroupIds, StringPool.COMMA));
-
 		_companyService.updatePreferences(
-			themeDisplay.getCompanyId(), unicodeProperties);
+			themeDisplay.getCompanyId(),
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"liferayAnalyticsGroupIds",
+				StringUtil.merge(liferayAnalyticsGroupIds, StringPool.COMMA)
+			).build());
 
 		return liferayAnalyticsGroupIds;
 	}

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/portlet/action/EditChannelMVCActionCommand.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/portlet/action/EditChannelMVCActionCommand.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Arrays;
@@ -223,14 +224,14 @@ public class EditChannelMVCActionCommand extends BaseAnalyticsMVCActionCommand {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		UnicodeProperties unicodeProperties = new UnicodeProperties(true);
-
-		unicodeProperties.setProperty(
-			"liferayAnalyticsGroupIds",
-			StringUtil.merge(liferayAnalyticsGroupIds, StringPool.COMMA));
-
 		_companyService.updatePreferences(
-			themeDisplay.getCompanyId(), unicodeProperties);
+			themeDisplay.getCompanyId(),
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"liferayAnalyticsGroupIds",
+				StringUtil.merge(liferayAnalyticsGroupIds, StringPool.COMMA)
+			).build());
 
 		return liferayAnalyticsGroupIds;
 	}

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_1/AnalyticsConfigurationPreferencesUpgradeProcess.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_1/AnalyticsConfigurationPreferencesUpgradeProcess.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Dictionary;
@@ -79,14 +79,13 @@ public class AnalyticsConfigurationPreferencesUpgradeProcess
 
 			configuration.update(properties);
 
-			UnicodeProperties unicodeProperties = new UnicodeProperties(true);
-
-			unicodeProperties.setProperty(
-				"liferayAnalyticsProjectId", projectId);
-
 			_companyLocalService.updatePreferences(
 				GetterUtil.getLong(properties.get("companyId")),
-				unicodeProperties);
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"liferayAnalyticsProjectId", projectId
+				).build());
 		}
 	}
 

--- a/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/instance/lifecycle/AddGoogleExpandoColumnsPortalInstanceLifecycleListener.java
+++ b/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/instance/lifecycle/AddGoogleExpandoColumnsPortalInstanceLifecycleListener.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 
 import java.util.List;
 
@@ -85,11 +86,11 @@ public class AddGoogleExpandoColumnsPortalInstanceLifecycleListener
 					ExpandoTableConstants.DEFAULT_TABLE_NAME);
 			}
 
-			UnicodeProperties unicodeProperties = new UnicodeProperties();
-
-			unicodeProperties.setProperty("hidden", "true");
-			unicodeProperties.setProperty(
-				"visible-with-update-permission", "false");
+			UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.put(
+				"hidden", "true"
+			).put(
+				"visible-with-update-permission", "false"
+			).build();
 
 			_addExpandoColumn(
 				expandoTable, "googleAccessToken", unicodeProperties);

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/internal/portlet/action/test/AddAssetListEntryVariationMVCActionCommandTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/internal/portlet/action/test/AddAssetListEntryVariationMVCActionCommandTest.java
@@ -81,11 +81,10 @@ public class AddAssetListEntryVariationMVCActionCommandTest {
 		UnicodeProperties defaultSegmentsEntryUnicodeProperties =
 			UnicodePropertiesBuilder.create(
 				true
+			).put(
+				"classNameIds",
+				StringUtil.merge(new long[] {RandomTestUtil.randomLong()})
 			).build();
-
-		defaultSegmentsEntryUnicodeProperties.setProperty(
-			"classNameIds",
-			StringUtil.merge(new long[] {RandomTestUtil.randomLong()}));
 
 		AssetListEntry assetListEntry =
 			_assetListEntryLocalService.addAssetListEntry(

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/AddAssetListEntryMVCActionCommand.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/AddAssetListEntryMVCActionCommand.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.portlet.ActionRequest;
@@ -73,17 +73,17 @@ public class AddAssetListEntryMVCActionCommand extends BaseMVCActionCommand {
 					(ThemeDisplay)actionRequest.getAttribute(
 						WebKeys.THEME_DISPLAY);
 
-				UnicodeProperties unicodeProperties = new UnicodeProperties(
-					true);
-
-				unicodeProperties.setProperty(
-					"groupIds", String.valueOf(themeDisplay.getScopeGroupId()));
-
 				assetListEntry =
 					_assetListEntryService.addDynamicAssetListEntry(
 						serviceContext.getUserId(),
 						serviceContext.getScopeGroupId(), title,
-						unicodeProperties.toString(), serviceContext);
+						UnicodePropertiesBuilder.create(
+							true
+						).put(
+							"groupIds",
+							String.valueOf(themeDisplay.getScopeGroupId())
+						).buildString(),
+						serviceContext);
 			}
 			else {
 				assetListEntry = _assetListEntryService.addAssetListEntry(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -183,18 +183,10 @@ public class DepotEntryLocalServiceTest {
 	public void testUpdateDepotEntryDeleteDefaultLocale() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry("name", "description");
 
-		UnicodeProperties formTypeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
 		Set<Locale> availableLocales = new HashSet<>();
 
 		availableLocales.add(LocaleUtil.getDefault());
 		availableLocales.add(LocaleUtil.fromLanguageId("es_ES"));
-
-		String[] locales = LocaleUtil.toLanguageIds(availableLocales);
-
-		formTypeSettingsUnicodeProperties.setProperty(
-			PropsKeys.LOCALES, StringUtil.merge(locales));
 
 		_depotEntryLocalService.updateDepotEntry(
 			depotEntry.getDepotEntryId(),
@@ -208,7 +200,11 @@ public class DepotEntryLocalServiceTest {
 			).put(
 				LocaleUtil.fromLanguageId("es_ES"), "nuevaDescripcion"
 			).build(),
-			Collections.emptyMap(), formTypeSettingsUnicodeProperties,
+			Collections.emptyMap(),
+			UnicodePropertiesBuilder.put(
+				PropsKeys.LOCALES,
+				StringUtil.merge(LocaleUtil.toLanguageIds(availableLocales))
+			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
 		Group group = _groupLocalService.getGroup(depotEntry.getGroupId());
@@ -224,11 +220,6 @@ public class DepotEntryLocalServiceTest {
 	public void testUpdateDepotEntryInheritLocale() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry("name", "description");
 
-		UnicodeProperties formTypeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		formTypeSettingsUnicodeProperties.setProperty("inheritLocales", "true");
-
 		_depotEntryLocalService.updateDepotEntry(
 			depotEntry.getDepotEntryId(),
 			HashMapBuilder.put(
@@ -237,7 +228,10 @@ public class DepotEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "newDescription"
 			).build(),
-			Collections.emptyMap(), formTypeSettingsUnicodeProperties,
+			Collections.emptyMap(),
+			UnicodePropertiesBuilder.put(
+				"inheritLocales", "true"
+			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
 		Group group = _groupLocalService.getGroup(depotEntry.getGroupId());
@@ -327,13 +321,6 @@ public class DepotEntryLocalServiceTest {
 
 		DepotEntry depotEntry = _addDepotEntry("name", "description");
 
-		UnicodeProperties formTypeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		formTypeSettingsUnicodeProperties.setProperty(
-			"inheritLocales", "false");
-		formTypeSettingsUnicodeProperties.setProperty(PropsKeys.LOCALES, null);
-
 		_depotEntryLocalService.updateDepotEntry(
 			depotEntry.getDepotEntryId(),
 			HashMapBuilder.put(
@@ -346,7 +333,10 @@ public class DepotEntryLocalServiceTest {
 			).put(
 				LocaleUtil.fromLanguageId("es_ES"), "descripcion"
 			).build(),
-			Collections.emptyMap(), formTypeSettingsUnicodeProperties,
+			Collections.emptyMap(),
+			UnicodePropertiesBuilder.put(
+				"inheritLocales", "false"
+			).build(),
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/ConvertLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/ConvertLayoutMVCActionCommandTest.java
@@ -47,7 +47,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -101,14 +101,11 @@ public class ConvertLayoutMVCActionCommandTest {
 
 	@Test
 	public void testConvertWidgetLayoutToContentLayout() throws Exception {
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column");
-
 		Layout originalLayout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column"
+			).buildString());
 
 		_mvcActionCommand.processAction(
 			_getMockLiferayPortletActionRequest(originalLayout.getPlid()),
@@ -121,14 +118,11 @@ public class ConvertLayoutMVCActionCommandTest {
 	public void testConvertWidgetLayoutToContentLayoutWithExistingStructure()
 		throws Exception {
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column");
-
 		Layout originalLayout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column"
+			).buildString());
 
 		_layoutPageTemplateStructureLocalService.addLayoutPageTemplateStructure(
 			TestPropsValues.getUserId(), _group.getGroupId(),

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_0/LayoutUpgradeProcess.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_0/LayoutUpgradeProcess.java
@@ -48,10 +48,7 @@ public class LayoutUpgradeProcess extends UpgradeProcess {
 			).build();
 
 		typeSettingsUnicodeProperties.setProperty(
-			"embeddedLayoutURL",
-			typeSettingsUnicodeProperties.getProperty("url"));
-
-		typeSettingsUnicodeProperties.remove("url");
+			"embeddedLayoutURL", typeSettingsUnicodeProperties.remove("url"));
 
 		_updateTypeSettings(plid, typeSettingsUnicodeProperties.toString());
 	}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutCopyHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutCopyHelperTest.java
@@ -298,15 +298,13 @@ public class LayoutCopyHelperTest {
 
 	@Test
 	public void testCopyTypeSettings() throws Exception {
-		UnicodeProperties sourceUnicodeProperties = new UnicodeProperties();
-
-		sourceUnicodeProperties.setProperty(
-			"lfr-theme:regular:show-footer", Boolean.TRUE.toString());
-		sourceUnicodeProperties.setProperty(
-			"lfr-theme:regular:show-header", Boolean.TRUE.toString());
-
 		Layout sourceLayout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), sourceUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				"lfr-theme:regular:show-footer", Boolean.TRUE.toString()
+			).put(
+				"lfr-theme:regular:show-header", Boolean.TRUE.toString()
+			).buildString());
 
 		Layout targetLayout = LayoutTestUtil.addLayout(
 			_group.getGroupId(), StringPool.BLANK);

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/template/test/LayoutConverterTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/template/test/LayoutConverterTest.java
@@ -50,7 +50,6 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
@@ -664,14 +663,11 @@ public class LayoutConverterTest {
 
 	@Test
 	public void testIsConvertibleTrueWidgetPageCustomizable() throws Exception {
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutConstants.CUSTOMIZABLE_LAYOUT, Boolean.TRUE.toString());
-
 		Layout layout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				LayoutConstants.CUSTOMIZABLE_LAYOUT, Boolean.TRUE.toString()
+			).buildString());
 
 		LayoutConverter layoutConverter =
 			_layoutConverterRegistry.getLayoutConverter(
@@ -867,17 +863,14 @@ public class LayoutConverterTest {
 		List<Map<String, List<String>>> encodedPortletIdsMaps =
 			new ArrayList<>();
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, layoutTemplateId);
-		typeSettingsUnicodeProperties.setProperty(
-			"lfr-theme:regular:wrap-widget-page-content",
-			Boolean.FALSE.toString());
-
 		Layout layout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, layoutTemplateId
+			).put(
+				"lfr-theme:regular:wrap-widget-page-content",
+				Boolean.FALSE.toString()
+			).buildString());
 
 		for (Map<String, String[]> portletIdsMap : portletIdsMaps) {
 			Set<Map.Entry<String, String[]>> entries = portletIdsMap.entrySet();
@@ -1001,14 +994,11 @@ public class LayoutConverterTest {
 	private void _testConvertNoPortlets(String layoutTemplateId)
 		throws Exception {
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, layoutTemplateId);
-
 		Layout layout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, layoutTemplateId
+			).buildString());
 
 		LayoutConverter layoutConverter =
 			_layoutConverterRegistry.getLayoutConverter(

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/BulkLayoutConverterTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/BulkLayoutConverterTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -121,14 +122,11 @@ public class BulkLayoutConverterTest {
 
 	@Test
 	public void testConvertLinkedLayout() throws Exception {
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column");
-
 		Layout layout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column"
+			).buildString());
 
 		LayoutPrototype layoutPrototype = LayoutTestUtil.addLayoutPrototype(
 			StringUtil.randomString());
@@ -158,19 +156,16 @@ public class BulkLayoutConverterTest {
 
 	@Test
 	public void testConvertPrivateLayout() throws Exception {
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column");
-
 		Layout layout = LayoutTestUtil.addLayout(
 			_group.getGroupId(), true, RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
-			typeSettingsUnicodeProperties.toString(), new HashMap<>(), false);
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column"
+			).buildString(),
+			new HashMap<>(), false);
 
 		Assert.assertEquals(LayoutConstants.TYPE_PORTLET, layout.getType());
 
@@ -185,14 +180,11 @@ public class BulkLayoutConverterTest {
 
 	@Test
 	public void testConvertPublicLayout() throws Exception {
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column");
-
 		Layout layout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+			_group.getGroupId(),
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column"
+			).buildString());
 
 		Assert.assertEquals(LayoutConstants.TYPE_PORTLET, layout.getType());
 
@@ -243,10 +235,9 @@ public class BulkLayoutConverterTest {
 			_corruptedLayout.getLayoutId(), StringPool.BLANK);
 
 		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column");
+			UnicodePropertiesBuilder.put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column"
+			).build();
 
 		_privateLayout = LayoutTestUtil.addLayout(
 			_group.getGroupId(), true, RandomTestUtil.randomLocaleStringMap(),

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectActionResourceImpl.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.vulcan.fields.NestedField;
 import com.liferay.portal.vulcan.fields.NestedFieldSupport;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -107,8 +107,9 @@ public class ObjectActionResourceImpl
 				objectAction.getName(),
 				objectAction.getObjectActionExecutorKey(),
 				objectAction.getObjectActionTriggerKey(),
-				new UnicodeProperties(
-					(Map<String, String>)objectAction.getParameters(), true)));
+				UnicodePropertiesBuilder.create(
+					(Map<String, String>)objectAction.getParameters(), true
+				).build()));
 	}
 
 	@Override
@@ -120,8 +121,9 @@ public class ObjectActionResourceImpl
 			_objectActionService.updateObjectAction(
 				objectActionId, objectAction.getActive(),
 				objectAction.getName(),
-				new UnicodeProperties(
-					(Map<String, String>)objectAction.getParameters(), true)));
+				UnicodePropertiesBuilder.create(
+					(Map<String, String>)objectAction.getParameters(), true
+				).build()));
 	}
 
 	private ObjectAction _toObjectAction(

--- a/modules/apps/ratings/ratings-test/src/testIntegration/java/com/liferay/ratings/transformer/test/RatingsDataTransformerUtilTest.java
+++ b/modules/apps/ratings/ratings-test/src/testIntegration/java/com/liferay/ratings/transformer/test/RatingsDataTransformerUtilTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.PortletPreferencesImpl;
 import com.liferay.ratings.kernel.transformer.RatingsDataTransformer;
@@ -123,27 +124,24 @@ public class RatingsDataTransformerUtilTest {
 	}
 
 	private UnicodeProperties _createUnicodeProperties(String value) {
-		UnicodeProperties unicodeProperties = new UnicodeProperties();
-
-		unicodeProperties.setProperty(
-			"com.liferay.blogs.model.BlogsEntry_RatingsType", value);
-		unicodeProperties.setProperty(
-			"com.liferay.bookmarks.model.BookmarksEntry_RatingsType", value);
-		unicodeProperties.setProperty(
+		return UnicodePropertiesBuilder.put(
+			"com.liferay.blogs.model.BlogsEntry_RatingsType", value
+		).put(
+			"com.liferay.bookmarks.model.BookmarksEntry_RatingsType", value
+		).put(
 			"com.liferay.document.library.kernel.model.DLFileEntry_RatingsType",
-			value);
-		unicodeProperties.setProperty(
-			"com.liferay.journal.model.JournalArticle_RatingsType", value);
-		unicodeProperties.setProperty(
-			"com.liferay.knowledge.base.model.KBArticle_RatingsType", value);
-		unicodeProperties.setProperty(
-			"com.liferay.message.boards.model.MBDiscussion_RatingsType", value);
-		unicodeProperties.setProperty(
-			"com.liferay.message.boards.model.MBMessage_RatingsType", value);
-		unicodeProperties.setProperty(
-			"com.liferay.wiki.model.WikiPage_RatingsType", value);
-
-		return unicodeProperties;
+			value
+		).put(
+			"com.liferay.journal.model.JournalArticle_RatingsType", value
+		).put(
+			"com.liferay.knowledge.base.model.KBArticle_RatingsType", value
+		).put(
+			"com.liferay.message.boards.model.MBDiscussion_RatingsType", value
+		).put(
+			"com.liferay.message.boards.model.MBMessage_RatingsType", value
+		).put(
+			"com.liferay.wiki.model.WikiPage_RatingsType", value
+		).build();
 	}
 
 	private static boolean _calledTransformRatingsData;

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.BigDecimalUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
@@ -121,14 +122,14 @@ public class SegmentsExperimentLocalServiceImpl
 		segmentsExperiment.setName(name);
 		segmentsExperiment.setDescription(description);
 
-		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
-			true);
-
-		typeSettingsUnicodeProperties.setProperty("goal", goal);
-		typeSettingsUnicodeProperties.setProperty("goalTarget", goalTarget);
-
 		segmentsExperiment.setTypeSettings(
-			typeSettingsUnicodeProperties.toString());
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"goal", goal
+			).put(
+				"goalTarget", goalTarget
+			).buildString());
 
 		segmentsExperiment.setStatus(status);
 

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.constants.SegmentsEntryConstants;
@@ -203,17 +204,16 @@ public class SegmentsExperienceLocalServiceTest {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());
 
-		UnicodeProperties initialTypeSettingsUnicodeProperties =
-			new UnicodeProperties(true);
-
-		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
-
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceLocalService.addSegmentsExperience(
 				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomInt(), RandomTestUtil.randomBoolean(),
-				initialTypeSettingsUnicodeProperties,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"property", "value"
+				).build(),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		UnicodeProperties actualTypeSettingsUnicodeProperties =
@@ -468,16 +468,15 @@ public class SegmentsExperienceLocalServiceTest {
 		Map<Locale, String> nameMap = RandomTestUtil.randomLocaleStringMap();
 		boolean active = RandomTestUtil.randomBoolean();
 
-		UnicodeProperties initialTypeSettingsUnicodeProperties =
-			new UnicodeProperties(true);
-
-		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
-
 		SegmentsExperience updatedSegmentsExperience =
 			_segmentsExperienceLocalService.updateSegmentsExperience(
 				segmentsExperience.getSegmentsExperienceId(),
 				segmentsEntry.getSegmentsEntryId(), nameMap, active,
-				initialTypeSettingsUnicodeProperties);
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"property", "value"
+				).build());
 
 		Assert.assertEquals(
 			segmentsEntry.getSegmentsEntryId(),
@@ -729,16 +728,15 @@ public class SegmentsExperienceLocalServiceTest {
 	public void testUpdateSegmentsExperienceWithoutTypeSettings()
 		throws Exception {
 
-		UnicodeProperties initialTypeSettingsUnicodeProperties =
-			new UnicodeProperties(true);
-
-		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
-
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceLocalService.appendSegmentsExperience(
 				SegmentsEntryConstants.ID_DEFAULT, _classNameId, _classPK,
 				RandomTestUtil.randomLocaleStringMap(), true,
-				initialTypeSettingsUnicodeProperties,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"property", "value"
+				).build(),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		SegmentsExperience updatedSegmentsExperience =

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -102,16 +103,15 @@ public class SegmentsExperienceServiceTest {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());
 
-		UnicodeProperties initialTypeSettingsUnicodeProperties =
-			new UnicodeProperties(true);
-
-		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
-
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceService.addSegmentsExperience(
 				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
 				RandomTestUtil.randomLocaleStringMap(), true,
-				initialTypeSettingsUnicodeProperties,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"property", "value"
+				).build(),
 				ServiceContextTestUtil.getServiceContext(
 					_group, TestPropsValues.getUserId()));
 
@@ -195,16 +195,15 @@ public class SegmentsExperienceServiceTest {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());
 
-		UnicodeProperties initialTypeSettingsUnicodeProperties =
-			new UnicodeProperties(true);
-
-		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
-
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceService.appendSegmentsExperience(
 				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
 				RandomTestUtil.randomLocaleStringMap(), true,
-				initialTypeSettingsUnicodeProperties,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"property", "value"
+				).build(),
 				ServiceContextTestUtil.getServiceContext(
 					_group, TestPropsValues.getUserId()));
 
@@ -641,18 +640,17 @@ public class SegmentsExperienceServiceTest {
 				ServiceContextTestUtil.getServiceContext(
 					_group, TestPropsValues.getUserId()));
 
-		UnicodeProperties initialTypeSettingsUnicodeProperties =
-			new UnicodeProperties(true);
-
-		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
-
 		SegmentsExperience updatedSegmentsExperience =
 			_segmentsExperienceService.updateSegmentsExperience(
 				segmentsExperience.getSegmentsExperienceId(),
 				RandomTestUtil.randomLong(),
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomBoolean(),
-				initialTypeSettingsUnicodeProperties);
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"property", "value"
+				).build());
 
 		UnicodeProperties actualTypeSettingsUnicodeProperties =
 			updatedSegmentsExperience.getTypeSettingsUnicodeProperties();
@@ -669,16 +667,15 @@ public class SegmentsExperienceServiceTest {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());
 
-		UnicodeProperties initialTypeSettingsUnicodeProperties =
-			new UnicodeProperties(true);
-
-		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
-
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceService.addSegmentsExperience(
 				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
 				RandomTestUtil.randomLocaleStringMap(), true,
-				initialTypeSettingsUnicodeProperties,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"property", "value"
+				).build(),
 				ServiceContextTestUtil.getServiceContext(
 					_group, TestPropsValues.getUserId()));
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -589,7 +589,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 		_assetListEntryLocalService.addDynamicAssetListEntry(
 			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
 			assetListJSONObject.getString("title"),
-			String.valueOf(new UnicodeProperties(map, true)), serviceContext);
+			String.valueOf(UnicodePropertiesBuilder.create(map, true)),
+			serviceContext);
 	}
 
 	private void _addCommerceCatalogs(
@@ -2488,26 +2489,18 @@ public class BundleSiteInitializer implements SiteInitializer {
 						layout);
 			}
 			else if (type.equals(SiteNavigationMenuItemTypeConstants.NODE)) {
-				UnicodeProperties typeSettingsUnicodeProperties =
-					new UnicodeProperties();
-
-				typeSettingsUnicodeProperties.setProperty(
-					"name", menuItemJSONObject.getString("name"));
-
-				typeSettings = typeSettingsUnicodeProperties.toString();
+				typeSettings = UnicodePropertiesBuilder.put(
+					"name", menuItemJSONObject.getString("name")
+				).buildString();
 			}
 			else if (type.equals(SiteNavigationMenuItemTypeConstants.URL)) {
-				UnicodeProperties typeSettingsUnicodeProperties =
-					new UnicodeProperties();
-
-				typeSettingsUnicodeProperties.setProperty(
-					"name", menuItemJSONObject.getString("name"));
-				typeSettingsUnicodeProperties.setProperty(
-					"url", menuItemJSONObject.getString("url"));
-				typeSettingsUnicodeProperties.setProperty(
-					"useNewTab", menuItemJSONObject.getString("useNewTab"));
-
-				typeSettings = typeSettingsUnicodeProperties.toString();
+				typeSettings = UnicodePropertiesBuilder.put(
+					"name", menuItemJSONObject.getString("name")
+				).put(
+					"url", menuItemJSONObject.getString("url")
+				).put(
+					"useNewTab", menuItemJSONObject.getString("useNewTab")
+				).buildString();
 			}
 			else if (type.equals("display-page")) {
 				String key = menuItemJSONObject.getString("key");
@@ -3080,9 +3073,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 				cpInstancePropertiesJSONObject.getJSONObject(
 					"subscriptionTypeSettings");
 
-			UnicodeProperties unicodeProperties = new UnicodeProperties(
-				JSONUtil.toStringMap(subscriptionTypeSettingsJSONObject), true);
-
 			_commerceReferencesHolder.cpInstanceLocalService.
 				updateSubscriptionInfo(
 					cpInstance.getCPInstanceId(),
@@ -3093,7 +3083,11 @@ public class BundleSiteInitializer implements SiteInitializer {
 					cpInstancePropertiesJSONObject.getInt("subscriptionLength"),
 					cpInstancePropertiesJSONObject.getString(
 						"subscriptionType"),
-					unicodeProperties,
+					UnicodePropertiesBuilder.create(
+						JSONUtil.toStringMap(
+							subscriptionTypeSettingsJSONObject),
+						true
+					).build(),
 					cpInstancePropertiesJSONObject.getLong(
 						"maxSubscriptionCycles"),
 					cpInstancePropertiesJSONObject.getBoolean(

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/display/page/test/SiteNavigationMenuItemDisplayPageTest.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/display/page/test/SiteNavigationMenuItemDisplayPageTest.java
@@ -303,14 +303,13 @@ public class SiteNavigationMenuItemDisplayPageTest {
 				SiteNavigationConstants.TYPE_DEFAULT, true, _serviceContext);
 
 		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			"classNameId",
-			String.valueOf(
-				_portal.getClassNameId(AssetCategory.class.getName())));
-		typeSettingsUnicodeProperties.setProperty(
-			"classPK", String.valueOf(_assetCategory.getCategoryId()));
+			UnicodePropertiesBuilder.put(
+				"classNameId",
+				String.valueOf(
+					_portal.getClassNameId(AssetCategory.class.getName()))
+			).put(
+				"classPK", String.valueOf(_assetCategory.getCategoryId())
+			).build();
 
 		SiteNavigationMenuItem siteNavigationMenuItem =
 			_siteNavigationMenuItemLocalService.addSiteNavigationMenuItem(
@@ -575,22 +574,19 @@ public class SiteNavigationMenuItemDisplayPageTest {
 				TestPropsValues.getUserId(), _group.getGroupId(), "Menu",
 				SiteNavigationConstants.TYPE_DEFAULT, true, _serviceContext);
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			"classNameId",
-			String.valueOf(
-				_portal.getClassNameId(AssetCategory.class.getName())));
-		typeSettingsUnicodeProperties.setProperty(
-			"classPK", String.valueOf(_assetCategory.getCategoryId()));
-
 		SiteNavigationMenuItem siteNavigationMenuItem =
 			_siteNavigationMenuItemLocalService.addSiteNavigationMenuItem(
 				TestPropsValues.getUserId(), _group.getGroupId(),
 				siteNavigationMenu.getSiteNavigationMenuId(), 0,
 				AssetCategory.class.getName(),
-				typeSettingsUnicodeProperties.toString(), _serviceContext);
+				UnicodePropertiesBuilder.put(
+					"classNameId",
+					String.valueOf(
+						_portal.getClassNameId(AssetCategory.class.getName()))
+				).put(
+					"classPK", String.valueOf(_assetCategory.getCategoryId())
+				).buildString(),
+				_serviceContext);
 
 		Assert.assertEquals(
 			1,

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/portlet/action/AddLayoutSiteNavigationMenuItemMVCActionCommand.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/portlet/action/AddLayoutSiteNavigationMenuItemMVCActionCommand.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.navigation.admin.constants.SiteNavigationAdminPortletKeys;
 import com.liferay.site.navigation.exception.SiteNavigationMenuItemNameException;
@@ -106,22 +107,21 @@ public class AddLayoutSiteNavigationMenuItemMVCActionCommand
 					continue;
 				}
 
-				UnicodeProperties curTypeSettingsUnicodeProperties =
-					new UnicodeProperties(true);
-
-				curTypeSettingsUnicodeProperties.setProperty(
-					"groupId", String.valueOf(groupId));
-				curTypeSettingsUnicodeProperties.setProperty(
-					"layoutUuid", layoutUuid);
-				curTypeSettingsUnicodeProperties.setProperty(
-					"privateLayout", String.valueOf(privateLayout));
-				curTypeSettingsUnicodeProperties.setProperty(
-					"title", layout.getName(themeDisplay.getLocale()));
-
 				SiteNavigationMenuItem siteNavigationMenuItem =
 					_siteNavigationMenuItemService.addSiteNavigationMenuItem(
 						themeDisplay.getScopeGroupId(), siteNavigationMenuId, 0,
-						type, curTypeSettingsUnicodeProperties.toString(),
+						type,
+						UnicodePropertiesBuilder.create(
+							true
+						).put(
+							"groupId", String.valueOf(groupId)
+						).put(
+							"layoutUuid", layoutUuid
+						).put(
+							"privateLayout", String.valueOf(privateLayout)
+						).put(
+							"title", layout.getName(themeDisplay.getLocale())
+						).buildString(),
 						serviceContext);
 
 				layoutSiteNavigationMenuItemMap.put(

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -250,15 +250,13 @@ public class LayoutSiteNavigationMenuItemType
 
 	@Override
 	public String getTypeSettingsFromLayout(Layout layout) {
-		UnicodeProperties unicodeProperties = new UnicodeProperties();
-
-		unicodeProperties.setProperty(
-			"groupId", String.valueOf(layout.getGroupId()));
-		unicodeProperties.setProperty("layoutUuid", layout.getUuid());
-		unicodeProperties.setProperty(
-			"privateLayout", String.valueOf(layout.isPrivateLayout()));
-
-		return unicodeProperties.toString();
+		return UnicodePropertiesBuilder.put(
+			"groupId", String.valueOf(layout.getGroupId())
+		).put(
+			"layoutUuid", layout.getUuid()
+		).put(
+			"privateLayout", String.valueOf(layout.isPrivateLayout())
+		).buildString();
 	}
 
 	@Override

--- a/modules/apps/site-navigation/site-navigation-menu-item-url-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/url/test/SiteNavigationMenuItemURLTest.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-url-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/url/test/SiteNavigationMenuItemURLTest.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -78,22 +78,19 @@ public class SiteNavigationMenuItemURLTest {
 				TestPropsValues.getUserId(), _group.getGroupId(), "Menu",
 				SiteNavigationConstants.TYPE_DEFAULT, true, serviceContext);
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			"name", StringUtil.randomString());
-		typeSettingsUnicodeProperties.setProperty(
-			"url", "http://www.liferay.com");
-		typeSettingsUnicodeProperties.setProperty(
-			"useNewTab", Boolean.TRUE.toString());
-
 		SiteNavigationMenuItem siteNavigationMenuItem =
 			_siteNavigationMenuItemLocalService.addSiteNavigationMenuItem(
 				TestPropsValues.getUserId(), _group.getGroupId(),
 				siteNavigationMenu.getSiteNavigationMenuId(), 0,
 				SiteNavigationMenuItemTypeConstants.URL,
-				typeSettingsUnicodeProperties.toString(), serviceContext);
+				UnicodePropertiesBuilder.put(
+					"name", StringUtil.randomString()
+				).put(
+					"url", "http://www.liferay.com"
+				).put(
+					"useNewTab", Boolean.TRUE.toString()
+				).buildString(),
+				serviceContext);
 
 		Assert.assertEquals(
 			1,
@@ -122,20 +119,17 @@ public class SiteNavigationMenuItemURLTest {
 				TestPropsValues.getUserId(), _group.getGroupId(), "Menu",
 				SiteNavigationConstants.TYPE_DEFAULT, true, serviceContext);
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			new UnicodeProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			"name", StringUtil.randomString());
-		typeSettingsUnicodeProperties.setProperty(
-			"url", "http://www.liferay.com");
-
 		SiteNavigationMenuItem siteNavigationMenuItem =
 			_siteNavigationMenuItemLocalService.addSiteNavigationMenuItem(
 				TestPropsValues.getUserId(), _group.getGroupId(),
 				siteNavigationMenu.getSiteNavigationMenuId(), 0,
 				SiteNavigationMenuItemTypeConstants.URL,
-				typeSettingsUnicodeProperties.toString(), serviceContext);
+				UnicodePropertiesBuilder.put(
+					"name", StringUtil.randomString()
+				).put(
+					"url", "http://www.liferay.com"
+				).buildString(),
+				serviceContext);
 
 		Assert.assertEquals(
 			1,

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/UpdateCertificateMVCActionCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/UpdateCertificateMVCActionCommand.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropertiesParamUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlPortletKeys;
@@ -271,13 +272,11 @@ public class UpdateCertificateMVCActionCommand extends BaseMVCActionCommand {
 			privateKeyEntry.getPrivateKey(), keyStorePassword, x509Certificate,
 			certificateUsage);
 
-		UnicodeProperties unicodeProperties = new UnicodeProperties();
-
-		unicodeProperties.setProperty(
-			_getCertificateUsagePropertyKey(certificateUsage),
-			keyStorePassword);
-
-		_samlProviderConfigurationHelper.updateProperties(unicodeProperties);
+		_samlProviderConfigurationHelper.updateProperties(
+			UnicodePropertiesBuilder.put(
+				_getCertificateUsagePropertyKey(certificateUsage),
+				keyStorePassword
+			).build());
 
 		SamlTempFileEntryUtil.deleteTempFileEntry(user, selectUploadedFile);
 

--- a/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/asset/list/asset/entry/query/processor/test/AsahInterestTermAssetListAssetEntryQueryProcessorTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/asset/list/asset/entry/query/processor/test/AsahInterestTermAssetListAssetEntryQueryProcessorTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -134,13 +135,10 @@ public class AsahInterestTermAssetListAssetEntryQueryProcessorTest {
 	private UnicodeProperties _getUnicodeProperties(
 		boolean enableContentRecommendation) {
 
-		UnicodeProperties unicodeProperties = new UnicodeProperties();
-
-		unicodeProperties.setProperty(
+		return UnicodePropertiesBuilder.put(
 			"enableContentRecommendation",
-			String.valueOf(enableContentRecommendation));
-
-		return unicodeProperties;
+			String.valueOf(enableContentRecommendation)
+		).build();
 	}
 
 	private static Company _company;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -2191,15 +2191,14 @@ public class DataFactory {
 			"<?xml version=\"1.0\"?><root><name>" + name + "</name></root>");
 		layoutModel.setType(LayoutConstants.TYPE_CONTENT);
 
-		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
-			true);
-
-		typeSettingsUnicodeProperties.setProperty(
-			"fragmentEntries", fragmentEntries);
-
 		layoutModel.setTypeSettings(
 			StringUtil.replace(
-				typeSettingsUnicodeProperties.toString(), '\n', "\\n"));
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"fragmentEntries", fragmentEntries
+				).buildString(),
+				'\n', "\\n"));
 
 		layoutModel.setFriendlyURL(StringPool.FORWARD_SLASH + name);
 		layoutModel.setLastPublishDate(new Date());
@@ -6415,11 +6414,12 @@ public class DataFactory {
 		layoutModel.setType(LayoutConstants.TYPE_PORTLET);
 		layoutModel.setHidden(hidden);
 
-		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
-			true);
-
-		typeSettingsUnicodeProperties.setProperty(
-			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, layoutTemplateId);
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, layoutTemplateId
+			).build();
 
 		for (int i = 0; i < columns.length; i++) {
 			if (!columns[i].equals("")) {
@@ -7221,14 +7221,14 @@ public class DataFactory {
 			layoutModel.setSystem(true);
 		}
 
-		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
-			true);
-
-		typeSettingsUnicodeProperties.setProperty("published", "true");
-
 		layoutModel.setTypeSettings(
 			StringUtil.replace(
-				typeSettingsUnicodeProperties.toString(), '\n', "\\n"));
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"published", "true"
+				).buildString(),
+				'\n', "\\n"));
 
 		layoutModel.setLastPublishDate(new Date());
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseBuilderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseBuilderCheck.java
@@ -20,6 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.source.formatter.checkstyle.util.DetailASTUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -605,6 +606,14 @@ public abstract class BaseBuilderCheck extends BaseChainedMethodCheck {
 				nextSiblingDetailAST, variableName, builderMethodNames);
 
 			if (fullIdent != null) {
+				if (_hasVariableNameInMethodCall(
+						nextSiblingDetailAST.findFirstToken(
+							TokenTypes.METHOD_CALL),
+						variableName)) {
+
+					return;
+				}
+
 				log(
 					assignDetailAST, _MSG_INCLUDE_BUILDER, fullIdent.getText(),
 					fullIdent.getLineNo(), builderClassName,
@@ -1598,6 +1607,24 @@ public abstract class BaseBuilderCheck extends BaseChainedMethodCheck {
 			int rangeEnd = range[1];
 
 			if ((rangeStart < start) || (rangeEnd > end)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _hasVariableNameInMethodCall(
+		DetailAST methodCallDetailAST, String variableName) {
+
+		DetailAST elistDetailAST = methodCallDetailAST.findFirstToken(
+			TokenTypes.ELIST);
+
+		for (DetailAST identDetailAST :
+				DetailASTUtil.getAllChildTokens(
+					elistDetailAST, true, TokenTypes.IDENT)) {
+
+			if (variableName.equals(identDetailAST.getText())) {
 				return true;
 			}
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UnicodePropertiesBuilderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UnicodePropertiesBuilderCheck.java
@@ -37,7 +37,7 @@ public class UnicodePropertiesBuilderCheck extends BaseBuilderCheck {
 		return ListUtil.fromArray(
 			new BaseBuilderCheck.BuilderInformation(
 				"UnicodeProperties", "UnicodePropertiesBuilder", "fastLoad",
-				"load", "put", "putAll", "setProperties"));
+				"load", "put", "putAll", "setProperty"));
 	}
 
 	@Override

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -47,6 +47,22 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testBuilder() throws Exception {
+		test(
+			"Builder.testjava",
+			new String[] {
+				"Include method call 'hashMap.put' (32) in 'HashMapBuilder' " +
+					"(28)",
+				"Inline variable definition 'company' (38) inside '" +
+					"HashMapBuilder' (40), possibly by using a lambda function",
+				"Null values are not allowed in 'HashMapBuilder'",
+				"Use 'HashMapBuilder' (52, 54)",
+				"Use 'HashMapBuilder' instead of new instance of 'HashMap'"
+			},
+			new Integer[] {28, 38, 47, 52, 58});
+	}
+
+	@Test
 	public void testCollapseImports() throws Exception {
 		test("CollapseImports.testjava");
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/Builder.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/Builder.testjava
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.HashMap;
+
+/**
+ * @author Kevin Lee
+ */
+public class Builder {
+
+	public HashMap<String, Object> includeMethodCall() {
+		HashMap<String, Object> hashMap = HashMapBuilder.<String, Object>put(
+			"a", 1
+		).build();
+
+		hashMap.put("b", 2);
+
+		return hashMap;
+	}
+
+	public HashMap<String, Object> inlineStatement() {
+		Company company = _getCompany();
+
+		return HashMapBuilder.<String, Object>put(
+			"companyGroup", company.getGroup()
+		).build();
+	}
+
+	public HashMap<String, Object> noNullValues() {
+		return HashMapBuilder.<String, Object>put(
+			"a", null
+		).build();
+	}
+
+	public HashMap<String, Object> useBuilder() {
+		HashMap<String, Object> hashMap = new HashMap<>();
+
+		hashMap.put("a", 1);
+		hashMap.put("b", 2);
+
+		return new HashMap<String, Object>() {
+			{
+				putAll(hashMap);
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-139482>

__Notes:__
This pull request does the following:

1. Fixes this issue where the `UnicodePropertiesBuilder` is not being enforced in the right places: <https://github.com/liferay/liferay-portal/commit/8abbaac744a8ddffe19428436bb504d3e071e040>.
2. Fixes the issue where SF would falsely log an error with input code like the following:

```java
UnicodeProperties typeSetttingsUnicodeProperties =
    UnicodePropertiesBuilder
        .create(
            true
        ).load(
            typeSettings
        ).build();

typeSettingsUnicodeProperties.setProperty(
        "newURL", typeSettingsUnicodeProperties.remove("url"));
```

3. Add a unit test for the `*BuilderCheck`.

Let me know if you have any questions.
