### PR TITLE
LPS-161955 Store the plid before returning so that unmodified Layouts can be referred to as well

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -602,6 +602,14 @@ public class LayoutStagedModelDataHandler
 			existingLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
 				uuid, groupId, privateLayout);
 
+			if (existingLayout != null) {
+				Map<Long, Long> layoutPlids =
+					(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+						Layout.class);
+
+				layoutPlids.put(layout.getPlid(), existingLayout.getPlid());
+			}
+
 			if (_sites.isLayoutModifiedSinceLastMerge(existingLayout) ||
 				!_isLayoutOutdated(existingLayout, layout)) {
 
@@ -634,16 +642,6 @@ public class LayoutStagedModelDataHandler
 						mergeFailFriendlyURLLayout.getLayoutId()));
 
 				return;
-			}
-
-			if (existingLayout != null) {
-				Map<Long, Long> layoutPlids =
-					(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-						Layout.class);
-
-				layoutPlids.put(
-					layout.getMasterLayoutPlid(),
-					existingLayout.getMasterLayoutPlid());
 			}
 		}
 		else {


### PR DESCRIPTION
Motivation
=======
[LPS-161955](https://issues.liferay.com/browse/LPS-161955)
Only Pages that were present in a Site Template during Site creation use the Site's Master Page Templates. Pages added later to the Site Template will propagate to the Site retaining the Site Template's Master Page Template.

Proposed Solution
========
Move the solution of LPS-159751 and change it to be ran during the Master Page import instead of the implementing Pages' import.

Steps to Verify
========
1. Create a Site Template
2. Create a Master Page
3. Create a Page based on the Master Page
4. Create a Site from the Site Template
5. Go back to the Site Template
6. Create a new Page from based on the Master Page
7. Go back to the Site
8. Go to Design > Page Template, Masters tab
9. Edit the Master Page
10. Add a new heading (this is the Site's local Master Page, not the Site Template's)
11. Publish the changes
12. Visit both pages in the Site

**Expected behaviour:** Both pages are displaying the changes made to the Site's Master Page
**Actual behaviour:** Only the first page (from the initial propagation of the Site creation) uses the Site's Master Page, the second page shows the Site Template's