### PR TITLE
LPS-161966 If Validator.isNull(masterLayoutUuid) then we should be resetting the Master Page to the default

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -823,6 +823,9 @@ public class LayoutStagedModelDataHandler
 				}
 			}
 		}
+		else {
+			importedLayout.setMasterLayoutPlid(0);
+		}
 
 		long parentPlid = layout.getParentPlid();
 		long parentLayoutId = layout.getParentLayoutId();


### PR DESCRIPTION
Motivation
=======
[LPS-161966](https://issues.liferay.com/browse/LPS-161966)
A Site Template can't propagate one of it's Page switching to the Blank Master Page Template

Proposed Solution
========
Set the default Master Page Template's plid ( 0 ) if no Master Page uuid belongs to the imported Layout

Steps to Verify
========
1. Create a Site Template
2. Create a Master Page
3. Create a Page based on the Master Page
4. Create a Site from the Site Template
5. Go back to the Site Template
6. Edit the Page
7. Change the Page to use the Blank Master Page
8. Publish
9. Go to the Site
10. Check the Page

**Expected behaviour:** Page uses the Blank Master Page
**Actual behaviour:** Page uses the Site Template's Master Page