### PR TITLE
LPS-162661 Add help property to specific fields in the frontend #2969

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItem.java
@@ -87,9 +87,9 @@ public interface ContentDashboardItem<T> {
 	public static class SpecificInformation<T> {
 
 		public SpecificInformation(
-			String help, String key, Type type, T value) {
+			String helpText, String key, Type type, T value) {
 
-			_help = help;
+			_helpText = helpText;
 			_key = key;
 			_type = type;
 			_value = value;
@@ -100,11 +100,11 @@ public interface ContentDashboardItem<T> {
 			_type = type;
 			_value = value;
 
-			_help = null;
+			_helpText = null;
 		}
 
-		public String getHelp() {
-			return _help;
+		public String getHelpText() {
+			return _helpText;
 		}
 
 		public String getKey() {
@@ -121,7 +121,7 @@ public interface ContentDashboardItem<T> {
 
 		public JSONObject toJSONObject(Language language, Locale locale) {
 			return JSONUtil.put(
-				"help", language.get(locale, getHelp())
+				"help", language.get(locale, getHelpText())
 			).put(
 				"title", language.get(locale, getKey())
 			).put(
@@ -173,7 +173,7 @@ public interface ContentDashboardItem<T> {
 			return String.valueOf(object);
 		}
 
-		private final String _help;
+		private final String _helpText;
 		private final String _key;
 		private final Type _type;
 		private final T _value;

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItem.java
@@ -19,11 +19,19 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.content.dashboard.item.action.ContentDashboardItemAction;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.info.item.InfoItemReference;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -64,7 +72,7 @@ public interface ContentDashboardItem<T> {
 
 	public String getScopeName(Locale locale);
 
-	public Map<String, Object> getSpecificInformation(Locale locale);
+	public List<SpecificInformation<?>> getSpecificInformation(Locale locale);
 
 	public String getTitle(Locale locale);
 
@@ -111,28 +119,42 @@ public interface ContentDashboardItem<T> {
 			return _value;
 		}
 
-		public enum Type {
-
-			DATE, STRING, URL
-
-		}
-
 		public JSONObject toJSONObject(Language language, Locale locale) {
 			return JSONUtil.put(
 				"help", language.get(locale, getHelp())
 			).put(
 				"title", language.get(locale, getKey())
 			).put(
-				"type", getType()
+				"type", String.valueOf(getType())
 			).put(
 				"value", _toString(getValue())
 			);
 		}
 
+		public enum Type {
+
+			DATE {
+
+				public String toString() {
+					return "Date";
+				}
+
+			},
+			STRING {
+
+				public String toString() {
+					return "String";
+				}
+
+			}, URL
+
+		}
+
 		private String _toString(Date date) {
 			Instant instant = date.toInstant();
 
-			ZonedDateTime zonedDateTime = instant.atZone(ZoneId.systemDefault());
+			ZonedDateTime zonedDateTime = instant.atZone(
+				ZoneId.systemDefault());
 
 			LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
 

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItem.java
@@ -76,4 +76,86 @@ public interface ContentDashboardItem<T> {
 
 	public boolean isViewable(HttpServletRequest httpServletRequest);
 
+	public static class SpecificInformation<T> {
+
+		public SpecificInformation(
+			String help, String key, Type type, T value) {
+
+			_help = help;
+			_key = key;
+			_type = type;
+			_value = value;
+		}
+
+		public SpecificInformation(String key, Type type, T value) {
+			_key = key;
+			_type = type;
+			_value = value;
+
+			_help = null;
+		}
+
+		public String getHelp() {
+			return _help;
+		}
+
+		public String getKey() {
+			return _key;
+		}
+
+		public Type getType() {
+			return _type;
+		}
+
+		public T getValue() {
+			return _value;
+		}
+
+		public enum Type {
+
+			DATE, STRING, URL
+
+		}
+
+		public JSONObject toJSONObject(Language language, Locale locale) {
+			return JSONUtil.put(
+				"help", language.get(locale, getHelp())
+			).put(
+				"title", language.get(locale, getKey())
+			).put(
+				"type", getType()
+			).put(
+				"value", _toString(getValue())
+			);
+		}
+
+		private String _toString(Date date) {
+			Instant instant = date.toInstant();
+
+			ZonedDateTime zonedDateTime = instant.atZone(ZoneId.systemDefault());
+
+			LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
+
+			return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+		}
+
+		private String _toString(Object object) {
+			if (object == null) {
+				return null;
+			}
+
+			if (object instanceof Date) {
+				return _toString((Date)object);
+			}
+
+			return String.valueOf(object);
+		}
+
+		private final String _help;
+		private final String _key;
+		private final Type _type;
+		private final T _value;
+
+	}
+
 }

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/packageinfo
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/content-dashboard/content-dashboard-blogs-impl/src/main/java/com/liferay/content/dashboard/blogs/internal/item/BlogsEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-blogs-impl/src/main/java/com/liferay/content/dashboard/blogs/internal/item/BlogsEntryContentDashboardItem.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -42,7 +41,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -294,10 +292,11 @@ public class BlogsEntryContentDashboardItem
 	}
 
 	@Override
-	public Map<String, Object> getSpecificInformation(Locale locale) {
-		return HashMapBuilder.<String, Object>put(
-			"display-date", _blogsEntry.getDisplayDate()
-		).build();
+	public List<SpecificInformation<?>> getSpecificInformation(Locale locale) {
+		return Collections.singletonList(
+			new SpecificInformation<>(
+				"display-date", SpecificInformation.Type.DATE,
+				_blogsEntry.getDisplayDate()));
 	}
 
 	@Override

--- a/modules/apps/content-dashboard/content-dashboard-blogs-test/src/testIntegration/java/com/liferay/content/dashboard/blogs/internal/item/test/BlogsEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-blogs-test/src/testIntegration/java/com/liferay/content/dashboard/blogs/internal/item/test/BlogsEntryContentDashboardItemTest.java
@@ -54,7 +54,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -357,15 +356,19 @@ public class BlogsEntryContentDashboardItemTest {
 		ContentDashboardItem contentDashboardItem =
 			_contentDashboardItemFactory.create(blogsEntry.getEntryId());
 
-		Map<String, Object> specificInformation =
-			contentDashboardItem.getSpecificInformation(LocaleUtil.US);
+		List<ContentDashboardItem.SpecificInformation<?>>
+			specificInformationList =
+				contentDashboardItem.getSpecificInformation(LocaleUtil.US);
 
 		Assert.assertEquals(
-			specificInformation.toString(), 1, specificInformation.size());
+			specificInformationList.toString(), 1,
+			specificInformationList.size());
+
+		ContentDashboardItem.SpecificInformation<?> specificInformation =
+			specificInformationList.get(0);
 
 		Assert.assertEquals(
-			specificInformation.get("display-date"),
-			blogsEntry.getDisplayDate());
+			specificInformation.getValue(), blogsEntry.getDisplayDate());
 	}
 
 	@Test

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -416,7 +416,8 @@ public class FileEntryContentDashboardItem
 			new SpecificInformation<>(
 				"size", SpecificInformation.Type.STRING, _getSize(locale)),
 			new SpecificInformation<>(
-				"web-dav-url", SpecificInformation.Type.URL, _getWebDAVURL()));
+				"webdav-help", "web-dav-url", SpecificInformation.Type.URL,
+				_getWebDAVURL()));
 	}
 
 	@Override

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -55,7 +55,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -67,12 +66,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -405,18 +404,19 @@ public class FileEntryContentDashboardItem
 	}
 
 	@Override
-	public Map<String, Object> getSpecificInformation(Locale locale) {
-		return HashMapBuilder.<String, Object>put(
-			"extension", _getExtension()
-		).put(
-			"file-name", _getFileName()
-		).put(
-			"latest-version-url", _getLatestVersionURL()
-		).put(
-			"size", _getSize(locale)
-		).put(
-			"web-dav-url", _getWebDAVURL()
-		).build();
+	public List<SpecificInformation<?>> getSpecificInformation(Locale locale) {
+		return Arrays.asList(
+			new SpecificInformation<>(
+				"extension", SpecificInformation.Type.STRING, _getExtension()),
+			new SpecificInformation<>(
+				"file-name", SpecificInformation.Type.STRING, _getFileName()),
+			new SpecificInformation<>(
+				"latest-version-url", SpecificInformation.Type.URL,
+				_getLatestVersionURL()),
+			new SpecificInformation<>(
+				"size", SpecificInformation.Type.STRING, _getSize(locale)),
+			new SpecificInformation<>(
+				"web-dav-url", SpecificInformation.Type.URL, _getWebDAVURL()));
 	}
 
 	@Override

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -513,7 +513,8 @@ public class FileEntryContentDashboardItemTest {
 
 		Assert.assertTrue(url.contains("webdav"));
 
-		Assert.assertEquals("webdav-help", webDAVSpecificInformation.getHelp());
+		Assert.assertEquals(
+			"webdav-help", webDAVSpecificInformation.getHelpText());
 	}
 
 	@Test

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -22,6 +22,7 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.content.dashboard.item.ContentDashboardItem;
 import com.liferay.content.dashboard.item.ContentDashboardItemFactory;
 import com.liferay.content.dashboard.item.ContentDashboardItemVersion;
 import com.liferay.content.dashboard.item.VersionableContentDashboardItem;
@@ -62,7 +63,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.net.URLEncoder;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -431,13 +433,50 @@ public class FileEntryContentDashboardItemTest {
 					ServiceContextTestUtil.getServiceContext(
 						_group.getGroupId()));
 
-		Map<String, Object> specificInformation =
-			versionableContentDashboardItem.getSpecificInformation(
-				LocaleUtil.getDefault());
+		List<ContentDashboardItem.SpecificInformation<?>>
+			specificInformationList =
+				versionableContentDashboardItem.getSpecificInformation(
+					LocaleUtil.getDefault());
 
-		Assert.assertEquals("jpg", specificInformation.get("extension"));
-		Assert.assertEquals("0 B", specificInformation.get("size"));
-		Assert.assertNotNull(specificInformation.get("file-name"));
+		Stream<ContentDashboardItem.SpecificInformation<?>> stream =
+			specificInformationList.stream();
+
+		ContentDashboardItem.SpecificInformation<?>
+			extensionSpecificInformation = stream.filter(
+				specificInformation -> Objects.equals(
+					specificInformation.getKey(), "extension")
+			).findFirst(
+			).orElseThrow(
+				() -> new AssertionError("extension not found")
+			);
+
+		Assert.assertEquals("jpg", extensionSpecificInformation.getValue());
+
+		stream = specificInformationList.stream();
+
+		ContentDashboardItem.SpecificInformation<?> sizeSpecificInformation =
+			stream.filter(
+				specificInformation -> Objects.equals(
+					specificInformation.getKey(), "size")
+			).findFirst(
+			).orElseThrow(
+				() -> new AssertionError("size not found")
+			);
+
+		Assert.assertEquals("0 B", sizeSpecificInformation.getValue());
+
+		stream = specificInformationList.stream();
+
+		ContentDashboardItem.SpecificInformation<?>
+			fileNameSpecificInformation = stream.filter(
+				specificInformation -> Objects.equals(
+					specificInformation.getKey(), "file-name")
+			).findFirst(
+			).orElseThrow(
+				() -> new AssertionError("file-name not found")
+			);
+
+		Assert.assertNotNull(fileNameSpecificInformation.getValue());
 	}
 
 	@Test

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -60,6 +61,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.net.URL;
 import java.net.URLEncoder;
 
 import java.util.List;
@@ -423,8 +425,25 @@ public class FileEntryContentDashboardItemTest {
 
 	@Test
 	public void testGetSpecificInformation() throws Exception {
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext());
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, new ThemeDisplay());
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST,
+			mockLiferayPortletRenderRequest);
+
+		serviceContext.setRequest(mockHttpServletRequest);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
 		VersionableContentDashboardItem<FileEntry>
 			versionableContentDashboardItem =
@@ -477,6 +496,24 @@ public class FileEntryContentDashboardItemTest {
 			);
 
 		Assert.assertNotNull(fileNameSpecificInformation.getValue());
+
+		stream = specificInformationList.stream();
+
+		ContentDashboardItem.SpecificInformation<URL>
+			webDAVSpecificInformation =
+				(ContentDashboardItem.SpecificInformation<URL>)stream.filter(
+					specificInformation -> Objects.equals(
+						specificInformation.getKey(), "web-dav-url")
+				).findFirst(
+				).orElseThrow(
+					() -> new AssertionError("web-dav-url not found")
+				);
+
+		String url = String.valueOf(webDAVSpecificInformation.getValue());
+
+		Assert.assertTrue(url.contains("webdav"));
+
+		Assert.assertEquals("webdav-help", webDAVSpecificInformation.getHelp());
 	}
 
 	@Test

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
@@ -48,7 +48,6 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -57,12 +56,12 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -385,14 +384,17 @@ public class JournalArticleContentDashboardItem
 	}
 
 	@Override
-	public Map<String, Object> getSpecificInformation(Locale locale) {
-		return HashMapBuilder.<String, Object>put(
-			"display-date", _journalArticle.getDisplayDate()
-		).put(
-			"expiration-date", _journalArticle.getExpirationDate()
-		).put(
-			"review-date", _journalArticle.getReviewDate()
-		).build();
+	public List<SpecificInformation<?>> getSpecificInformation(Locale locale) {
+		return Arrays.asList(
+			new SpecificInformation<>(
+				"display-date", SpecificInformation.Type.DATE,
+				_journalArticle.getDisplayDate()),
+			new SpecificInformation<>(
+				"expiration-date", SpecificInformation.Type.DATE,
+				_journalArticle.getExpirationDate()),
+			new SpecificInformation<>(
+				"review-date", SpecificInformation.Type.DATE,
+				_journalArticle.getReviewDate()));
 	}
 
 	@Override

--- a/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
@@ -84,8 +84,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -640,20 +641,59 @@ public class JournalArticleContentDashboardItemTest {
 			_contentDashboardItemFactory.create(
 				journalArticle.getResourcePrimKey());
 
-		Map<String, Object> specificInformation =
-			contentDashboardItem.getSpecificInformation(LocaleUtil.US);
+		List<ContentDashboardItem.SpecificInformation<?>>
+			specificInformationList =
+				contentDashboardItem.getSpecificInformation(LocaleUtil.US);
 
 		Assert.assertEquals(
-			specificInformation.toString(), 3, specificInformation.size());
+			specificInformationList.toString(), 3,
+			specificInformationList.size());
+
+		Stream<ContentDashboardItem.SpecificInformation<?>> stream =
+			specificInformationList.stream();
+
+		ContentDashboardItem.SpecificInformation<?>
+			displayDateSpecificInformation = stream.filter(
+				specificInformation -> Objects.equals(
+					specificInformation.getKey(), "display-date")
+			).findFirst(
+			).orElseThrow(
+				() -> new AssertionError("display-date not found")
+			);
+
 		Assert.assertEquals(
-			specificInformation.get("display-date"),
-			journalArticle.getDisplayDate());
+			journalArticle.getDisplayDate(),
+			displayDateSpecificInformation.getValue());
+
+		stream = specificInformationList.stream();
+
+		ContentDashboardItem.SpecificInformation<?>
+			expirationDateSpecificInformation = stream.filter(
+				specificInformation -> Objects.equals(
+					specificInformation.getKey(), "expiration-date")
+			).findFirst(
+			).orElseThrow(
+				() -> new AssertionError("expiration-date not found")
+			);
+
 		Assert.assertEquals(
-			specificInformation.get("expiration-date"),
-			journalArticle.getExpirationDate());
+			journalArticle.getExpirationDate(),
+			expirationDateSpecificInformation.getValue());
+
+		stream = specificInformationList.stream();
+
+		ContentDashboardItem.SpecificInformation<?>
+			reviewDateSpecificInformation = stream.filter(
+				specificInformation -> Objects.equals(
+					specificInformation.getKey(), "review-date")
+			).findFirst(
+			).orElseThrow(
+				() -> new AssertionError("review-date not found")
+			);
+
 		Assert.assertEquals(
-			specificInformation.get("review-date"),
-			journalArticle.getReviewDate());
+			journalArticle.getReviewDate(),
+			reviewDateSpecificInformation.getValue());
 	}
 
 	@Test

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
@@ -39,10 +39,10 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 import javax.portlet.ResourceRequest;
@@ -364,8 +364,10 @@ public class GetContentDashboardItemVersionsResourceCommandTest {
 		}
 
 		@Override
-		public Map<String, Object> getSpecificInformation(Locale locale) {
-			return null;
+		public List<SpecificInformation<?>> getSpecificInformation(
+			Locale locale) {
+
+			return Collections.emptyList();
 		}
 
 		@Override

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
@@ -53,8 +53,6 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
-import java.net.URL;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -68,8 +66,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -468,36 +464,19 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
-		Map<String, Object> specificInformation =
-			contentDashboardItem.getSpecificInformation(locale);
+		List<ContentDashboardItem.SpecificInformation<?>>
+			specificInformationList =
+				contentDashboardItem.getSpecificInformation(locale);
 
-		SortedSet<String> keys = new TreeSet<>(specificInformation.keySet());
+		for (ContentDashboardItem.SpecificInformation specificInformation :
+				specificInformationList) {
 
-		for (String key : keys) {
 			jsonObject.put(
-				key,
-				JSONUtil.put(
-					"title", _language.get(locale, key)
-				).put(
-					"type",
-					_getSpecificInformationType(specificInformation.get(key))
-				).put(
-					"value", _toString(specificInformation.get(key))
-				));
+				specificInformation.getKey(),
+				specificInformation.toJSONObject(_language, locale));
 		}
 
 		return jsonObject;
-	}
-
-	private String _getSpecificInformationType(Object object) {
-		if (object instanceof Date) {
-			return "Date";
-		}
-		else if (object instanceof URL) {
-			return "URL";
-		}
-
-		return "String";
 	}
 
 	private JSONObject _getSubscribeContentDashboardItemActionJSONObject(
@@ -654,18 +633,6 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 		LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
 
 		return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-	}
-
-	private String _toString(Object object) {
-		if (object == null) {
-			return null;
-		}
-
-		if (object instanceof Date) {
-			return _toString((Date)object);
-		}
-
-		return String.valueOf(object);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
@@ -183,17 +183,18 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 			contentDashboardItem.getDescription(locale)
 		);
 
-		Map<String, Object> specificInformation =
-			contentDashboardItem.getSpecificInformation(locale);
+		List<ContentDashboardItem.SpecificInformation<?>>
+			specificInformationList =
+				contentDashboardItem.getSpecificInformation(locale);
 
-		workbookBuilder.cell(_toString(specificInformation, "extension"));
+		workbookBuilder.cell(_toString(specificInformationList, "extension"));
 
-		workbookBuilder.cell(_toString(specificInformation, "file-name"));
+		workbookBuilder.cell(_toString(specificInformationList, "file-name"));
 
 		workbookBuilder.cell(
-			_toString(specificInformation, "size")
+			_toString(specificInformationList, "size")
 		).cell(
-			_toString(specificInformation, "display-date")
+			_toString(specificInformationList, "display-date")
 		).cell(
 			_toString(contentDashboardItem.getCreateDate())
 		);
@@ -337,19 +338,23 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 	}
 
 	private String _toString(
-		Map<String, Object> specificInformation, String fieldName) {
+		List<ContentDashboardItem.SpecificInformation<?>>
+			specificInformationList,
+		String fieldName) {
 
-		return Optional.ofNullable(
-			specificInformation
-		).map(
-			safeSpecificInformation -> safeSpecificInformation.get(fieldName)
-		).filter(
-			Objects::nonNull
-		).map(
-			field -> _toString(field)
-		).orElse(
-			StringPool.BLANK
-		);
+		if (specificInformationList == null) {
+			return StringPool.BLANK;
+		}
+
+		for (ContentDashboardItem.SpecificInformation<?> specificInformation :
+				specificInformationList) {
+
+			if (Objects.equals(specificInformation.getKey(), fieldName)) {
+				return _toString(specificInformation.getValue());
+			}
+		}
+
+		return StringPool.BLANK;
 	}
 
 	private String _toString(Object value) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SpecificFields.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SpecificFields.tsx
@@ -12,6 +12,8 @@
  * details.
  */
 
+import ClayIcon from '@clayui/icon';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 const {default: FileUrlCopyButton} = require('./FileUrlCopyButton');
@@ -41,20 +43,26 @@ const SpecificFields = ({fields, languageTag}: IProps) => {
 	}
 
 	return fields.map(
-		({
-			title,
-			type,
-			value,
-		}: {
-			title: string;
-			type: SpecificItemTypes;
-			value: string;
-		}): JSX.Element | string =>
+		({help, title, type, value}: SpecificField): JSX.Element | string =>
 			title &&
 			value &&
 			type && (
 				<div className="c-mb-4 sidebar-section" key={title}>
-					<h5 className="c-mb-1 font-weight-semi-bold">{title}</h5>
+					<h5 className="c-mb-1 font-weight-semi-bold">
+						{title}
+
+						{help && (
+							<ClayTooltipProvider>
+								<span
+									className="ml-1 text-secondary"
+									data-tooltip-align="top"
+									title={help}
+								>
+									<ClayIcon symbol="question-circle-full" />
+								</span>
+							</ClayTooltipProvider>
+						)}
+					</h5>
 
 					<SpecificItem
 						languageTag={languageTag}
@@ -69,6 +77,7 @@ const SpecificFields = ({fields, languageTag}: IProps) => {
 type SpecificItemTypes = 'Date' | 'String' | 'URL';
 
 interface SpecificField {
+	help?: string;
 	title: string;
 	type: SpecificItemTypes;
 	value: string;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -60,7 +59,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -360,23 +358,30 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 			contentDashboardItemSubtype.getLabel(LocaleUtil.US),
 			jsonObject.getString("subType"));
 
-		Map<String, Object> specificInformation =
-			contentDashboardItem.getSpecificInformation(LocaleUtil.US);
+		List<ContentDashboardItem.SpecificInformation<?>>
+			specificInformationList =
+				contentDashboardItem.getSpecificInformation(LocaleUtil.US);
 
 		Assert.assertEquals(
-			String.valueOf(specificInformation), 2, specificInformation.size());
+			String.valueOf(specificInformationList), 2,
+			specificInformationList.size());
 
 		JSONObject specificFieldsJSONObject = jsonObject.getJSONObject(
 			"specificFields");
 
-		for (Map.Entry<String, Object> entry : specificInformation.entrySet()) {
+		for (ContentDashboardItem.SpecificInformation<?> specificInformation :
+				specificInformationList) {
+
 			JSONObject specificFieldJSONObject =
-				specificFieldsJSONObject.getJSONObject(entry.getKey());
+				specificFieldsJSONObject.getJSONObject(
+					specificInformation.getKey());
 
 			Assert.assertEquals(
-				specificFieldJSONObject.getString("title"), entry.getKey());
+				specificFieldJSONObject.getString("title"),
+				specificInformation.getKey());
 			Assert.assertEquals(
-				specificFieldJSONObject.getString("value"), entry.getValue());
+				specificFieldJSONObject.getString("value"),
+				specificInformation.getValue());
 		}
 
 		JSONObject userJSONObject = jsonObject.getJSONObject("user");
@@ -831,14 +836,15 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 				}
 
 				@Override
-				public Map<String, Object> getSpecificInformation(
+				public List<SpecificInformation<?>> getSpecificInformation(
 					Locale locale) {
 
-					return HashMapBuilder.<String, Object>put(
-						"extension", ".pdf"
-					).put(
-						"size", "5"
-					).build();
+					return Arrays.asList(
+						new SpecificInformation<>(
+							"extension", SpecificInformation.Type.STRING,
+							".pdf"),
+						new SpecificInformation<>(
+							"size", SpecificInformation.Type.STRING, ".5"));
 				}
 
 				@Override

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
@@ -300,8 +300,10 @@ public class ContentDashboardDropdownItemsProviderTest {
 			}
 
 			@Override
-			public Map<String, Object> getSpecificInformation(Locale locale) {
-				return Collections.emptyMap();
+			public List<SpecificInformation<?>> getSpecificInformation(
+				Locale locale) {
+
+				return Collections.emptyList();
 			}
 
 			@Override

--- a/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SpecificFields.d.ts
+++ b/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SpecificFields.d.ts
@@ -19,6 +19,7 @@ declare const SpecificFields: ({
 }: IProps) => (string | JSX.Element)[] | null;
 declare type SpecificItemTypes = 'Date' | 'String' | 'URL';
 interface SpecificField {
+	help?: string;
 	title: string;
 	type: SpecificItemTypes;
 	value: string;


### PR DESCRIPTION
Motivation
=======
Help icon is missing from WebDAV field
[Link to story or ticket](https://issues.liferay.com/browse/LPS-162661)

Proposed Solution
========
The specific fields of an asset can now have a help attribute that must display a help icon with a Tooltip.

Steps to Verify:
----------------
- Create a basic document
- Go to Content Dashboard (Liferay Menu > Applications > Content > Content Dashboard)
- Click in the info icon of the document in the table
- In the sidebar click on the details accordion component
- Go to WebDAV URL and check there is a help icon that display a tooltip