### PR TITLE
LPS-146488 LPS-146490 LPS-146489 [CP 2.0] Team invitation integration with koroneiki

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/components/formik-fields/Select/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/components/formik-fields/Select/index.js
@@ -11,6 +11,7 @@
 
 import ClayForm, {ClaySelect} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
 import {useField} from 'formik';
 import {Badge} from '../..';
 import {required, validate} from '../../../utils/validations.form';
@@ -36,20 +37,18 @@ const Select = ({
 
 	const getStyleStatus = () => {
 		if (meta.touched) {
-			return meta.error ? ' has-error' : ' has-success';
+			return meta.error ? 'has-error' : 'has-success';
 		}
 
-		return '';
+		return;
 	};
 
 	return (
 		<ClayForm.Group
-			className={`w-100${getStyleStatus()} ${
-				groupStyle ? groupStyle : ''
-			}`}
+			className={classNames('w-100', getStyleStatus(), groupStyle)}
 		>
 			<label>
-				{`${label} `}
+				{label}
 
 				{props.required && (
 					<span className="inline-item-after reference-mark text-warning">

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/containers/setup-forms/InviteTeamMembersForm/TeamMemberInputs/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/containers/setup-forms/InviteTeamMembersForm/TeamMemberInputs/index.js
@@ -23,6 +23,7 @@ const TeamMemberInputs = ({
 	invite,
 	options,
 	placeholderEmail,
+	selectOnChange,
 }) => {
 	const debouncedEmail = useDebounce(invite?.email, 500);
 	const [bannedDomain, setBannedDomain] = useState(debouncedEmail);
@@ -65,12 +66,9 @@ const TeamMemberInputs = ({
 				<Select
 					groupStyle="m-0"
 					label="Role"
-					name={`invites[${id}].roleId`}
-					options={options.map(({disabled, label, value}) => ({
-						disabled,
-						label,
-						value,
-					}))}
+					name={`invites[${id}].role.id`}
+					onChange={(event) => selectOnChange(event.target.value)}
+					options={options}
 				/>
 			</ClayInput.GroupItem>
 		</ClayInput.Group>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/containers/setup-forms/InviteTeamMembersForm/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/containers/setup-forms/InviteTeamMembersForm/index.js
@@ -198,7 +198,8 @@ const InviteTeamMembersPage = ({
 
 			setInitialError(false);
 			setBaseButtonDisabled(sucessfullyEmails !== totalEmails);
-		} else if (touched['invites']?.some((field) => field?.email)) {
+		}
+		else if (touched['invites']?.some((field) => field?.email)) {
 			setInitialError(true);
 			setBaseButtonDisabled(true);
 		}
@@ -241,7 +242,8 @@ const InviteTeamMembersPage = ({
 			if (!addTeamMemberError && !associateUserAccountError) {
 				handlePage();
 			}
-		} else {
+		}
+		else {
 			setInitialError(true);
 			setBaseButtonDisabled(true);
 			setTouched({

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/containers/setup-forms/InviteTeamMembersForm/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/containers/setup-forms/InviteTeamMembersForm/index.js
@@ -196,7 +196,8 @@ const InviteTeamMembersPage = ({
 
 			setInitialError(false);
 			setBaseButtonDisabled(sucessfullyEmails !== totalEmails);
-		} else if (touched['invites']?.some((field) => field?.email)) {
+		}
+		else if (touched['invites']?.some((field) => field?.email)) {
 			setInitialError(true);
 			setBaseButtonDisabled(true);
 		}
@@ -231,7 +232,8 @@ const InviteTeamMembersPage = ({
 			if (!addTeamMemberError && !associateUserAccountError) {
 				handlePage();
 			}
-		} else {
+		}
+		else {
 			setInitialError(true);
 			setBaseButtonDisabled(true);
 			setTouched({

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.js
@@ -210,6 +210,24 @@ export const addTeamMembersInvitation = gql`
 	}
 `;
 
+export const associateUserAccountWithAccountAndAccountRole = gql`
+	mutation associateUserAccountWithAccountAndAccountRole(
+		$emailAddress: String!
+		$accountKey: String!
+		$accountRoleId: Long!
+	) {
+		createAccountUserAccountByExternalReferenceCodeByEmailAddress(
+			emailAddress: $emailAddress
+			externalReferenceCode: $accountKey
+		)
+		createAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress(
+			accountRoleId: $accountRoleId
+			emailAddress: $emailAddress
+			externalReferenceCode: $accountKey
+		)
+	}
+`;
+
 export const getAccountFlags = gql`
 	query getAccountFlags($filter: String) {
 		c {

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/rest/raysource/LicenseKeys.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/rest/raysource/LicenseKeys.js
@@ -109,3 +109,24 @@ export async function exportLicenseKeys(
 
 	return response;
 }
+
+export async function associateContactRoleNameByEmailByProject(
+	accountKey,
+	licenseKeyDownloadURL,
+	sessionId,
+	emailURI,
+	roleName
+) {
+	// eslint-disable-next-line @liferay/portal/no-global-fetch
+	const response = await fetch(
+		`${licenseKeyDownloadURL}/accounts/${accountKey}/contacts/by-email-address/${emailURI}/roles?contactRoleNames=${roleName}`,
+		{
+			headers: {
+				'Okta-Session-ID': sessionId,
+			},
+			method: 'PUT',
+		}
+	);
+
+	return response;
+}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/utils/getInitialInvite.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/utils/getInitialInvite.js
@@ -9,9 +9,12 @@
  * distribution rights of the Software.
  */
 
-export default function getInitialInvite(roleId = '') {
+export default function getInitialInvite(initialRole) {
 	return {
 		email: '',
-		roleId,
+		role: initialRole || {
+			id: 0,
+			name: '',
+		},
 	};
 }

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/pages/index.js
@@ -72,7 +72,7 @@ const Pages = () => {
 			Skeleton: <Overview.Skeleton />,
 		},
 		[PAGE_TYPES.teamMembers]: {
-			Component: <TeamMembers project={project} />,
+			Component: <TeamMembers project={project} sessionId={sessionId} />,
 			Skeleton: <ActivationKeys.Skeleton />,
 		},
 	};

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/onboarding/context/reducer.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/onboarding/context/reducer.js
@@ -12,6 +12,7 @@
 export const actionTypes = {
 	CHANGE_STEP: 'CHANGE_STEP',
 	UPDATE_PROJECT: 'UPDATE_PROJECT',
+	UPDATE_SESSION_ID: 'UPDATE_SESSION_ID',
 	UPDATE_SUBSCRIPTION_GROUPS: 'UPDATE_SUBSCRIPTION_GROUPS',
 	UPDATE_USER_ACCOUNT: 'UPDATE_USER_ACCOUNT',
 };
@@ -28,6 +29,12 @@ const reducer = (state, action) => {
 			return {
 				...state,
 				project: action.payload,
+			};
+		}
+		case actionTypes.UPDATE_SESSION_ID: {
+			return {
+				...state,
+				sessionId: action.payload,
 			};
 		}
 		case actionTypes.UPDATE_USER_ACCOUNT: {

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/onboarding/pages/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/onboarding/pages/index.js
@@ -23,7 +23,10 @@ import SuccessDXPCloud from './SuccessDXPCloud';
 import Welcome from './Welcome';
 
 const Pages = () => {
-	const [{project, step, subscriptionGroups}, dispatch] = useOnboarding();
+	const [
+		{project, sessionId, step, subscriptionGroups},
+		dispatch,
+	] = useOnboarding();
 
 	const invitesPageHandle = () => {
 		const hasSubscriptionsDXPCloud = !!subscriptionGroups?.length;
@@ -48,6 +51,7 @@ const Pages = () => {
 					handlePage={invitesPageHandle}
 					leftButton="Skip for now"
 					project={project}
+					sessionId={sessionId}
 				/>
 			),
 		},


### PR DESCRIPTION
### How it was developed?
It was added a new GraphQL query to create/update an user associating with an account (project) and also associate a accountRole for this user in an account (project).

I added the `associateUserAccountWithAccountAndAccountRole` GraphQL query that run two mutations (eaedb544f65ecf16404521a9dd146fa604f54f7d).
```
export const associateUserAccountWithAccountAndAccountRole = gql`
	mutation associateUserAccountWithAccountAndAccountRole(
		$emailAddress: String!
		$accountKey: String!
		$accountRoleId: Long!
	) {
		createAccountUserAccountByExternalReferenceCodeByEmailAddress(
			emailAddress: $emailAddress
			externalReferenceCode: $accountKey
		)
		createAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress(
			accountRoleId: $accountRoleId
			emailAddress: $emailAddress
			externalReferenceCode: $accountKey
		)
	}
`;
```

_In my test these mutation don't run in same time._

- `createAccountUserAccountByExternalReferenceCodeByEmailAddress`: Create/Update an user by e-mail and associate with an account (project).
  - For new user, it's create with first and last name filled with e-mail. I asked Amos about this behavior, and this is not a problem because the Okta replace these infos with the data come from raysource (after first login).
- `createAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress`: Associate a accountRole of a project for the user.

This query was used within a `Promise.all` that run it for each user selected in form (b39db6c9c0f8b794885349dc3e9fab1e2325dd4a).
Maybe in the future we can change it for a batch request. I saw that has for these request, I choose for don't use them because was been necessary a huge changes.

Basically was this, but it was necessary refactor the `InviteTeamMembersForms` component to get both id and name from select role.
Another change for this component was related with the use of roles
- Before was just necessary treat with string or roles' names, but now it's necessary treat the role as entity, in other words, it's necessary use the id and name.
  - For fix this, I add an `onChange` handler for selects inputs that find the role entity by the id selected.
- On component render start, there are some roles business to choose if some roles appears or not. It was necessary also change it, becase before it was only necessary check if some roles name exist and if not, just added. But as now we are treat as entity, it's was necessary remove the entire role.
  - Because this, was necessary some changes in site-initializer backend to add new roles that can be remove or keep it (https://github.com/pt-liferay-solutions/liferay-portal/pull/849).

**Endpoint**
  - To run the endpoint, a new rest was added to fill in the user's accountRole.
![img1_rest](https://user-images.githubusercontent.com/93679278/153041290-25adc447-36b4-48f8-a104-c73e8be5d6d7.png)


### What has been affected by the development (optional)?

All flows that use `InviteTeamMembersForms` component was affected
- Onboarding ([LPS-140151](https://issues.liferay.com/browse/LPS-140151))
- Modal in Team Members section ([LPS-140195](https://issues.liferay.com/browse/LPS-140195))

**Endpoint**
   - Had to create logic to get sessionId to use the rest api, affected the onboarding context and the flows that use the InviteTeamMembersForms component.
![img_session1](https://user-images.githubusercontent.com/93679278/153260978-2784e91d-cb89-4c4e-8bc4-e4eb821688b3.png)

### Test Plan

1. Go to Team Members Form
  - By Onboarding flow:
    - The user logged need be an Account Administrator for the project.
    - Check if doesn't have AccountFlags entries for the project that you want to access the Onboarding flow.
    - Select some project that is associated with Garretz, and came from AccountSync, click on the project and you will be taken to Onboarding Flow, the second step is the form.
  - By Team Members section
    - Select any project that is associated with Garretz, and that came from AccountSync, and go to the Team Member section by selecting from the side menu
    - Click on `+ Invite` button.
2. Fill out with garrettz@mbopartners.com.broken and select any roles and click on `Send Invitations`.
3. Go to the Users list for Account for this project.
  - Control Panel > Account > Find the account by the External Reference Code > Click on User tab
4. Check if the users that was filled in the form appears here, with the roles that was choose for them.

### It's necessary to add data mocks (optional)?
No.