### PR TITLE
LPS-162225 Make it clear that we should do the startsWith check first.

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
@@ -202,7 +202,22 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 	private String _transform(String imgElementString, String src)
 		throws PortalException {
 
-		if (!src.contains("/documents") || src.startsWith("data:image/")) {
+		// Check if the src starts with "data:image/" first because "data:image"
+		// indicates a Base64 URL which can potentially be millions of
+		// characters. So it is faster to run startsWith first to return early
+		// on these Strings first so that we don't have to do a 'contains' over
+		// a very long string.
+
+		if (src.startsWith("data:image/")) {
+			return imgElementString;
+		}
+
+		// If we got past the above check, we have a URL. Now we can do a quick
+		// check if the URL contains "/documents" as a crude way of bypassing
+		// most non-Liferay URLs before we have to get into the less performant
+		// regex logic.
+
+		if (!src.contains("/documents")) {
 			return imgElementString;
 		}
 


### PR DESCRIPTION
startsWith is O(n) with respect to the length of the _argument_ string.
In our case, the input string is "data:image/" which is always exactly
11 characters long.

contains is O(n) with respect to the length of the String being operated
on. It is not uncommon for this number to be in the millions for Base64
Strings.

Therefore for these Base64 Strings there is a noticeable
difference in performance if we do startsWith first and return early,
compared to if we do contains first and then startsWith.