### PR TITLE
[TS] LPS-154310 Add an additional check for Asset Library Connected Site Member

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -36,6 +36,7 @@ import com.liferay.portal.security.permission.PermissionCacheUtil;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -303,21 +304,17 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 		long[] roleIds = getRoleIds(getUserId(), liveGroup.getGroupId());
 
-		Role memberRole = _roleLocalService.getRole(
-			liveGroup.getCompanyId(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-
-		if (Arrays.binarySearch(roleIds, memberRole.getRoleId()) >= 0) {
-			return true;
-		}
-
-		Role connectedSiteMemberRole = _roleLocalService.getRole(
-			liveGroup.getCompanyId(),
+		List<String> roleNames = Arrays.asList(
+			DepotRolesConstants.ASSET_LIBRARY_MEMBER,
 			DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER);
 
-		if (Arrays.binarySearch(roleIds, connectedSiteMemberRole.getRoleId()) >=
-				0) {
+		for (String roleName : roleNames) {
+			Role role = _roleLocalService.getRole(
+				liveGroup.getCompanyId(), roleName);
 
-			return true;
+			if (Arrays.binarySearch(roleIds, role.getRoleId()) >= 0) {
+				return true;
+			}
 		}
 
 		return false;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -303,10 +303,20 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 		long[] roleIds = getRoleIds(getUserId(), liveGroup.getGroupId());
 
-		Role role = _roleLocalService.getRole(
+		Role memberRole = _roleLocalService.getRole(
 			liveGroup.getCompanyId(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
-		if (Arrays.binarySearch(roleIds, role.getRoleId()) >= 0) {
+		if (Arrays.binarySearch(roleIds, memberRole.getRoleId()) >= 0) {
+			return true;
+		}
+
+		Role connectedSiteMemberRole = _roleLocalService.getRole(
+			liveGroup.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER);
+
+		if (Arrays.binarySearch(roleIds, connectedSiteMemberRole.getRoleId()) >=
+				0) {
+
 			return true;
 		}
 


### PR DESCRIPTION
Hi Team,

Can you help review this PR?

Notes from @noornajj :
> https://issues.liferay.com/browse/LPS-154310
> 
> The issue here is that when a user is added to a user group which is added as a member to an Asset Library, then that user does not get VIEW access to the Asset Library.
> This was due to the method _isGroupMemeber only checking for the Asset Library Member role when the user is assigned only the Asset Library Connected Site Member role. To fix the issue, I added an additional check for that role.

Please let us know if you have any questions.
Thanks!