### PR TITLE
LPS-162665 WebDAV copy tooltip in wrong position

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/FileUrlCopyButton.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/FileUrlCopyButton.js
@@ -71,6 +71,7 @@ const FileUrlCopyButton = ({url}) => {
 									? 'exclamation-circle'
 									: 'copy'
 							}
+							title={Liferay.Language.get('copy')}
 						/>
 					</ClayInput.GroupItem>
 				</ClayInput.Group>


### PR DESCRIPTION
[Jira issue](https://issues.liferay.com/browse/LPS-162665)

## Motivation

The tooltip in `FileUrlCopyButton` component is missing so the title of the collapsible section is taking its place. 
At the end, the user sees a misplaced tooltip with an irrelevant text.

## Proposed solution

Just adding the title attr to the component with a generic `Copy` text does the job.

## how to verify

- Visit the Content Dashboard
- Open the info panel for a document, for example, an image
- Open the details section panel
- Hover the copy icon icons

**Expected**: a tooltip with the text `Copy`

## Screenshots

![image](https://user-images.githubusercontent.com/19485114/189695206-57d0429e-0095-460f-b91c-1c29bed6698d.png)

![image](https://user-images.githubusercontent.com/19485114/189695262-657de3dc-af3f-4e7c-8f37-5c66dbfb36d3.png)

