### PR TITLE
LPS-163405 Clean ContentDashboardItemAPI, so we can extract Versions from it

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/PreviewFileEntryContentDashboardItemActionProvider.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/PreviewFileEntryContentDashboardItemActionProvider.java
@@ -17,11 +17,11 @@ package com.liferay.content.dashboard.document.library.internal.item.action.prov
 import com.liferay.content.dashboard.document.library.internal.item.action.PreviewFileEntryContentDashboardItemAction;
 import com.liferay.content.dashboard.item.action.ContentDashboardItemAction;
 import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemActionProvider;
-import com.liferay.info.item.InfoItemServiceTracker;
-import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
+import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -45,12 +45,8 @@ public class PreviewFileEntryContentDashboardItemActionProvider
 			return null;
 		}
 
-		InfoItemFieldValuesProvider<FileEntry> infoItemFieldValuesProvider =
-			_infoItemServiceTracker.getFirstInfoItemService(
-				InfoItemFieldValuesProvider.class, FileEntry.class.getName());
-
 		return new PreviewFileEntryContentDashboardItemAction(
-			fileEntry, infoItemFieldValuesProvider, _language);
+			_dluRLHelper, fileEntry, httpServletRequest, _language, _portal);
 	}
 
 	@Override
@@ -73,13 +69,10 @@ public class PreviewFileEntryContentDashboardItemActionProvider
 			return false;
 		}
 
-		InfoItemFieldValuesProvider<FileEntry> infoItemFieldValuesProvider =
-			_infoItemServiceTracker.getFirstInfoItemService(
-				InfoItemFieldValuesProvider.class, FileEntry.class.getName());
-
 		ContentDashboardItemAction contentDashboardItemAction =
 			new PreviewFileEntryContentDashboardItemAction(
-				fileEntry, infoItemFieldValuesProvider, _language);
+				_dluRLHelper, fileEntry, httpServletRequest, _language,
+				_portal);
 
 		if (Validator.isNull(contentDashboardItemAction.getURL())) {
 			return false;
@@ -89,9 +82,12 @@ public class PreviewFileEntryContentDashboardItemActionProvider
 	}
 
 	@Reference
-	private InfoItemServiceTracker _infoItemServiceTracker;
+	private DLURLHelper _dluRLHelper;
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/test/PreviewFileEntryContentDashboardItemActionProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/test/PreviewFileEntryContentDashboardItemActionProviderTest.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.document.library.internal.item.action.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.content.dashboard.item.action.ContentDashboardItemAction;
+import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemActionProvider;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Cristina González
+ */
+@RunWith(Arquillian.class)
+public class PreviewFileEntryContentDashboardItemActionProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(), 0);
+	}
+
+	@Test
+	public void testGetContentDashboardItemAction() throws Exception {
+		_fileEntry = _dlAppLocalService.addFileEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + "." + ContentTypes.IMAGE_JPEG,
+			MimeTypesUtil.getExtensionContentType(ContentTypes.IMAGE_JPEG),
+			new byte[0], null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(mockHttpServletRequest));
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST, mockLiferayResourceRequest);
+
+		ContentDashboardItemAction contentDashboardItemAction =
+			_contentDashboardItemActionProvider.getContentDashboardItemAction(
+				_fileEntry, mockHttpServletRequest);
+
+		String url = contentDashboardItemAction.getURL();
+
+		Assert.assertTrue(Validator.isNotNull(url));
+
+		System.out.println(url);
+
+		Assert.assertTrue(
+			url.contains("fileEntryId=" + _fileEntry.getFileEntryId()));
+		Assert.assertTrue(
+			url.contains(
+				"mvcRenderCommandName=%2Fdocument_library%2Fview_file_entry"));
+	}
+
+	@Test
+	public void testGetKey() {
+		Assert.assertEquals(
+			"preview", _contentDashboardItemActionProvider.getKey());
+	}
+
+	@Test
+	public void testGetType() {
+		Assert.assertEquals(
+			ContentDashboardItemAction.Type.PREVIEW,
+			_contentDashboardItemActionProvider.getType());
+	}
+
+	@Test
+	public void testIsShow() throws Exception {
+		_fileEntry = _dlAppLocalService.addFileEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + "." + ContentTypes.IMAGE_JPEG,
+			MimeTypesUtil.getExtensionContentType(ContentTypes.IMAGE_JPEG),
+			new byte[0], null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(mockHttpServletRequest));
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST, mockLiferayResourceRequest);
+
+		Assert.assertTrue(
+			_contentDashboardItemActionProvider.isShow(
+				_fileEntry, mockHttpServletRequest));
+	}
+
+	@Test
+	public void testIsShowWithDraftFileEntry() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		try {
+			_fileEntry = _dlAppLocalService.addFileEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomString() + "." + ContentTypes.IMAGE_JPEG,
+				MimeTypesUtil.getExtensionContentType(ContentTypes.IMAGE_JPEG),
+				new byte[0], null, null,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+			DLFileEntry dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+				_fileEntry.getFileEntryId());
+
+			DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+			_dlFileEntryLocalService.updateStatus(
+				TestPropsValues.getUserId(), dlFileVersion.getFileVersionId(),
+				WorkflowConstants.STATUS_DRAFT,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()),
+				new HashMap<String, Serializable>());
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			ThemeDisplay themeDisplay = _getThemeDisplay(
+				mockHttpServletRequest);
+
+			themeDisplay.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, themeDisplay);
+
+			mockHttpServletRequest.setAttribute(
+				JavaConstants.JAVAX_PORTLET_REQUEST,
+				mockLiferayResourceRequest);
+
+			Assert.assertTrue(
+				!_contentDashboardItemActionProvider.isShow(
+					_fileEntry, mockHttpServletRequest));
+		}
+		finally {
+			_userLocalService.deleteUser(user);
+		}
+	}
+
+	private ThemeDisplay _getThemeDisplay(HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setRequest(httpServletRequest);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.content.dashboard.document.library.internal.item.action.provider.PreviewFileEntryContentDashboardItemActionProvider"
+	)
+	private ContentDashboardItemActionProvider
+		_contentDashboardItemActionProvider;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	private FileEntry _fileEntry;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/BlogsEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/BlogsEntryContentDashboardItem.java
@@ -32,8 +32,6 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -278,11 +276,6 @@ public class BlogsEntryContentDashboardItem
 	}
 
 	@Override
-	public Preview getPreview() {
-		return new Preview(_getPreviewImageURL(), null);
-	}
-
-	@Override
 	public String getScopeName(Locale locale) {
 		return Optional.ofNullable(
 			_group
@@ -345,33 +338,6 @@ public class BlogsEntryContentDashboardItem
 		List<Version> versions = getLatestVersions(locale);
 
 		return versions.get(versions.size() - 1);
-	}
-
-	private String _getPreviewImageURL() {
-		return Optional.ofNullable(
-			ServiceContextThreadLocal.getServiceContext()
-		).map(
-			ServiceContext::getLiferayPortletRequest
-		).map(
-			portletRequest -> {
-				List<ContentDashboardItemAction> contentDashboardItemActions =
-					getContentDashboardItemActions(
-						_portal.getHttpServletRequest(portletRequest),
-						ContentDashboardItemAction.Type.PREVIEW_IMAGE);
-
-				Stream<ContentDashboardItemAction> stream =
-					contentDashboardItemActions.stream();
-
-				return stream.findAny(
-				).map(
-					ContentDashboardItemAction::getURL
-				).orElse(
-					null
-				);
-			}
-		).orElse(
-			null
-		);
 	}
 
 	private ContentDashboardItemAction _toContentDashboardItemAction(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/BlogsEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/BlogsEntryContentDashboardItem.java
@@ -124,11 +124,6 @@ public class BlogsEntryContentDashboardItem
 	}
 
 	@Override
-	public Clipboard getClipboard() {
-		return Clipboard.EMPTY;
-	}
-
-	@Override
 	public List<ContentDashboardItemAction> getContentDashboardItemActions(
 		HttpServletRequest httpServletRequest,
 		ContentDashboardItemAction.Type... types) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
@@ -66,8 +66,6 @@ public interface ContentDashboardItem<T> {
 
 	public Date getModifiedDate();
 
-	public Preview getPreview();
-
 	public String getScopeName(Locale locale);
 
 	public Map<String, Object> getSpecificInformation(Locale locale);
@@ -81,36 +79,6 @@ public interface ContentDashboardItem<T> {
 	public String getUserName();
 
 	public boolean isViewable(HttpServletRequest httpServletRequest);
-
-	public static class Preview {
-
-		public static final Preview EMPTY = new Preview(null, null);
-
-		public Preview(String imageURL, String url) {
-			_imageURL = imageURL;
-			_url = url;
-		}
-
-		public String getImageURL() {
-			return _imageURL;
-		}
-
-		public String getUrl() {
-			return _url;
-		}
-
-		public JSONObject toJSONObject() {
-			return JSONUtil.put(
-				"imageURL", getImageURL()
-			).put(
-				"url", getUrl()
-			);
-		}
-
-		private final String _imageURL;
-		private final String _url;
-
-	}
 
 	public static class Version {
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
@@ -45,8 +45,6 @@ public interface ContentDashboardItem<T> {
 
 	public List<Locale> getAvailableLocales();
 
-	public Clipboard getClipboard();
-
 	public List<ContentDashboardItemAction> getContentDashboardItemActions(
 		HttpServletRequest httpServletRequest,
 		ContentDashboardItemAction.Type... types);
@@ -83,36 +81,6 @@ public interface ContentDashboardItem<T> {
 	public String getUserName();
 
 	public boolean isViewable(HttpServletRequest httpServletRequest);
-
-	public static class Clipboard {
-
-		public static final Clipboard EMPTY = new Clipboard(null, null);
-
-		public Clipboard(String name, String url) {
-			_name = name;
-			_url = url;
-		}
-
-		public String getName() {
-			return _name;
-		}
-
-		public String getUrl() {
-			return _url;
-		}
-
-		public JSONObject toJSONObject() {
-			return JSONUtil.put(
-				"name", getName()
-			).put(
-				"url", getUrl()
-			);
-		}
-
-		private final String _name;
-		private final String _url;
-
-	}
 
 	public static class Preview {
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
@@ -370,6 +370,8 @@ public class FileEntryContentDashboardItem
 		return HashMapBuilder.<String, Object>put(
 			"extension", _getExtension()
 		).put(
+			"file-name", _getFileName()
+		).put(
 			"latest-version-url", _getLatestVersionURL()
 		).put(
 			"size", _getSize(locale)
@@ -427,9 +429,12 @@ public class FileEntryContentDashboardItem
 	}
 
 	private String _getExtension() {
-		return FileUtil.getExtension(
-			InfoItemFieldValuesProviderUtil.getStringValue(
-				_fileEntry, _infoItemFieldValuesProvider, "fileName"));
+		return FileUtil.getExtension(_getFileName());
+	}
+
+	private String _getFileName() {
+		return InfoItemFieldValuesProviderUtil.getStringValue(
+			_fileEntry, _infoItemFieldValuesProvider, "fileName");
 	}
 
 	private Version _getLastVersion(Locale locale) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
@@ -23,7 +23,6 @@ import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.web.internal.info.item.provider.util.InfoItemFieldValuesProviderUtil;
 import com.liferay.content.dashboard.web.internal.item.action.ContentDashboardItemActionProviderTracker;
 import com.liferay.content.dashboard.web.internal.util.ContentDashboardGroupUtil;
-import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemReference;
@@ -44,10 +43,8 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -350,11 +347,6 @@ public class FileEntryContentDashboardItem
 	}
 
 	@Override
-	public Preview getPreview() {
-		return new Preview(_getPreviewImageURL(), _getViewURL());
-	}
-
-	@Override
 	public String getScopeName(Locale locale) {
 		return Optional.ofNullable(
 			_group
@@ -476,65 +468,8 @@ public class FileEntryContentDashboardItem
 		);
 	}
 
-	private String _getPreviewImageURL() {
-		return Optional.ofNullable(
-			ServiceContextThreadLocal.getServiceContext()
-		).map(
-			ServiceContext::getLiferayPortletRequest
-		).map(
-			portletRequest -> {
-				List<ContentDashboardItemAction> contentDashboardItemActions =
-					getContentDashboardItemActions(
-						_portal.getHttpServletRequest(portletRequest),
-						ContentDashboardItemAction.Type.PREVIEW_IMAGE);
-
-				Stream<ContentDashboardItemAction> stream =
-					contentDashboardItemActions.stream();
-
-				return stream.findAny(
-				).map(
-					ContentDashboardItemAction::getURL
-				).orElse(
-					null
-				);
-			}
-		).orElse(
-			null
-		);
-	}
-
 	private String _getSize(Locale locale) {
 		return LanguageUtil.formatStorageSize(_fileEntry.getSize(), locale);
-	}
-
-	private String _getViewURL() {
-		return Optional.ofNullable(
-			ServiceContextThreadLocal.getServiceContext()
-		).map(
-			ServiceContext::getLiferayPortletRequest
-		).map(
-			portletRequest -> {
-				try {
-					String backURL = ParamUtil.getString(
-						portletRequest, "backURL");
-
-					String portletNamespace = _portal.getPortletNamespace(
-						DLPortletKeys.DOCUMENT_LIBRARY_ADMIN);
-
-					return HttpComponentsUtil.addParameter(
-						_dlURLHelper.getFileEntryControlPanelLink(
-							portletRequest, _fileEntry.getFileEntryId()),
-						portletNamespace + "redirect", backURL);
-				}
-				catch (PortalException portalException) {
-					_log.error(portalException);
-
-					return null;
-				}
-			}
-		).orElse(
-			null
-		);
 	}
 
 	private URL _getWebDAVURL() {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
@@ -171,11 +171,6 @@ public class FileEntryContentDashboardItem
 	}
 
 	@Override
-	public Clipboard getClipboard() {
-		return Clipboard.EMPTY;
-	}
-
-	@Override
 	public List<ContentDashboardItemAction> getContentDashboardItemActions(
 		HttpServletRequest httpServletRequest,
 		ContentDashboardItemAction.Type... types) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
@@ -37,8 +37,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -331,11 +329,6 @@ public class JournalArticleContentDashboardItem
 	}
 
 	@Override
-	public Preview getPreview() {
-		return new Preview(_getPreviewImageURL(), null);
-	}
-
-	@Override
 	public String getScopeName(Locale locale) {
 		return Optional.ofNullable(
 			_group
@@ -414,33 +407,6 @@ public class JournalArticleContentDashboardItem
 		List<Version> versions = getLatestVersions(locale);
 
 		return versions.get(versions.size() - 1);
-	}
-
-	private String _getPreviewImageURL() {
-		return Optional.ofNullable(
-			ServiceContextThreadLocal.getServiceContext()
-		).map(
-			ServiceContext::getLiferayPortletRequest
-		).map(
-			portletRequest -> {
-				List<ContentDashboardItemAction> contentDashboardItemActions =
-					getContentDashboardItemActions(
-						_portal.getHttpServletRequest(portletRequest),
-						ContentDashboardItemAction.Type.PREVIEW_IMAGE);
-
-				Stream<ContentDashboardItemAction> stream =
-					contentDashboardItemActions.stream();
-
-				return stream.findAny(
-				).map(
-					ContentDashboardItemAction::getURL
-				).orElse(
-					null
-				);
-			}
-		).orElse(
-			null
-		);
 	}
 
 	private ContentDashboardItemAction _toContentDashboardItemAction(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
@@ -176,11 +176,6 @@ public class JournalArticleContentDashboardItem
 	}
 
 	@Override
-	public Clipboard getClipboard() {
-		return Clipboard.EMPTY;
-	}
-
-	@Override
 	public List<ContentDashboardItemAction> getContentDashboardItemActions(
 		HttpServletRequest httpServletRequest,
 		ContentDashboardItemAction.Type... types) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
@@ -134,8 +134,6 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 				).put(
 					"classPK", _getClassPK(contentDashboardItem)
 				).put(
-					"clipboard", _getClipboardJSONObject(contentDashboardItem)
-				).put(
 					"createDate",
 					_toString(contentDashboardItem.getCreateDate())
 				).put(
@@ -311,18 +309,6 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 			contentDashboardItem.getInfoItemReference();
 
 		return infoItemReference.getClassPK();
-	}
-
-	private JSONObject _getClipboardJSONObject(
-		ContentDashboardItem contentDashboardItem) {
-
-		return Optional.ofNullable(
-			contentDashboardItem.getClipboard()
-		).map(
-			ContentDashboardItem.Clipboard::toJSONObject
-		).orElse(
-			null
-		);
 	}
 
 	private String _getDownloadURL(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
@@ -159,13 +159,8 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 					_toString(contentDashboardItem.getModifiedDate())
 				).put(
 					"preview",
-					Optional.ofNullable(
-						contentDashboardItem.getPreview()
-					).map(
-						ContentDashboardItem.Preview::toJSONObject
-					).orElse(
-						null
-					)
+					_getPreviewJSONObject(
+						contentDashboardItem, httpServletRequest)
 				).put(
 					"specificFields",
 					_getSpecificFieldsJSONObject(contentDashboardItem, locale)
@@ -380,6 +375,55 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 		}
 
 		return jsonArray;
+	}
+
+	private String _getPreviewImageURL(
+		ContentDashboardItem contentDashboardItem,
+		HttpServletRequest httpServletRequest) {
+
+		List<ContentDashboardItemAction> contentDashboardItemActions =
+			contentDashboardItem.getContentDashboardItemActions(
+				httpServletRequest,
+				ContentDashboardItemAction.Type.PREVIEW_IMAGE);
+
+		if (ListUtil.isNotEmpty(contentDashboardItemActions)) {
+			ContentDashboardItemAction contentDashboardItemAction =
+				contentDashboardItemActions.get(0);
+
+			return contentDashboardItemAction.getURL();
+		}
+
+		return null;
+	}
+
+	private JSONObject _getPreviewJSONObject(
+		ContentDashboardItem contentDashboardItem,
+		HttpServletRequest httpServletRequest) {
+
+		return JSONUtil.put(
+			"imageURL",
+			_getPreviewImageURL(contentDashboardItem, httpServletRequest)
+		).put(
+			"url", _getPreviewURL(contentDashboardItem, httpServletRequest)
+		);
+	}
+
+	private String _getPreviewURL(
+		ContentDashboardItem contentDashboardItem,
+		HttpServletRequest httpServletRequest) {
+
+		List<ContentDashboardItemAction> contentDashboardItemActions =
+			contentDashboardItem.getContentDashboardItemActions(
+				httpServletRequest, ContentDashboardItemAction.Type.PREVIEW);
+
+		if (ListUtil.isNotEmpty(contentDashboardItemActions)) {
+			ContentDashboardItemAction contentDashboardItemAction =
+				contentDashboardItemActions.get(0);
+
+			return contentDashboardItemAction.getURL();
+		}
+
+		return null;
 	}
 
 	private JSONObject _getSpecificFieldsJSONObject(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
@@ -185,12 +185,7 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 
 		workbookBuilder.cell(_toString(specificInformation, "extension"));
 
-		if (contentDashboardItem.getClipboard() != null) {
-			ContentDashboardItem.Clipboard clipboard =
-				contentDashboardItem.getClipboard();
-
-			workbookBuilder.cell(_toString(clipboard.getName()));
-		}
+		workbookBuilder.cell(_toString(specificInformation, "file-name"));
 
 		workbookBuilder.cell(
 			_toString(specificInformation, "size")

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -697,12 +697,6 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 				}
 
 				@Override
-				public Clipboard getClipboard() {
-					return new Clipboard(
-						"name", "www.previewURL.url.com/previewURL");
-				}
-
-				@Override
 				public List<ContentDashboardItemAction>
 					getContentDashboardItemActions(
 						HttpServletRequest httpServletRequest,

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -771,13 +771,6 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 				}
 
 				@Override
-				public Preview getPreview() {
-					return new Preview(
-						"www.preview.com/imageURL",
-						"www.viewURL.url.com/viewURL");
-				}
-
-				@Override
 				public String getScopeName(Locale locale) {
 					return RandomTestUtil.randomString();
 				}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -190,6 +190,74 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 					}
 
 				}
+			).withContentDashboardItemAction(
+				new ContentDashboardItemAction() {
+
+					@Override
+					public String getIcon() {
+						return "preview-image";
+					}
+
+					@Override
+					public String getLabel(Locale locale) {
+						return "preview-image";
+					}
+
+					@Override
+					public String getName() {
+						return "preview-image";
+					}
+
+					@Override
+					public Type getType() {
+						return Type.PREVIEW_IMAGE;
+					}
+
+					@Override
+					public String getURL() {
+						return "http://www.preview.com/imageURL";
+					}
+
+					@Override
+					public String getURL(Locale locale) {
+						return getURL();
+					}
+
+				}
+			).withContentDashboardItemAction(
+				new ContentDashboardItemAction() {
+
+					@Override
+					public String getIcon() {
+						return "preview";
+					}
+
+					@Override
+					public String getLabel(Locale locale) {
+						return "preview";
+					}
+
+					@Override
+					public String getName() {
+						return "preview";
+					}
+
+					@Override
+					public Type getType() {
+						return Type.PREVIEW;
+					}
+
+					@Override
+					public String getURL() {
+						return "http://www.viewURL.url.com/viewURL";
+					}
+
+					@Override
+					public String getURL(Locale locale) {
+						return getURL();
+					}
+
+				}
 			).withSubtype(
 				"subType"
 			).withUser(
@@ -251,6 +319,17 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		Assert.assertNotNull(jsonObject.getString("fetchSharingButtonURL"));
 		Assert.assertNotNull(
 			jsonObject.getString("fetchSharingCollaboratorsURL"));
+
+		Assert.assertNotNull(jsonObject.getString("preview"));
+
+		JSONObject previewJSONObject = jsonObject.getJSONObject("preview");
+
+		Assert.assertEquals(
+			"http://www.preview.com/imageURL",
+			previewJSONObject.getString("imageURL"));
+		Assert.assertEquals(
+			"http://www.viewURL.url.com/viewURL",
+			previewJSONObject.getString("url"));
 
 		JSONArray tagsJSONArray = jsonObject.getJSONArray("tags");
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
@@ -229,11 +229,6 @@ public class ContentDashboardDropdownItemsProviderTest {
 			}
 
 			@Override
-			public Clipboard getClipboard() {
-				return Clipboard.EMPTY;
-			}
-
-			@Override
 			public List<ContentDashboardItemAction>
 				getContentDashboardItemActions(
 					HttpServletRequest httpServletRequest,
@@ -300,11 +295,6 @@ public class ContentDashboardDropdownItemsProviderTest {
 			@Override
 			public Date getModifiedDate() {
 				return null;
-			}
-
-			@Override
-			public Preview getPreview() {
-				return Preview.EMPTY;
 			}
 
 			@Override


### PR DESCRIPTION
Motivation
=======
We need to move the ContentDashboardItem API to content-dashoard-api module
[Link to story or ticket](https://issues.liferay.com/browse/LPS-163405)

Proposed Solution
========
Delete all unused methods (Clipboard and Preview), so we don't need to maintain them once they are made public.

Steps to Verify:
----------------
No functional changes, unit and integration tests have been included in the PR