### PR TITLE
[TS]LPS-156353 After editing the name and saving the table doesn't update

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
@@ -125,7 +125,7 @@ export default function EditNotificationTemplate({
 				type: 'success',
 			});
 
-			window.history.back();
+			window.location.assign(document.referrer);
 		}
 		else if (response.status === 404) {
 			openToast({


### PR DESCRIPTION
@mbowerman Let me know if I should send this to Fortunato instead.


Notes from Levan:
> Ticket: LPS-156353
> 
> Issue: When updating the name of a notification template, saving would result in the notification table showing the previous name of the notification instead of the updated version. By reloading the page or having the browser dev tools open when saving the name, the correct and updated version of the name will be displayed.
> 
> Solution: Changed the call from onSubmit from window.history.back(); to window.location.assign(document.referrer); to properly load the correct version of the page. It seems that window.history.back(); called for the cached version of the previous page with the old name.
> 
