### PR TITLE
LPS-169057 Clear the user's permission cache if site initialization failed, in order to avoid breaking the permission-checking logic

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/AddGroupMVCActionCommand.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/AddGroupMVCActionCommand.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.liveusers.LiveUsers;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.ratings.kernel.RatingsType;
 import com.liferay.site.admin.web.internal.constants.SiteAdminConstants;
 import com.liferay.site.admin.web.internal.constants.SiteAdminPortletKeys;
@@ -536,7 +537,15 @@ public class AddGroupMVCActionCommand extends BaseMVCActionCommand {
 
 		@Override
 		public Group call() throws Exception {
-			return _updateGroup(_actionRequest);
+			try {
+				return _updateGroup(_actionRequest);
+			}
+			catch (Exception exception) {
+				PermissionCacheUtil.clearCache(
+					_portal.getUserId(_actionRequest));
+
+				throw exception;
+			}
 		}
 
 		private GroupCallable(ActionRequest actionRequest) {


### PR DESCRIPTION
Ticket: [LPS-169057](https://issues.liferay.com/browse/LPS-169057)

The `_updateGroup` takes place in a single transaction which adds the Group first then does many other things. During the course of this time, it fetches the added groupId into the PermissionCache. This means that if the transaction gets rolled back, we need to clear the PermissionCache to prevent the invalid groupId from being stuck in there for the user, which will completely break the portal for the user if it happens.