### PR TITLE
[Remove Spring extender usages] LPS-161574 Break circular dependency between CommerceAddressLocalServiceImpl and CommerceOrderLocalServiceImpl 

### DIFF
--- a/modules/apps/commerce/commerce-address-content-web/src/main/java/com/liferay/commerce/address/content/web/internal/portlet/action/EditCommerceAddressMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-address-content-web/src/main/java/com/liferay/commerce/address/content/web/internal/portlet/action/EditCommerceAddressMVCActionCommand.java
@@ -22,6 +22,7 @@ import com.liferay.commerce.exception.CommerceAddressStreetException;
 import com.liferay.commerce.exception.NoSuchAddressException;
 import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.service.CommerceAddressService;
+import com.liferay.commerce.service.CommerceOrderLocalService;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -146,11 +147,17 @@ public class EditCommerceAddressMVCActionCommand extends BaseMVCActionCommand {
 				commerceAddressId, name, description, street1, street2, street3,
 				city, zip, regionId, countryId, phoneNumber, defaultBilling,
 				defaultShipping, serviceContext);
+
+			_commerceOrderLocalService.resetCommerceOrderShipping(
+				commerceAddressId);
 		}
 	}
 
 	@Reference
 	private CommerceAddressService _commerceAddressService;
+
+	@Reference
+	private CommerceOrderLocalService _commerceOrderLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/commerce/commerce-address-content-web/src/main/java/com/liferay/commerce/address/content/web/internal/portlet/action/EditCommerceAddressMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-address-content-web/src/main/java/com/liferay/commerce/address/content/web/internal/portlet/action/EditCommerceAddressMVCActionCommand.java
@@ -105,6 +105,9 @@ public class EditCommerceAddressMVCActionCommand extends BaseMVCActionCommand {
 
 		if (commerceAddressId > 0) {
 			_commerceAddressService.deleteCommerceAddress(commerceAddressId);
+
+			_commerceOrderLocalService.removeCommerceOrderAddresses(
+				commerceAddressId);
 		}
 	}
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -549,6 +549,9 @@ public interface CommerceOrderLocalService
 			long commerceOrderId, CommerceContext commerceContext)
 		throws PortalException;
 
+	public void removeCommerceOrderAddresses(long commerceAddressId)
+		throws PortalException;
+
 	public CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId, CommerceContext commerceContext)
 		throws PortalException;

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -554,8 +554,10 @@ public interface CommerceOrderLocalService
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
-	public CommerceOrder resetCommerceOrderShipping(long commerceOrderId)
-		throws PortalException;
+	public CommerceOrder resetCommerceOrderShipping(
+		CommerceOrder commerceOrder);
+
+	public void resetCommerceOrderShipping(long shippingAddressId);
 
 	public CommerceOrder resetTermsAndConditions(
 			long commerceOrderId, boolean resetDeliveryCommerceTerm,

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -749,7 +749,6 @@ public interface CommerceOrderLocalService
 			long commerceOrderId, long shippingAddressId)
 		throws PortalException;
 
-	@Indexable(type = IndexableType.REINDEX)
 	public CommerceOrder updateShippingAddress(
 			long commerceOrderId, String name, String description,
 			String street1, String street2, String street3, String city,

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -719,6 +719,12 @@ public class CommerceOrderLocalServiceUtil {
 		return getService().recalculatePrice(commerceOrderId, commerceContext);
 	}
 
+	public static void removeCommerceOrderAddresses(long commerceAddressId)
+		throws PortalException {
+
+		getService().removeCommerceOrderAddresses(commerceAddressId);
+	}
+
 	public static CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId,
 			com.liferay.commerce.context.CommerceContext commerceContext)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -728,10 +728,14 @@ public class CommerceOrderLocalServiceUtil {
 			userId, commerceOrderId, commerceContext);
 	}
 
-	public static CommerceOrder resetCommerceOrderShipping(long commerceOrderId)
-		throws PortalException {
+	public static CommerceOrder resetCommerceOrderShipping(
+		CommerceOrder commerceOrder) {
 
-		return getService().resetCommerceOrderShipping(commerceOrderId);
+		return getService().resetCommerceOrderShipping(commerceOrder);
+	}
+
+	public static void resetCommerceOrderShipping(long shippingAddressId) {
+		getService().resetCommerceOrderShipping(shippingAddressId);
 	}
 
 	public static CommerceOrder resetTermsAndConditions(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -817,6 +817,14 @@ public class CommerceOrderLocalServiceWrapper
 	}
 
 	@Override
+	public void removeCommerceOrderAddresses(long commerceAddressId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_commerceOrderLocalService.removeCommerceOrderAddresses(
+			commerceAddressId);
+	}
+
+	@Override
 	public com.liferay.commerce.model.CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId,
 			com.liferay.commerce.context.CommerceContext commerceContext)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -828,11 +828,16 @@ public class CommerceOrderLocalServiceWrapper
 
 	@Override
 	public com.liferay.commerce.model.CommerceOrder resetCommerceOrderShipping(
-			long commerceOrderId)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		com.liferay.commerce.model.CommerceOrder commerceOrder) {
 
 		return _commerceOrderLocalService.resetCommerceOrderShipping(
-			commerceOrderId);
+			commerceOrder);
+	}
+
+	@Override
+	public void resetCommerceOrderShipping(long shippingAddressId) {
+		_commerceOrderLocalService.resetCommerceOrderShipping(
+			shippingAddressId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -23,11 +23,8 @@ import com.liferay.commerce.exception.CommerceAddressTypeException;
 import com.liferay.commerce.exception.CommerceAddressZipException;
 import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.model.CommerceGeocoder;
-import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.model.impl.CommerceAddressImpl;
-import com.liferay.commerce.service.CommerceOrderLocalService;
 import com.liferay.commerce.service.base.CommerceAddressLocalServiceBaseImpl;
-import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Group;
@@ -47,8 +44,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.vulcan.util.TransformUtil;
-
-import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -168,22 +163,6 @@ public class CommerceAddressLocalServiceImpl
 
 		_addressLocalService.deleteAddress(
 			commerceAddress.getCommerceAddressId());
-
-		// Commerce orders
-
-		List<CommerceOrder> commerceOrders =
-			_commerceOrderLocalService.getCommerceOrdersByBillingAddress(
-				commerceAddress.getCommerceAddressId());
-
-		removeCommerceOrderAddresses(
-			commerceOrders, commerceAddress.getCommerceAddressId());
-
-		commerceOrders =
-			_commerceOrderLocalService.getCommerceOrdersByShippingAddress(
-				commerceAddress.getCommerceAddressId());
-
-		removeCommerceOrderAddresses(
-			commerceOrders, commerceAddress.getCommerceAddressId());
 
 		return commerceAddress;
 	}
@@ -582,29 +561,6 @@ public class CommerceAddressLocalServiceImpl
 		return CommerceAddressImpl.fromAddress(address);
 	}
 
-	protected void removeCommerceOrderAddresses(
-			List<CommerceOrder> commerceOrders, long commerceAddressId)
-		throws PortalException {
-
-		for (CommerceOrder commerceOrder : commerceOrders) {
-			long billingAddressId = commerceOrder.getBillingAddressId();
-			long shippingAddressId = commerceOrder.getShippingAddressId();
-
-			if (billingAddressId == commerceAddressId) {
-				commerceOrder.setBillingAddressId(0);
-			}
-
-			if (shippingAddressId == commerceAddressId) {
-				commerceOrder.setShippingAddressId(0);
-				commerceOrder.setCommerceShippingMethodId(0);
-				commerceOrder.setShippingOptionName(null);
-				commerceOrder.setShippingAmount(BigDecimal.ZERO);
-			}
-
-			_commerceOrderLocalService.updateCommerceOrder(commerceOrder);
-		}
-	}
-
 	protected void validate(
 			String name, String street1, String city, String zip,
 			long countryId, int type)
@@ -659,9 +615,6 @@ public class CommerceAddressLocalServiceImpl
 
 	@ServiceReference(type = CommerceGeocoder.class)
 	private CommerceGeocoder _commerceGeocoder;
-
-	@BeanReference(type = CommerceOrderLocalService.class)
-	private CommerceOrderLocalService _commerceOrderLocalService;
 
 	@ServiceReference(type = GroupLocalService.class)
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -579,17 +579,6 @@ public class CommerceAddressLocalServiceImpl
 			CommerceAddressImpl.toAddressTypeId(type), address.isMailing(),
 			address.isPrimary(), phoneNumber);
 
-		// Commerce orders
-
-		List<CommerceOrder> commerceOrders =
-			_commerceOrderLocalService.getCommerceOrdersByShippingAddress(
-				commerceAddressId);
-
-		for (CommerceOrder commerceOrder : commerceOrders) {
-			_commerceOrderLocalService.resetCommerceOrderShipping(
-				commerceOrder.getCommerceOrderId());
-		}
-
 		return CommerceAddressImpl.fromAddress(address);
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -590,31 +590,18 @@ public class CommerceAddressLocalServiceImpl
 			long billingAddressId = commerceOrder.getBillingAddressId();
 			long shippingAddressId = commerceOrder.getShippingAddressId();
 
-			long commerceShippingMethodId =
-				commerceOrder.getCommerceShippingMethodId();
-			String shippingOptionName = commerceOrder.getShippingOptionName();
-			BigDecimal shippingPrice = commerceOrder.getShippingAmount();
-
 			if (billingAddressId == commerceAddressId) {
-				billingAddressId = 0;
+				commerceOrder.setBillingAddressId(0);
 			}
 
 			if (shippingAddressId == commerceAddressId) {
-				shippingAddressId = 0;
-
-				commerceShippingMethodId = 0;
-				shippingOptionName = null;
-				shippingPrice = BigDecimal.ZERO;
+				commerceOrder.setShippingAddressId(0);
+				commerceOrder.setCommerceShippingMethodId(0);
+				commerceOrder.setShippingOptionName(null);
+				commerceOrder.setShippingAmount(BigDecimal.ZERO);
 			}
 
-			_commerceOrderLocalService.updateCommerceOrder(
-				null, commerceOrder.getCommerceOrderId(), billingAddressId,
-				commerceShippingMethodId, shippingAddressId,
-				commerceOrder.getAdvanceStatus(),
-				commerceOrder.getCommercePaymentMethodKey(),
-				commerceOrder.getPurchaseOrderNumber(), shippingPrice,
-				shippingOptionName, commerceOrder.getSubtotal(),
-				commerceOrder.getTotal(), null);
+			_commerceOrderLocalService.updateCommerceOrder(commerceOrder);
 		}
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -914,6 +914,22 @@ public class CommerceOrderLocalServiceImpl
 		return commerceOrderPersistence.update(commerceOrder);
 	}
 
+	public void removeCommerceOrderAddresses(long commerceAddressId)
+		throws PortalException {
+
+		if (commerceAddressId > 0) {
+			_removeCommerceOrderAddresses(
+				commerceOrderLocalService.getCommerceOrdersByBillingAddress(
+					commerceAddressId),
+				commerceAddressId);
+
+			_removeCommerceOrderAddresses(
+				commerceOrderLocalService.getCommerceOrdersByShippingAddress(
+					commerceAddressId),
+				commerceAddressId);
+		}
+	}
+
 	@Override
 	public CommerceOrder reorderCommerceOrder(
 			long userId, long commerceOrderId, CommerceContext commerceContext)
@@ -2032,6 +2048,29 @@ public class CommerceOrderLocalServiceImpl
 
 		if (Validator.isNull(purchaseOrderNumber)) {
 			throw new CommerceOrderPurchaseOrderNumberException();
+		}
+	}
+
+	private void _removeCommerceOrderAddresses(
+			List<CommerceOrder> commerceOrders, long commerceAddressId)
+		throws PortalException {
+
+		for (CommerceOrder commerceOrder : commerceOrders) {
+			long billingAddressId = commerceOrder.getBillingAddressId();
+			long shippingAddressId = commerceOrder.getShippingAddressId();
+
+			if (billingAddressId == commerceAddressId) {
+				commerceOrder.setBillingAddressId(0);
+			}
+
+			if (shippingAddressId == commerceAddressId) {
+				commerceOrder.setCommerceShippingMethodId(0);
+				commerceOrder.setShippingAddressId(0);
+				commerceOrder.setShippingAmount(BigDecimal.ZERO);
+				commerceOrder.setShippingOptionName(null);
+			}
+
+			commerceOrderLocalService.updateCommerceOrder(commerceOrder);
 		}
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -1578,7 +1578,6 @@ public class CommerceOrderLocalServiceImpl
 		return commerceOrderPersistence.update(commerceOrder);
 	}
 
-	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public CommerceOrder updateShippingAddress(
 			long commerceOrderId, String name, String description,

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -1587,11 +1587,16 @@ public class CommerceOrderLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		return updateAddress(
+		CommerceOrder commerceOrder = updateAddress(
 			commerceOrderId, name, description, street1, street2, street3, city,
 			zip, regionId, countryId, phoneNumber,
 			CommerceOrder::getShippingAddressId,
 			CommerceOrder::setShippingAddressId, serviceContext);
+
+		resetCommerceOrderShipping(commerceOrder.getShippingAddressId());
+
+		return commerceOrderPersistence.findByPrimaryKey(
+			commerceOrder.getCommerceOrderId());
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -995,17 +995,28 @@ public class CommerceOrderLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public CommerceOrder resetCommerceOrderShipping(long commerceOrderId)
-		throws PortalException {
-
-		CommerceOrder commerceOrder =
-			commerceOrderLocalService.getCommerceOrder(commerceOrderId);
+	public CommerceOrder resetCommerceOrderShipping(
+		CommerceOrder commerceOrder) {
 
 		commerceOrder.setCommerceShippingMethodId(0);
 		commerceOrder.setShippingAmount(BigDecimal.ZERO);
 		commerceOrder.setShippingOptionName(null);
 
 		return commerceOrderPersistence.update(commerceOrder);
+	}
+
+	@Override
+	public void resetCommerceOrderShipping(long shippingAddressId) {
+		if (shippingAddressId > 0) {
+			List<CommerceOrder> commerceOrders =
+				commerceOrderLocalService.getCommerceOrdersByShippingAddress(
+					shippingAddressId);
+
+			for (CommerceOrder commerceOrder : commerceOrders) {
+				commerceOrderLocalService.resetCommerceOrderShipping(
+					commerceOrder);
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/order/test/CommerceOrderTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/order/test/CommerceOrderTest.java
@@ -750,8 +750,12 @@ public class CommerceOrderTest {
 		_commerceOrderLocalService.deleteCommerceOrder(commerceOrder);
 		_commerceOrderLocalService.deleteCommerceOrder(secondCommerceOrder);
 		_commerceAddressLocalService.deleteCommerceAddress(commerceAddress);
+		_commerceOrderLocalService.removeCommerceOrderAddresses(
+			commerceAddress.getCommerceAddressId());
 		_commerceAddressLocalService.deleteCommerceAddress(
 			secondCommerceAddress);
+		_commerceOrderLocalService.removeCommerceOrderAddresses(
+			secondCommerceAddress.getCommerceAddressId());
 		_commerceAccountLocalService.deleteCommerceAccount(commerceAccount);
 		_commerceAccountLocalService.deleteCommerceAccount(
 			secondCommerceAccount);
@@ -965,6 +969,8 @@ public class CommerceOrderTest {
 		_commerceOrderLocalService.deleteCommerceOrders(commerceChannelGroupId);
 		_commerceAccountLocalService.deleteCommerceAccount(commerceAccount);
 		_commerceAddressLocalService.deleteCommerceAddress(commerceAddress);
+		_commerceOrderLocalService.removeCommerceOrderAddresses(
+			commerceAddress.getCommerceAddressId());
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
@@ -151,45 +151,10 @@ public class AccountAddressResourceImpl
 			Long id, AccountAddress accountAddress)
 		throws Exception {
 
-		CommerceAddress commerceAddress =
-			_commerceAddressService.getCommerceAddress(id);
-
-		Country country = _countryService.getCountryByA2(
-			commerceAddress.getCompanyId(), accountAddress.getCountryISOCode());
-
-		commerceAddress = _commerceAddressService.updateCommerceAddress(
-			commerceAddress.getCommerceAddressId(),
-			GetterUtil.getString(
-				accountAddress.getName(), commerceAddress.getName()),
-			GetterUtil.getString(
-				accountAddress.getDescription(),
-				commerceAddress.getDescription()),
-			GetterUtil.getString(
-				accountAddress.getStreet1(), commerceAddress.getStreet1()),
-			GetterUtil.getString(
-				accountAddress.getStreet2(), commerceAddress.getStreet2()),
-			GetterUtil.getString(
-				accountAddress.getStreet3(), commerceAddress.getStreet3()),
-			GetterUtil.getString(
-				accountAddress.getCity(), commerceAddress.getCity()),
-			GetterUtil.getString(
-				accountAddress.getZip(), commerceAddress.getZip()),
-			GetterUtil.getLong(
-				_getRegionId(country, accountAddress),
-				commerceAddress.getRegionId()),
-			GetterUtil.getLong(
-				_getCountryId(country), commerceAddress.getCountryId()),
-			GetterUtil.getString(
-				accountAddress.getPhoneNumber(),
-				commerceAddress.getPhoneNumber()),
-			GetterUtil.getInteger(
-				accountAddress.getType(), commerceAddress.getType()),
-			_serviceContextHelper.getServiceContext());
-
-		_commerceOrderLocalService.resetCommerceOrderShipping(
-			commerceAddress.getCommerceAddressId());
-
-		return _toAccountAddress(commerceAddress);
+		return _toAccountAddress(
+			_updateCommerceAddress(
+				_commerceAddressService.getCommerceAddress(id),
+				accountAddress));
 	}
 
 	@Override
@@ -207,40 +172,7 @@ public class AccountAddressResourceImpl
 					externalReferenceCode);
 		}
 
-		Country country = _countryService.getCountryByA2(
-			commerceAddress.getCompanyId(), accountAddress.getCountryISOCode());
-
-		_commerceAddressService.updateCommerceAddress(
-			commerceAddress.getCommerceAddressId(),
-			GetterUtil.getString(
-				accountAddress.getName(), commerceAddress.getName()),
-			GetterUtil.getString(
-				accountAddress.getDescription(),
-				commerceAddress.getDescription()),
-			GetterUtil.getString(
-				accountAddress.getStreet1(), commerceAddress.getStreet1()),
-			GetterUtil.getString(
-				accountAddress.getStreet2(), commerceAddress.getStreet2()),
-			GetterUtil.getString(
-				accountAddress.getStreet3(), commerceAddress.getStreet3()),
-			GetterUtil.getString(
-				accountAddress.getCity(), commerceAddress.getCity()),
-			GetterUtil.getString(
-				accountAddress.getZip(), commerceAddress.getZip()),
-			GetterUtil.getLong(
-				_getRegionId(country, accountAddress),
-				commerceAddress.getRegionId()),
-			GetterUtil.getLong(
-				_getCountryId(country), commerceAddress.getCountryId()),
-			GetterUtil.getString(
-				accountAddress.getPhoneNumber(),
-				commerceAddress.getPhoneNumber()),
-			GetterUtil.getInteger(
-				accountAddress.getType(), commerceAddress.getType()),
-			_serviceContextHelper.getServiceContext());
-
-		_commerceOrderLocalService.resetCommerceOrderShipping(
-			commerceAddress.getCommerceAddressId());
+		_updateCommerceAddress(commerceAddress, accountAddress);
 
 		Response.ResponseBuilder responseBuilder = Response.noContent();
 
@@ -276,33 +208,8 @@ public class AccountAddressResourceImpl
 		}
 
 		if (commerceAddress != null) {
-			Country country = _countryService.getCountryByA2(
-				commerceAddress.getCompanyId(),
-				accountAddress.getCountryISOCode());
-
-			commerceAddress = _commerceAddressService.updateCommerceAddress(
-				commerceAddress.getCommerceAddressId(),
-				GetterUtil.getString(accountAddress.getName(), null),
-				GetterUtil.getString(accountAddress.getDescription(), null),
-				GetterUtil.getString(accountAddress.getStreet1(), null),
-				GetterUtil.getString(accountAddress.getStreet2(), null),
-				GetterUtil.getString(accountAddress.getStreet3(), null),
-				GetterUtil.getString(accountAddress.getCity(), null),
-				GetterUtil.getString(accountAddress.getZip(), null),
-				GetterUtil.getLong(
-					_getRegionId(country, accountAddress),
-					commerceAddress.getRegionId()),
-				GetterUtil.getLong(
-					_getCountryId(country), commerceAddress.getCountryId()),
-				GetterUtil.getString(accountAddress.getPhoneNumber(), null),
-				GetterUtil.getInteger(
-					accountAddress.getType(), commerceAddress.getType()),
-				_serviceContextHelper.getServiceContext());
-
-			_commerceOrderLocalService.resetCommerceOrderShipping(
-				commerceAddress.getCommerceAddressId());
-
-			return _toAccountAddress(commerceAddress);
+			return _toAccountAddress(
+				_updateCommerceAddress(commerceAddress, accountAddress));
 		}
 
 		return _addAccountAddress(commerceAccount, accountAddress);
@@ -322,34 +229,10 @@ public class AccountAddressResourceImpl
 			Long id, AccountAddress accountAddress)
 		throws Exception {
 
-		CommerceAddress commerceAddress =
-			_commerceAddressService.getCommerceAddress(id);
-
-		Country country = _countryService.getCountryByA2(
-			commerceAddress.getCompanyId(), accountAddress.getCountryISOCode());
-
-		commerceAddress = _commerceAddressService.updateCommerceAddress(
-			commerceAddress.getCommerceAddressId(),
-			GetterUtil.getString(accountAddress.getName()),
-			GetterUtil.getString(accountAddress.getDescription()),
-			GetterUtil.getString(accountAddress.getStreet1()),
-			GetterUtil.getString(accountAddress.getStreet2()),
-			GetterUtil.getString(accountAddress.getStreet3()),
-			GetterUtil.getString(accountAddress.getCity()),
-			GetterUtil.getString(accountAddress.getZip()),
-			GetterUtil.getLong(
-				_getRegionId(country, accountAddress),
-				commerceAddress.getRegionId()),
-			GetterUtil.getLong(
-				_getCountryId(country), commerceAddress.getCountryId()),
-			GetterUtil.getString(accountAddress.getPhoneNumber()),
-			GetterUtil.getInteger(accountAddress.getType()),
-			_serviceContextHelper.getServiceContext());
-
-		_commerceOrderLocalService.resetCommerceOrderShipping(
-			commerceAddress.getCommerceAddressId());
-
-		return _toAccountAddress(commerceAddress);
+		return _toAccountAddress(
+			_updateCommerceAddress(
+				_commerceAddressService.getCommerceAddress(id),
+				accountAddress));
 	}
 
 	private AccountAddress _addAccountAddress(
@@ -447,6 +330,48 @@ public class AccountAddressResourceImpl
 		}
 
 		return accountAddresses;
+	}
+
+	private CommerceAddress _updateCommerceAddress(
+			CommerceAddress commerceAddress, AccountAddress accountAddress)
+		throws Exception {
+
+		Country country = _countryService.getCountryByA2(
+			commerceAddress.getCompanyId(), accountAddress.getCountryISOCode());
+
+		commerceAddress = _commerceAddressService.updateCommerceAddress(
+			commerceAddress.getCommerceAddressId(),
+			GetterUtil.getString(
+				accountAddress.getName(), commerceAddress.getName()),
+			GetterUtil.getString(
+				accountAddress.getDescription(),
+				commerceAddress.getDescription()),
+			GetterUtil.getString(
+				accountAddress.getStreet1(), commerceAddress.getStreet1()),
+			GetterUtil.getString(
+				accountAddress.getStreet2(), commerceAddress.getStreet2()),
+			GetterUtil.getString(
+				accountAddress.getStreet3(), commerceAddress.getStreet3()),
+			GetterUtil.getString(
+				accountAddress.getCity(), commerceAddress.getCity()),
+			GetterUtil.getString(
+				accountAddress.getZip(), commerceAddress.getZip()),
+			GetterUtil.getLong(
+				_getRegionId(country, accountAddress),
+				commerceAddress.getRegionId()),
+			GetterUtil.getLong(
+				_getCountryId(country), commerceAddress.getCountryId()),
+			GetterUtil.getString(
+				accountAddress.getPhoneNumber(),
+				commerceAddress.getPhoneNumber()),
+			GetterUtil.getInteger(
+				accountAddress.getType(), commerceAddress.getType()),
+			_serviceContextHelper.getServiceContext());
+
+		_commerceOrderLocalService.resetCommerceOrderShipping(
+			commerceAddress.getCommerceAddressId());
+
+		return commerceAddress;
 	}
 
 	@Reference

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.commerce.constants.CommerceAddressConstants;
 import com.liferay.commerce.exception.NoSuchAddressException;
 import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.service.CommerceAddressService;
+import com.liferay.commerce.service.CommerceOrderLocalService;
 import com.liferay.headless.commerce.admin.account.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.account.dto.v1_0.AccountAddress;
 import com.liferay.headless.commerce.admin.account.internal.dto.v1_0.converter.AccountAddressDTOConverter;
@@ -185,6 +186,9 @@ public class AccountAddressResourceImpl
 				accountAddress.getType(), commerceAddress.getType()),
 			_serviceContextHelper.getServiceContext());
 
+		_commerceOrderLocalService.resetCommerceOrderShipping(
+			commerceAddress.getCommerceAddressId());
+
 		return _toAccountAddress(commerceAddress);
 	}
 
@@ -235,6 +239,9 @@ public class AccountAddressResourceImpl
 				accountAddress.getType(), commerceAddress.getType()),
 			_serviceContextHelper.getServiceContext());
 
+		_commerceOrderLocalService.resetCommerceOrderShipping(
+			commerceAddress.getCommerceAddressId());
+
 		Response.ResponseBuilder responseBuilder = Response.noContent();
 
 		return responseBuilder.build();
@@ -273,25 +280,29 @@ public class AccountAddressResourceImpl
 				commerceAddress.getCompanyId(),
 				accountAddress.getCountryISOCode());
 
-			return _toAccountAddress(
-				_commerceAddressService.updateCommerceAddress(
-					commerceAddress.getCommerceAddressId(),
-					GetterUtil.getString(accountAddress.getName(), null),
-					GetterUtil.getString(accountAddress.getDescription(), null),
-					GetterUtil.getString(accountAddress.getStreet1(), null),
-					GetterUtil.getString(accountAddress.getStreet2(), null),
-					GetterUtil.getString(accountAddress.getStreet3(), null),
-					GetterUtil.getString(accountAddress.getCity(), null),
-					GetterUtil.getString(accountAddress.getZip(), null),
-					GetterUtil.getLong(
-						_getRegionId(country, accountAddress),
-						commerceAddress.getRegionId()),
-					GetterUtil.getLong(
-						_getCountryId(country), commerceAddress.getCountryId()),
-					GetterUtil.getString(accountAddress.getPhoneNumber(), null),
-					GetterUtil.getInteger(
-						accountAddress.getType(), commerceAddress.getType()),
-					_serviceContextHelper.getServiceContext()));
+			commerceAddress = _commerceAddressService.updateCommerceAddress(
+				commerceAddress.getCommerceAddressId(),
+				GetterUtil.getString(accountAddress.getName(), null),
+				GetterUtil.getString(accountAddress.getDescription(), null),
+				GetterUtil.getString(accountAddress.getStreet1(), null),
+				GetterUtil.getString(accountAddress.getStreet2(), null),
+				GetterUtil.getString(accountAddress.getStreet3(), null),
+				GetterUtil.getString(accountAddress.getCity(), null),
+				GetterUtil.getString(accountAddress.getZip(), null),
+				GetterUtil.getLong(
+					_getRegionId(country, accountAddress),
+					commerceAddress.getRegionId()),
+				GetterUtil.getLong(
+					_getCountryId(country), commerceAddress.getCountryId()),
+				GetterUtil.getString(accountAddress.getPhoneNumber(), null),
+				GetterUtil.getInteger(
+					accountAddress.getType(), commerceAddress.getType()),
+				_serviceContextHelper.getServiceContext());
+
+			_commerceOrderLocalService.resetCommerceOrderShipping(
+				commerceAddress.getCommerceAddressId());
+
+			return _toAccountAddress(commerceAddress);
 		}
 
 		return _addAccountAddress(commerceAccount, accountAddress);
@@ -334,6 +345,9 @@ public class AccountAddressResourceImpl
 			GetterUtil.getString(accountAddress.getPhoneNumber()),
 			GetterUtil.getInteger(accountAddress.getType()),
 			_serviceContextHelper.getServiceContext());
+
+		_commerceOrderLocalService.resetCommerceOrderShipping(
+			commerceAddress.getCommerceAddressId());
 
 		return _toAccountAddress(commerceAddress);
 	}
@@ -443,6 +457,9 @@ public class AccountAddressResourceImpl
 
 	@Reference
 	private CommerceAddressService _commerceAddressService;
+
+	@Reference
+	private CommerceOrderLocalService _commerceOrderLocalService;
 
 	@Reference
 	private CountryLocalService _countryService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
@@ -65,6 +65,8 @@ public class AccountAddressResourceImpl
 	public Response deleteAccountAddress(Long id) throws Exception {
 		_commerceAddressService.deleteCommerceAddress(id);
 
+		_commerceOrderLocalService.removeCommerceOrderAddresses(id);
+
 		Response.ResponseBuilder responseBuilder = Response.noContent();
 
 		return responseBuilder.build();
@@ -86,6 +88,9 @@ public class AccountAddressResourceImpl
 		}
 
 		_commerceAddressService.deleteCommerceAddress(
+			commerceAddress.getCommerceAddressId());
+
+		_commerceOrderLocalService.removeCommerceOrderAddresses(
 			commerceAddress.getCommerceAddressId());
 
 		Response.ResponseBuilder responseBuilder = Response.noContent();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.commerce.account.service.persistence.CommerceAccountUserRelPK
 import com.liferay.commerce.constants.CommerceAddressConstants;
 import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.service.CommerceAddressService;
+import com.liferay.commerce.service.CommerceOrderLocalService;
 import com.liferay.headless.commerce.admin.account.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.account.dto.v1_0.AccountAddress;
 import com.liferay.headless.commerce.admin.account.dto.v1_0.AccountMember;
@@ -563,6 +564,9 @@ public class AccountResourceImpl extends BaseAccountResourceImpl {
 								ADDRESS_TYPE_BILLING_AND_SHIPPING),
 						serviceContext);
 
+					_commerceOrderLocalService.resetCommerceOrderShipping(
+						exisitingCommerceAddress.getCommerceAddressId());
+
 					if (GetterUtil.get(
 							accountAddress.getDefaultBilling(), false)) {
 
@@ -705,6 +709,9 @@ public class AccountResourceImpl extends BaseAccountResourceImpl {
 
 	@Reference
 	private CommerceAddressService _commerceAddressService;
+
+	@Reference
+	private CommerceOrderLocalService _commerceOrderLocalService;
 
 	@Reference
 	private CountryService _countryService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
@@ -44,6 +44,7 @@ import com.liferay.commerce.product.service.CommerceChannelLocalService;
 import com.liferay.commerce.product.service.CommerceChannelService;
 import com.liferay.commerce.service.CommerceAddressService;
 import com.liferay.commerce.service.CommerceOrderItemService;
+import com.liferay.commerce.service.CommerceOrderLocalService;
 import com.liferay.commerce.service.CommerceOrderService;
 import com.liferay.commerce.service.CommerceOrderTypeLocalService;
 import com.liferay.commerce.service.CommerceOrderTypeService;
@@ -484,6 +485,9 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		if (commerceOrder.getShippingAddressId() > 0) {
 			_updateCommerceOrderAddress(
 				commerceOrder, address, type, serviceContext);
+
+			_commerceOrderLocalService.resetCommerceOrderShipping(
+				commerceOrder.getShippingAddressId());
 		}
 		else {
 			CommerceAddress commerceAddress = _addCommerceAddress(
@@ -830,6 +834,9 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 
 	@Reference
 	private CommerceOrderItemService _commerceOrderItemService;
+
+	@Reference
+	private CommerceOrderLocalService _commerceOrderLocalService;
 
 	@Reference
 	private CommerceOrderService _commerceOrderService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/AddressResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/AddressResourceTest.java
@@ -103,6 +103,9 @@ public class AddressResourceTest extends BaseAddressResourceTestCase {
 		if (_commerceAddress != null) {
 			_commerceAddressLocalService.deleteCommerceAddress(
 				_commerceAddress);
+
+			_commerceOrderLocalService.removeCommerceOrderAddresses(
+				_commerceAddress.getCommerceAddressId());
 		}
 
 		if (_commerceAccount != null) {


### PR DESCRIPTION
@dantewang, the pr used moving logic from ALocalServiceImpl to BLocalServiceImpl to break circular dependency.

If we choose to use this way. I will send the pr to liferay-core-infra. I will run ci test in this pr.