### PR TITLE
LPS-150864 Inaccessible Experiences in Page editor after export/import

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/data/handler/SegmentsExperienceStagedModelDataHandler.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/data/handler/SegmentsExperienceStagedModelDataHandler.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.constants.SegmentsPortletKeys;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -140,7 +141,7 @@ public class SegmentsExperienceStagedModelDataHandler
 
 		long segmentsEntryId = MapUtil.getLong(
 			segmentsEntryIds, segmentsExperience.getSegmentsEntryId(),
-			segmentsExperience.getSegmentsEntryId());
+			SegmentsEntryConstants.ID_DEFAULT);
 
 		Map<Long, Long> referenceClassPKs =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(


### PR DESCRIPTION
Motivation
=======
This PR solves the following issue
[LPS-150864](https://issues.liferay.com/browse/LPS-150864)

Proposed Solution
========
The proposed solution is to assign the ID_DEFAULT value to the segmentEntry in case the segment isn't imported. In this situation we will keep the Experiences in the import and link them to the Anyone segment (the value by default).
