### PR TITLE
LPS-147498 Revert "LPS-143165 Obtain urlTitleMap from unique title pr…

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/model/listener/LayoutFriendlyURLModelListener.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/model/listener/LayoutFriendlyURLModelListener.java
@@ -62,21 +62,14 @@ public class LayoutFriendlyURLModelListener
 			if (!_stagingGroupHelper.isLiveGroup(
 					layoutFriendlyURL.getGroupId())) {
 
-				long classNameId = _layoutFriendlyURLEntryHelper.getClassNameId(
-					layoutFriendlyURL.isPrivateLayout());
-
-				String urlTitle =
-					_friendlyURLEntryLocalService.getUniqueUrlTitle(
-						layoutFriendlyURL.getGroupId(), classNameId,
-						layoutFriendlyURL.getPlid(),
-						layoutFriendlyURL.getFriendlyURL(),
-						layoutFriendlyURL.getLanguageId());
-
 				_friendlyURLEntryLocalService.addFriendlyURLEntry(
-					layoutFriendlyURL.getGroupId(), classNameId,
+					layoutFriendlyURL.getGroupId(),
+					_layoutFriendlyURLEntryHelper.getClassNameId(
+						layoutFriendlyURL.isPrivateLayout()),
 					layoutFriendlyURL.getPlid(),
 					Collections.singletonMap(
-						layoutFriendlyURL.getLanguageId(), urlTitle),
+						layoutFriendlyURL.getLanguageId(),
+						layoutFriendlyURL.getFriendlyURL()),
 					ServiceContextThreadLocal.getServiceContext());
 			}
 		}


### PR DESCRIPTION
…oduced by friendlyURLEntryLocalService"

This reverts commit 29c273549469c577801dcbba69512e2958113534.

https://issues.liferay.com/browse/LPS-147498

The issue here is that the friendly URL gets incremented when being updated to another layout's old friendly URL. The expected behavior is it should show a UI error that the friendly URL is being used. 
To fix the issue I reverted LPS-143165. This fix is no longer reproducible and therefore the changes are no longer needed. See discussion in [PTR-2863](https://issues.liferay.com/browse/PTR-2863)