### PR TITLE
LPS-153319 Allow to set/update extended properties in existing Liferay Portal Entities

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 9.11.1
+Bundle-Version: 9.12.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/EntityExtensionContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/EntityExtensionContext.java
@@ -14,8 +14,16 @@
 
 package com.liferay.portal.vulcan.jaxrs.context;
 
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
 import java.util.Map;
 import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import javax.ws.rs.core.UriInfo;
 
 /**
  * @author Javier de Arcos
@@ -36,9 +44,30 @@ public abstract class EntityExtensionContext<T> implements ExtensionContext {
 		return getEntityFilteredPropertyKeys(_toEntity(object));
 	}
 
-	public void setEntityExtendedProperties(
-		T entity, Map<String, Object> extendedProperties) {
+	public void setContextAcceptLanguage(AcceptLanguage acceptLanguage) {
+		contextAcceptLanguage = acceptLanguage;
 	}
+
+	public void setContextCompany(Company company) {
+		contextCompany = company;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest httpServletRequest) {
+
+		contextHttpServletRequest = httpServletRequest;
+	}
+
+	public void setContextUriInfo(UriInfo uriInfo) {
+		contextUriInfo = uriInfo;
+	}
+
+	public void setContextUser(User user) {
+		contextUser = user;
+	}
+
+	public abstract void setEntityExtendedProperties(
+		T entity, Map<String, Object> extendedProperties);
 
 	@Override
 	public void setExtendedProperties(
@@ -46,6 +75,12 @@ public abstract class EntityExtensionContext<T> implements ExtensionContext {
 
 		setEntityExtendedProperties(_toEntity(object), extendedProperties);
 	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected UriInfo contextUriInfo;
+	protected User contextUser;
 
 	private T _toEntity(Object object) {
 		try {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/EntityExtensionContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/EntityExtensionContext.java
@@ -36,6 +36,17 @@ public abstract class EntityExtensionContext<T> implements ExtensionContext {
 		return getEntityFilteredPropertyKeys(_toEntity(object));
 	}
 
+	public void setEntityExtendedProperties(
+		T entity, Map<String, Object> extendedProperties) {
+	}
+
+	@Override
+	public void setExtendedProperties(
+		Object object, Map<String, Object> extendedProperties) {
+
+		setEntityExtendedProperties(_toEntity(object), extendedProperties);
+	}
+
 	private T _toEntity(Object object) {
 		try {
 			T entity = (T)object;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/ExtensionContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/ExtensionContext.java
@@ -17,13 +17,20 @@ package com.liferay.portal.vulcan.jaxrs.context;
 import java.util.Map;
 import java.util.Set;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author Javier de Arcos
  */
+@ProviderType
 public interface ExtensionContext {
 
 	public Map<String, Object> getExtendedProperties(Object object);
 
 	public Set<String> getFilteredPropertyKeys(Object object);
+
+	public default void setExtendedProperties(
+		Object object, Map<String, Object> extendedProperties) {
+	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/ExtensionContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/ExtensionContext.java
@@ -14,8 +14,16 @@
 
 package com.liferay.portal.vulcan.jaxrs.context;
 
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
 import java.util.Map;
 import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import javax.ws.rs.core.UriInfo;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -29,8 +37,18 @@ public interface ExtensionContext {
 
 	public Set<String> getFilteredPropertyKeys(Object object);
 
-	public default void setExtendedProperties(
-		Object object, Map<String, Object> extendedProperties) {
-	}
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
+
+	public void setContextCompany(Company contextCompany);
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest);
+
+	public void setContextUriInfo(UriInfo contextUriInfo);
+
+	public void setContextUser(User contextUser);
+
+	public void setExtendedProperties(
+		Object object, Map<String, Object> extendedProperties);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/ExtensionContextRegistry.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/context/ExtensionContextRegistry.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.jaxrs.context;
+
+/**
+ * @author Javier de Arcos
+ */
+public interface ExtensionContextRegistry {
+
+	public ExtensionContext getExtensionContext(String className);
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/jaxrs/context/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/jaxrs/context/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/ExtensionContextRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/ExtensionContextRegistryImpl.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.context;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContextRegistry;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(immediate = true, service = ExtensionContextRegistry.class)
+public class ExtensionContextRegistryImpl implements ExtensionContextRegistry {
+
+	@Override
+	public ExtensionContext getExtensionContext(String className) {
+		return _serviceTrackerMap.getService(className);
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+			bundleContext, ExtensionContext.class,
+			"extension.context.class.name");
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTrackerMap.close();
+	}
+
+	private ServiceTrackerMap<String, ExtensionContext> _serviceTrackerMap;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ExtensionContextResolver.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ExtensionContextResolver.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.context.resolver;
+
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContextRegistry;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Javier de Arcos
+ */
+@Provider
+public class ExtensionContextResolver
+	implements ContextResolver<ExtensionContext> {
+
+	public ExtensionContextResolver(
+		ExtensionContextRegistry extensionContextRegistry) {
+
+		_extensionContextRegistry = extensionContextRegistry;
+	}
+
+	@Override
+	public ExtensionContext getContext(Class<?> clazz) {
+		return _extensionContextRegistry.getExtensionContext(clazz.getName());
+	}
+
+	private final ExtensionContextRegistry _extensionContextRegistry;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -45,6 +45,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.PaginationConte
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.RestrictFieldsQueryParamContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.SortContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.UserContextProvider;
+import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.ExtensionContextResolver;
 import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.ObjectMapperContextResolver;
 import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.XmlMapperContextResolver;
 import com.liferay.portal.vulcan.internal.jaxrs.dynamic.feature.StatusDynamicFeature;
@@ -70,6 +71,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor.EntityExtensi
 import com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor.NestedFieldsWriterInterceptor;
 import com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor.PageEntityExtensionWriterInterceptor;
 import com.liferay.portal.vulcan.internal.param.converter.provider.DateParamConverterProvider;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContextRegistry;
 
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -148,6 +150,8 @@ public class VulcanFeature implements Feature {
 				_roleLocalService, _getScopeChecker(),
 				_vulcanBatchEngineImportTaskResource));
 		featureContext.register(
+			new ExtensionContextResolver(_extensionContextRegistry));
+		featureContext.register(
 			new FilterContextProvider(
 				_expressionConvert, _filterParserProvider, _language, _portal));
 		featureContext.register(
@@ -209,6 +213,9 @@ public class VulcanFeature implements Feature {
 		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
 	)
 	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private ExtensionContextRegistry _extensionContextRegistry;
 
 	@Reference
 	private FilterParserProvider _filterParserProvider;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
@@ -14,18 +14,27 @@
 
 package com.liferay.portal.vulcan.internal.jaxrs.message.body;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.internal.jaxrs.validation.ValidationUtil;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,6 +44,7 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Providers;
 
@@ -66,21 +76,69 @@ public abstract class BaseMessageBodyReader
 			InputStream inputStream)
 		throws IOException {
 
-		ObjectReader objectMapper = _getObjectMapper(
-			clazz
-		).readerFor(
-			clazz
-		);
+		ObjectMapper objectMapper = _getObjectMapper(clazz);
 
-		Object value = objectMapper.readValue(inputStream);
+		ObjectReader objectReader = objectMapper.readerFor(clazz);
+
+		ExtensionContext extensionContext = _getExtensionContext(
+			clazz, mediaType);
+
+		if (extensionContext == null) {
+			return objectReader.readValue(inputStream);
+		}
+
+		JsonNode jsonNode = objectReader.readTree(inputStream);
+
+		objectReader = objectReader.without(
+			DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+		Object object = objectReader.readValue(jsonNode);
+
+		_setExtendedProperties(
+			clazz, extensionContext, jsonNode, object, objectMapper);
 
 		if (!StringUtil.equals(
 				_httpServletRequest.getMethod(), HttpMethod.PATCH)) {
 
-			ValidationUtil.validate(value);
+			ValidationUtil.validate(object);
 		}
 
-		return value;
+		return object;
+	}
+
+	private ExtensionContext _getExtensionContext(
+		Class<?> clazz, MediaType mediaType) {
+
+		ContextResolver<ExtensionContext> extensionContextContextResolver =
+			_providers.getContextResolver(ExtensionContext.class, mediaType);
+
+		return extensionContextContextResolver.getContext(clazz);
+	}
+
+	private Object _getJsonNodeValue(
+			JsonNode jsonNode, ObjectMapper objectMapper)
+		throws IOException {
+
+		if (jsonNode.isBoolean()) {
+			return jsonNode.asBoolean();
+		}
+		else if (jsonNode.isDouble()) {
+			return jsonNode.asDouble();
+		}
+		else if (jsonNode.isInt()) {
+			return jsonNode.asInt();
+		}
+		else if (jsonNode.isLong()) {
+			return jsonNode.asLong();
+		}
+		else if (jsonNode.isTextual()) {
+			return jsonNode.asText();
+		}
+		else if (jsonNode.isObject()) {
+			return objectMapper.readValue(jsonNode.traverse(), Object.class);
+		}
+
+		return null;
 	}
 
 	private ObjectMapper _getObjectMapper(Class<?> clazz) {
@@ -92,6 +150,35 @@ public abstract class BaseMessageBodyReader
 			() -> new InternalServerErrorException(
 				"Unable to generate object mapper for class " + clazz)
 		);
+	}
+
+	private void _setExtendedProperties(
+			Class<?> clazz, ExtensionContext extensionContext,
+			JsonNode jsonNode, Object object, ObjectMapper objectMapper)
+		throws IOException {
+
+		List<String> clazzFieldNames = new ArrayList<>();
+
+		for (Field field : clazz.getDeclaredFields()) {
+			clazzFieldNames.add(field.getName());
+		}
+
+		Iterator<String> fieldNamesIterator = jsonNode.fieldNames();
+		Map<String, Object> extendedProperties = new HashMap<>();
+
+		while (fieldNamesIterator.hasNext()) {
+			String jsonFieldName = fieldNamesIterator.next();
+
+			if (!clazzFieldNames.contains(jsonFieldName)) {
+				JsonNode fieldNameJsonNode = jsonNode.get(jsonFieldName);
+
+				extendedProperties.put(
+					jsonFieldName,
+					_getJsonNodeValue(fieldNameJsonNode, objectMapper));
+			}
+		}
+
+		extensionContext.setExtendedProperties(object, extendedProperties);
 	}
 
 	private final Class<? extends ObjectMapper> _contextType;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
@@ -19,7 +19,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.internal.jaxrs.validation.ValidationUtil;
 import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
 
@@ -44,6 +47,7 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Providers;
@@ -98,7 +102,7 @@ public abstract class BaseMessageBodyReader
 			clazz, extensionContext, jsonNode, object, objectMapper);
 
 		if (!StringUtil.equals(
-				_httpServletRequest.getMethod(), HttpMethod.PATCH)) {
+				_contextHttpServletRequest.getMethod(), HttpMethod.PATCH)) {
 
 			ValidationUtil.validate(object);
 		}
@@ -178,13 +182,32 @@ public abstract class BaseMessageBodyReader
 			}
 		}
 
+		extensionContext.setContextAcceptLanguage(_contextAcceptLanguage);
+		extensionContext.setContextCompany(_contextCompany);
+		extensionContext.setContextHttpServletRequest(
+			_contextHttpServletRequest);
+		extensionContext.setContextUriInfo(_contextUriInfo);
+		extensionContext.setContextUser(_contextUser);
+
 		extensionContext.setExtendedProperties(object, extendedProperties);
 	}
+
+	@Context
+	private AcceptLanguage _contextAcceptLanguage;
+
+	@Context
+	private Company _contextCompany;
+
+	@Context
+	private HttpServletRequest _contextHttpServletRequest;
 
 	private final Class<? extends ObjectMapper> _contextType;
 
 	@Context
-	private HttpServletRequest _httpServletRequest;
+	private UriInfo _contextUriInfo;
+
+	@Context
+	private User _contextUser;
 
 	private final MediaType _mediaType;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
 
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
 import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
 
@@ -21,7 +24,10 @@ import java.io.IOException;
 
 import java.util.Optional;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 import javax.ws.rs.ext.WriterInterceptor;
@@ -55,6 +61,13 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 		ExtensionContext extensionContext,
 		WriterInterceptorContext writerInterceptorContext) {
 
+		extensionContext.setContextAcceptLanguage(_contextAcceptLanguage);
+		extensionContext.setContextCompany(_contextCompany);
+		extensionContext.setContextHttpServletRequest(
+			_contextHttpServletRequest);
+		extensionContext.setContextUriInfo(_contextUriInfo);
+		extensionContext.setContextUser(_contextUser);
+
 		writerInterceptorContext.setEntity(
 			ExtendedEntity.extend(
 				writerInterceptorContext.getEntity(),
@@ -65,6 +78,21 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 
 		writerInterceptorContext.setGenericType(ExtendedEntity.class);
 	}
+
+	@Context
+	private AcceptLanguage _contextAcceptLanguage;
+
+	@Context
+	private Company _contextCompany;
+
+	@Context
+	private HttpServletRequest _contextHttpServletRequest;
+
+	@Context
+	private UriInfo _contextUriInfo;
+
+	@Context
+	private User _contextUser;
 
 	@Context
 	private Providers _providers;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/resolver/ExtensionContextResolverTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/resolver/ExtensionContextResolverTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.resolver;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.ExtensionContextResolver;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContextRegistry;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Javier de Arcos
+ */
+public class ExtensionContextResolverTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetContext() {
+		ExtensionContextRegistry mockedExtensionContextRegistry = Mockito.mock(
+			ExtensionContextRegistry.class);
+
+		ExtensionContextResolver extensionContextResolver =
+			new ExtensionContextResolver(mockedExtensionContextRegistry);
+
+		extensionContextResolver.getContext(TestClass.class);
+
+		Mockito.verify(
+			mockedExtensionContextRegistry
+		).getExtensionContext(
+			Mockito.eq(TestClass.class.getName())
+		);
+	}
+
+	private static class TestClass {
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/util/JAXRSExtensionContextUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/util/JAXRSExtensionContextUtil.java
@@ -111,6 +111,11 @@ public class JAXRSExtensionContextUtil {
 			return null;
 		}
 
+		@Override
+		public void setEntityExtendedProperties(
+			TestObject entity, Map<String, Object> extendedProperties) {
+		}
+
 	}
 
 	private static class TestExtensionContextResolver

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/test/ExtensionContextRegistryImplTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/test/ExtensionContextRegistryImplTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.jaxrs.context.EntityExtensionContext;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContextRegistry;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Javier de Arcos
+ */
+@RunWith(Arquillian.class)
+public class ExtensionContextRegistryImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ExtensionContextRegistryImplTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			ExtensionContext.class, _testEntityExtensionContext,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"extension.context.class.name", TestEntity.class.getName()
+			).build());
+	}
+
+	@After
+	public void tearDown() {
+		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testGetExtensionContext() {
+		ExtensionContext extensionContext =
+			_extensionContextRegistry.getExtensionContext(
+				TestEntity.class.getName());
+
+		Assert.assertEquals(_testEntityExtensionContext, extensionContext);
+
+		extensionContext = _extensionContextRegistry.getExtensionContext(
+			"NonExistentClassName");
+
+		Assert.assertNull(extensionContext);
+	}
+
+	@Inject
+	private ExtensionContextRegistry _extensionContextRegistry;
+
+	private ServiceRegistration<ExtensionContext> _serviceRegistration;
+	private final TestEntityExtensionContext _testEntityExtensionContext =
+		new TestEntityExtensionContext();
+
+	private static class TestEntity {
+	}
+
+	private static class TestEntityExtensionContext
+		extends EntityExtensionContext<TestEntity> {
+
+		@Override
+		public Map<String, Object> getEntityExtendedProperties(
+			TestEntity entity) {
+
+			return null;
+		}
+
+		@Override
+		public Set<String> getEntityFilteredPropertyKeys(TestEntity entity) {
+			return null;
+		}
+
+		@Override
+		public void setEntityExtendedProperties(
+			TestEntity entity, Map<String, Object> extendedProperties) {
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR completes the API Extensibility Framework allowing to set/update extended properties to existing Liferay entities through the APIs.

It extends the ExtensionContext interface with a new method called setExtendedProperties that will be called when a new request of this type of entity is received by a Liferay API. I've also included context objects to allow checking permissions and other complex logic in the EntityExtensionContext.

The recommended way of extending a Liferay Entity is using the abstract class EntityExtensionContext which provides all the context objects and is type-safe.

I've also eased the development of the EntityExtensionContext adding an ExtensionContextRegistry and an ExtensionContextResolver in Vulcan that makes all the wiring. This way the only thing you need to do to extend an entity is to extend the EntityExtensionContext class and register it as a Component implementing the ExtensionContext service and specifying the class name of the entity you are extending in the `extension.context.class.name` property, like:
```
@Component(
	immediate = true,
	property = "extension.context.class.name=com.liferay.headless.delivery.dto.v1_0.BlogPosting",
	service = ExtensionContext.class
)
public class BlogPostingExtensionContext
	extends EntityExtensionContext<BlogPosting> {

	@Override
	public Map<String, Object> getEntityExtendedProperties(BlogPosting entity) {
		/* This method will be called before returning the entity to allow you to add extended properties */
	}

	@Override
	public Set<String> getEntityFilteredPropertyKeys(BlogPosting entity) {
		/* This method will be called before returning the entity to allow you to filter existing properties */
	}

	@Override
	public void setEntityExtendedProperties(
		BlogPosting entity, Map<String, Object> extendedProperties) {

		/* This method will be called when creating or updating an entity to allow you to save the extended properties */
	}

}
```

I've doubt about adding an ObjectMapper to the EntityExtensionContext class to ease creating complex properties, but I didn't want to add a dependency to jackson libs just for that. At the end, it is something that can be done by any EntityExtensionContext implementation creating its own ObjectMapper. 