### PR TITLE
LPS-165316 Keep the Experience Selector Open after Creating a New Experience

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -20,7 +20,7 @@ import ClayLink from '@clayui/link';
 import {useModal} from '@clayui/modal';
 import {ReactPortal, useIsMounted} from '@liferay/frontend-js-react-web';
 import {navigate, openToast} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {config} from '../../../app/config/index';
 import {useDispatch, useSelector} from '../../../app/contexts/StoreContext';
@@ -35,6 +35,24 @@ import updateExperiencePriority from '../thunks/updateExperiencePriority';
 import {useDebounceCallback} from '../utils';
 import ExperienceModal from './ExperienceModal';
 import ExperiencesList from './ExperiencesList';
+
+const useOnClickOutside = (ref, handler) => {
+	useEffect(() => {
+		const listener = (event) => {
+			if (!ref.current || ref.current.contains(event.target)) {
+				return;
+			}
+			handler(event);
+		};
+		document.addEventListener('mousedown', listener);
+		document.addEventListener('touchstart', listener);
+
+		return () => {
+			document.removeEventListener('mousedown', listener);
+			document.removeEventListener('touchstart', listener);
+		};
+	}, [ref, handler]);
+};
 
 /**
  * It produces an object with a target and subtarget keys indicating what experiences
@@ -99,6 +117,7 @@ const ExperienceSelector = ({
 		onClose: () => {
 			setOpenModal(false);
 			setEditingExperience({});
+			debouncedSetOpen(true);
 		},
 	});
 
@@ -112,10 +131,13 @@ const ExperienceSelector = ({
 		}
 	}, 100);
 
-	const handleDropdownButtonClick = () => debouncedSetOpen(!open);
-	const handleDropdownButtonBlur = () => debouncedSetOpen(false);
-	const handleDropdownBlur = () => debouncedSetOpen(false);
-	const handleDropdownFocus = () => debouncedSetOpen(true);
+	const dropdownRef = useRef();
+
+	const memoizedDebouncedSetOpen = useCallback(
+		() => debouncedSetOpen(false),
+		[debouncedSetOpen]
+	);
+	useOnClickOutside(dropdownRef, memoizedDebouncedSetOpen);
 
 	const handleNewSegmentClick = ({
 		experienceId,
@@ -250,7 +272,10 @@ const ExperienceSelector = ({
 		}
 	};
 
-	const handleOnNewExperiecneClick = () => setOpenModal(true);
+	const handleOnNewExperienceClick = () => {
+		setOpenModal(true);
+		debouncedSetOpen(false);
+	};
 
 	const handleEditExperienceClick = (experienceData) => {
 		const {name, segmentsEntryId, segmentsExperienceId} = experienceData;
@@ -340,8 +365,7 @@ const ExperienceSelector = ({
 				disabled={!canUpdateExperiences}
 				displayType="secondary"
 				id={selectId}
-				onBlur={handleDropdownButtonBlur}
-				onClick={handleDropdownButtonClick}
+				onClick={() => debouncedSetOpen(!open)}
 				ref={buttonRef}
 				small
 				type="button"
@@ -365,8 +389,7 @@ const ExperienceSelector = ({
 				<ReactPortal className="cadmin">
 					<div
 						className="dropdown-menu p-4 page-editor__toolbar-experience__dropdown-menu toggled"
-						onBlur={handleDropdownBlur}
-						onFocus={handleDropdownFocus}
+						ref={dropdownRef}
 						style={{
 							left: buttonBoundingClientRect.left,
 							top: buttonBoundingClientRect.bottom,
@@ -375,7 +398,7 @@ const ExperienceSelector = ({
 					>
 						<ExperiencesSelectorHeader
 							canCreateExperiences={canUpdateExperiences}
-							onNewExperience={handleOnNewExperiecneClick}
+							onNewExperience={handleOnNewExperienceClick}
 							showEmptyStateMessage={experiences.length <= 1}
 						/>
 


### PR DESCRIPTION
## Motivation

Improve the UX of the Experiences dropdown.
In this PR we keep the panel open on Experience creation: being precise, we reopen the dropdown on modal close.
Also now we keep the panel open on experience deletion.

## Solution proposed

We get rid of the blur/focus events we used in the button and the dropdown, as they had conflicts between them. It was working but not in a very smooth way: the button blur event was closing the panel, so a new focus event was implemented in the panel reopening it, this allowed the user to click in the button and then in the panel without losing it.

Now we use a `clickoutside` hook with a ref to the dropdown. This way the panel only gets closed if it's open and the user clicks away.
In addition we force the reopening of the dropdown on modal close.

## How to test
- navigate to home page
- edit the page
- click on experiences selector and open the dropdown
- create a new experience
- the dropdown should be open on modal close
- delete an experience
- the dropdown should be open
- click outside the dropdown
- the dropdown should be closed