### PR TITLE
corrected language key order -> display-order

### DIFF
--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_order_type/details.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_order_type/details.jsp
@@ -54,11 +54,11 @@ if ((commerceOrderType != null) && (commerceOrderType.getExpirationDate() != nul
 					</div>
 
 					<div class="col-auto">
-						<aui:input label='<%= HtmlUtil.escape("order") %>' name="displayOrder" value="<%= String.valueOf(commerceOrderType.getDisplayOrder()) %>" />
+						<aui:input label="display-order" name="displayOrder" value="<%= String.valueOf(commerceOrderType.getDisplayOrder()) %>" />
 					</div>
 
 					<div class="col-auto">
-						<aui:input label='<%= HtmlUtil.escape("active") %>' name="active" type="toggle-switch" value="<%= commerceOrderType.isActive() %>" />
+						<aui:input label="active" name="active" type="toggle-switch" value="<%= commerceOrderType.isActive() %>" />
 					</div>
 				</div>
 


### PR DESCRIPTION
The single-word-language-key "order" is ambiguous and (IMHO) should be eliminated completely. it can refer to the noun for what was "ordered in a shop", noun for "display-order", verb (imperative) to "order something from a shop" or "apply display-order" - and potentially more. While they're all the same word in english, they're translated differently in various target languages.
(No LPS, I'm just blindly sending this PR to the liferay account and see what will happen with it - let me know if I should do it differently)