### PR TITLE
LPS-168816 Add the Scope Card to the Segments Editor

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -14221,6 +14221,7 @@ select-the-scope-of-the-action-that-this-role-can-perform-on-the-portal=Select t
 select-the-scope-of-the-action-that-this-role-can-perform-on-the-x=Select the scope of the action that this role can perform on the <em>{0}</em>.
 select-the-scope-of-the-action-that-this-role-can-perform-on-the-x-portlet=Select the scope of the action that this role can perform on the <em>{0}</em> portlet.
 select-the-scope-of-the-action-that-this-role-can-perform-on-the-x-resource=Select the scope of the action that this role can perform on the <em>{0}</em> resource.
+select-the-scope-of-your-segment-to-specify-where-it-can-be-used=Select the scope of your segment to specify where it can be used. If no scope is selected, this segment will be available for all sites.
 select-the-searchable-types-description=Select the assets and objects to be searched. If no types are selected, all are searched. To disable all types, disable the search framework indexer clauses setting.
 select-the-sites-where-this-role-can-perform-the-x-action-on-the-x-portlet=Select the sites where this role can perform the <em>{0}</em> action on the {1} portlet.
 select-the-sites-where-this-role-can-perform-the-x-action-on-the-x-resource=Select the sites where this role can perform the <em>{0}</em> action on the {1} resource.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -14221,7 +14221,6 @@ select-the-scope-of-the-action-that-this-role-can-perform-on-the-portal=Select t
 select-the-scope-of-the-action-that-this-role-can-perform-on-the-x=Select the scope of the action that this role can perform on the <em>{0}</em>.
 select-the-scope-of-the-action-that-this-role-can-perform-on-the-x-portlet=Select the scope of the action that this role can perform on the <em>{0}</em> portlet.
 select-the-scope-of-the-action-that-this-role-can-perform-on-the-x-resource=Select the scope of the action that this role can perform on the <em>{0}</em> resource.
-select-the-scope-of-your-segment-to-specify-where-it-can-be-used=Select the scope of your segment to specify where it can be used. If no scope is selected, this segment will be available for all sites.
 select-the-searchable-types-description=Select the assets and objects to be searched. If no types are selected, all are searched. To disable all types, disable the search framework indexer clauses setting.
 select-the-sites-where-this-role-can-perform-the-x-action-on-the-x-portlet=Select the sites where this role can perform the <em>{0}</em> action on the {1} portlet.
 select-the-sites-where-this-role-can-perform-the-x-action-on-the-x-resource=Select the sites where this role can perform the <em>{0}</em> action on the {1} resource.

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
@@ -60,7 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
@@ -323,6 +322,12 @@ public class EditSegmentsEntryDisplayContext {
 			segmentsEntry.getName(), siteDefaultLocale);
 	}
 
+	private String _getGroupDescriptiveName() throws Exception {
+		Group group = _groupLocalService.getGroup(_getGroupId());
+
+		return group.getDescriptiveName(_locale);
+	}
+
 	private long _getGroupId() throws PortalException {
 		return BeanParamUtil.getLong(
 			_getSegmentsEntry(), _httpServletRequest, "groupId",
@@ -450,29 +455,12 @@ public class EditSegmentsEntryDisplayContext {
 		).put(
 			"requestMembersCountURL", _getSegmentsEntryClassPKsCountURL()
 		).put(
-			"scopeName", _getScopeName()
+			"scopeName", _getGroupDescriptiveName()
 		).put(
 			"segmentsConfigurationURL", _getSegmentsCompanyConfigurationURL()
 		).put(
 			"showInEditMode", _isShowInEditMode()
 		).build();
-	}
-
-	private String _getScopeName() throws Exception {
-		Group group = _groupLocalService.getGroup(_getGroupId());
-
-		try {
-			return Optional.ofNullable(
-				group.getDescriptiveName(_locale)
-			).orElseGet(
-				() -> group.getName(_locale)
-			);
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-
-			return group.getName(_locale);
-		}
 	}
 
 	private String _getSegmentsCompanyConfigurationURL() {

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
@@ -25,12 +25,14 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -58,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
@@ -73,6 +76,7 @@ public class EditSegmentsEntryDisplayContext {
 
 	public EditSegmentsEntryDisplayContext(
 		FilterParserProvider filterParserProvider,
+		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, RenderRequest renderRequest,
 		RenderResponse renderResponse,
 		SegmentsConfigurationProvider segmentsConfigurationProvider,
@@ -81,6 +85,7 @@ public class EditSegmentsEntryDisplayContext {
 		SegmentsEntryService segmentsEntryService) {
 
 		_filterParserProvider = filterParserProvider;
+		_groupLocalService = groupLocalService;
 		_httpServletRequest = httpServletRequest;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
@@ -445,10 +450,29 @@ public class EditSegmentsEntryDisplayContext {
 		).put(
 			"requestMembersCountURL", _getSegmentsEntryClassPKsCountURL()
 		).put(
+			"scopeName", _getScopeName()
+		).put(
 			"segmentsConfigurationURL", _getSegmentsCompanyConfigurationURL()
 		).put(
 			"showInEditMode", _isShowInEditMode()
 		).build();
+	}
+
+	private String _getScopeName() throws Exception {
+		Group group = _groupLocalService.getGroup(_getGroupId());
+
+		try {
+			return Optional.ofNullable(
+				group.getDescriptiveName(_locale)
+			).orElseGet(
+				() -> group.getName(_locale)
+			);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return group.getName(_locale);
+		}
 	}
 
 	private String _getSegmentsCompanyConfigurationURL() {
@@ -564,6 +588,7 @@ public class EditSegmentsEntryDisplayContext {
 	private Map<String, Object> _data;
 	private final FilterParserProvider _filterParserProvider;
 	private Long _groupId;
+	private final GroupLocalService _groupLocalService;
 	private final HttpServletRequest _httpServletRequest;
 	private final Locale _locale;
 	private String _redirect;

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/EditSegmentsEntryMVCRenderCommand.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/EditSegmentsEntryMVCRenderCommand.java
@@ -15,6 +15,7 @@
 package com.liferay.segments.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.segments.configuration.provider.SegmentsConfigurationProvider;
@@ -57,7 +58,7 @@ public class EditSegmentsEntryMVCRenderCommand implements MVCRenderCommand {
 
 		EditSegmentsEntryDisplayContext editSegmentsEntryDisplayContext =
 			new EditSegmentsEntryDisplayContext(
-				_filterParserProvider,
+				_filterParserProvider, _groupLocalService,
 				_portal.getHttpServletRequest(renderRequest), renderRequest,
 				renderResponse, _segmentsConfigurationProvider,
 				_segmentsCriteriaContributorRegistry,
@@ -72,6 +73,9 @@ public class EditSegmentsEntryMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_contributor_builder.scss
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_contributor_builder.scss
@@ -35,7 +35,13 @@
 				transition: all 0.5s ease;
 
 				.content-wrapper {
-					padding: 40px 24px;
+					padding: 18px 24px;
+
+					.panel-header {
+						border-bottom: 1px solid;
+						border-bottom-color: #e7e7ed;
+						border-radius: 0;
+					}
 
 					.panel-header-link {
 						border-bottom-left-radius: 0;

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_contributor_builder.scss
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_contributor_builder.scss
@@ -35,12 +35,13 @@
 				transition: all 0.5s ease;
 
 				.content-wrapper {
-					padding: 18px 24px;
-
-					.panel-header {
-						border-bottom: 1px solid;
-						border-bottom-color: #e7e7ed;
-						border-radius: 0;
+					.panel-header-link {
+						border-bottom: 1px solid $mainLighten74;
+						border-bottom-left-radius: 0;
+						border-bottom-right-radius: 0;
+						padding-bottom: 16px;
+						padding-left: 24px;
+						padding-top: 16px;
 					}
 
 					.panel-header-link {

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -52,6 +52,7 @@ class ContributorBuilder extends React.Component {
 		previewMembersURL: PropTypes.string,
 		propertyGroups: PropTypes.arrayOf(propertyGroupShape),
 		renderEmptyValuesErrors: PropTypes.bool,
+		scopeName: PropTypes.string,
 		supportedConjunctions: PropTypes.arrayOf(conjunctionShape).isRequired,
 		supportedOperators: PropTypes.arrayOf(operatorShape).isRequired,
 		supportedPropertyTypes: propertyTypesShape.isRequired,
@@ -112,6 +113,7 @@ class ContributorBuilder extends React.Component {
 			onPreviewMembers,
 			propertyGroups,
 			renderEmptyValuesErrors,
+			scopeName,
 			supportedConjunctions,
 			supportedOperators,
 			supportedPropertyTypes,
@@ -187,19 +189,8 @@ class ContributorBuilder extends React.Component {
 										>
 											<ClayPanel.Body className="align-items-center d-flex justify-content-between p-4">
 												<p className="mb-0 mr-6">
-													{Liferay.Language.get(
-														'select-the-scope-of-your-segment-to-specify-where-it-can-be-used'
-													)}
+													{scopeName}
 												</p>
-
-												<ClayButton
-													displayType="secondary"
-													size="sm"
-												>
-													{Liferay.Language.get(
-														'select'
-													)}
-												</ClayButton>
 											</ClayPanel.Body>
 										</ClayPanel>
 									)}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -167,23 +167,26 @@ class ContributorBuilder extends React.Component {
 							)}
 
 							<ClayLayout.ContainerFluid>
-								<div className="content-wrapper">
+								<div className="content-wrapper p-4">
 									{Liferay.FeatureFlags['LPS-166954'] && (
 										<ClayPanel
+											className="mb-4"
 											collapsable
 											defaultExpanded={true}
 											displayTitle={
-												<h2 className="mb-0 size- text-dark">
-													{Liferay.Language.get(
-														'scope'
-													)}
-												</h2>
+												<ClayPanel.Title>
+													<h2 className="m-0 text-dark">
+														{Liferay.Language.get(
+															'scope'
+														)}
+													</h2>
+												</ClayPanel.Title>
 											}
 											displayType="secondary"
 											showCollapseIcon
 										>
-											<ClayPanel.Body className="align-items-center center d-flex justify-content-between">
-												<p className="mb-2 mr-6 mt-2 text-dark">
+											<ClayPanel.Body className="align-items-center d-flex justify-content-between p-4">
+												<p className="mb-0 mr-6">
 													{Liferay.Language.get(
 														'select-the-scope-of-your-segment-to-specify-where-it-can-be-used'
 													)}
@@ -191,8 +194,7 @@ class ContributorBuilder extends React.Component {
 
 												<ClayButton
 													displayType="secondary"
-													small
-													type="button"
+													size="sm"
 												>
 													{Liferay.Language.get(
 														'select'

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -170,191 +170,191 @@ class ContributorBuilder extends React.Component {
 
 							<ClayLayout.ContainerFluid>
 								<div className="content-wrapper p-4">
-									{Liferay.FeatureFlags['LPS-166954'] && (
-										<ClayPanel
-											className="mb-4"
-											collapsable
-											defaultExpanded={true}
-											displayTitle={
-												<ClayPanel.Title>
-													<h2 className="m-0 text-dark">
-														{Liferay.Language.get(
-															'scope'
-														)}
-													</h2>
-												</ClayPanel.Title>
-											}
-											displayType="secondary"
-											showCollapseIcon
-										>
-											<ClayPanel.Body className="align-items-center d-flex justify-content-between p-4">
-												<p className="mb-0 mr-6">
-													{scopeName}
-												</p>
-											</ClayPanel.Body>
-										</ClayPanel>
-									)}
-
-									{Liferay.FeatureFlags['LPS-166954'] && (
-										<ClayPanel
-											collapsable
-											defaultExpanded={true}
-											displayTitle={
-												<ClayPanel.Header className="p-0">
-													<div className="align-items-center d-flex flex-wrap justify-content-between">
-														<h2 className="mb-0 sheet-title">
+									{Liferay.FeatureFlags['LPS-166954'] ? (
+										<>
+											<ClayPanel
+												className="mb-4"
+												collapsable
+												defaultExpanded={true}
+												displayTitle={
+													<ClayPanel.Title>
+														<h2 className="m-0 text-dark">
 															{Liferay.Language.get(
-																'conditions'
+																'scope'
 															)}
 														</h2>
+													</ClayPanel.Title>
+												}
+												displayType="secondary"
+												showCollapseIcon
+											>
+												<ClayPanel.Body className="align-items-center d-flex justify-content-between p-4">
+													<p className="mb-0 mr-6">
+														{scopeName}
+													</p>
+												</ClayPanel.Body>
+											</ClayPanel>
 
-														<div className="criterion-string">
-															<div className="btn-group">
-																<div className="btn-group-item inline-item mt-0">
-																	{membersCountLoading && (
-																		<ClayLoadingIndicator
-																			className="mr-4"
-																			small
-																		/>
-																	)}
+											<ClayPanel
+												collapsable
+												defaultExpanded={true}
+												displayTitle={
+													<ClayPanel.Header className="p-0">
+														<div className="align-items-center d-flex flex-wrap justify-content-between">
+															<h2 className="mb-0 sheet-title">
+																{Liferay.Language.get(
+																	'conditions'
+																)}
+															</h2>
 
-																	{!membersCountLoading && (
-																		<span className="mr-4">
-																			{Liferay.Language.get(
-																				'conditions-match'
-																			)}
-
-																			<b className="ml-2 text-dark">
-																				{getPluralMessage(
-																					Liferay.Language.get(
-																						'x-member'
-																					),
-																					Liferay.Language.get(
-																						'x-members'
-																					),
-																					membersCount
-																				)}
-																			</b>
-																		</span>
-																	)}
-
-																	<ClayButton
-																		displayType="secondary"
-																		onClick={(
-																			event
-																		) => {
-																			handleViewMembersClick(
-																				event
-																			);
-																		}}
-																		small
-																		type="button"
-																	>
-																		{Liferay.Language.get(
-																			'view-members'
+															<div className="criterion-string">
+																<div className="btn-group">
+																	<div className="btn-group-item inline-item mt-0">
+																		{membersCountLoading && (
+																			<ClayLoadingIndicator
+																				className="mr-4"
+																				small
+																			/>
 																		)}
-																	</ClayButton>
+
+																		{!membersCountLoading && (
+																			<span className="mr-4">
+																				{Liferay.Language.get(
+																					'conditions-match'
+																				)}
+
+																				<b className="ml-2 text-dark">
+																					{getPluralMessage(
+																						Liferay.Language.get(
+																							'x-member'
+																						),
+																						Liferay.Language.get(
+																							'x-members'
+																						),
+																						membersCount
+																					)}
+																				</b>
+																			</span>
+																		)}
+
+																		<ClayButton
+																			displayType="secondary"
+																			onClick={(
+																				event
+																			) => {
+																				handleViewMembersClick(
+																					event
+																				);
+																			}}
+																			small
+																			type="button"
+																		>
+																			{Liferay.Language.get(
+																				'view-members'
+																			)}
+																		</ClayButton>
+																	</div>
 																</div>
 															</div>
 														</div>
-													</div>
-												</ClayPanel.Header>
-											}
-										>
-											<ClayPanel.Body>
-												{emptyContributors &&
-													(editingId === undefined ||
-														!editing) && (
-														<EmptyPlaceholder />
-													)}
+													</ClayPanel.Header>
+												}
+											>
+												<ClayPanel.Body>
+													{emptyContributors &&
+														(editingId ===
+															undefined ||
+															!editing) && (
+															<EmptyPlaceholder />
+														)}
 
-												{contributors
-													.filter((criteria) => {
-														const editingCriteria =
-															editingId ===
-																criteria.propertyKey &&
-															editing;
-														const emptyCriteriaQuery =
-															criteria.query ===
-															'';
+													{contributors
+														.filter((criteria) => {
+															const editingCriteria =
+																editingId ===
+																	criteria.propertyKey &&
+																editing;
+															const emptyCriteriaQuery =
+																criteria.query ===
+																'';
 
-														return (
-															editingCriteria ||
-															!emptyCriteriaQuery
-														);
-													})
-													.map((criteria, i) => {
-														return (
-															<React.Fragment
-																key={i}
-															>
-																{i !== 0 && (
-																	<>
-																		<Conjunction
-																			className="mb-4 ml-0 mt-4"
-																			conjunctionName={
-																				criteria.conjunctionId
-																			}
-																			editing={
-																				editing
-																			}
-																			onSelect={
-																				onConjunctionChange
-																			}
-																			supportedConjunctions={
-																				supportedConjunctions
-																			}
-																		/>
-																	</>
-																)}
+															return (
+																editingCriteria ||
+																!emptyCriteriaQuery
+															);
+														})
+														.map((criteria, i) => {
+															return (
+																<React.Fragment
+																	key={i}
+																>
+																	{i !==
+																		0 && (
+																		<>
+																			<Conjunction
+																				className="mb-4 ml-0 mt-4"
+																				conjunctionName={
+																					criteria.conjunctionId
+																				}
+																				editing={
+																					editing
+																				}
+																				onSelect={
+																					onConjunctionChange
+																				}
+																				supportedConjunctions={
+																					supportedConjunctions
+																				}
+																			/>
+																		</>
+																	)}
 
-																<CriteriaBuilder
-																	criteria={
-																		criteria.criteriaMap
-																	}
-																	editing={
-																		editing
-																	}
-																	emptyContributors={
-																		emptyContributors
-																	}
-																	entityName={
-																		criteria.entityName
-																	}
-																	modelLabel={
-																		criteria.modelLabel
-																	}
-																	onChange={
-																		this
-																			._handleCriteriaChange
-																	}
-																	propertyKey={
-																		criteria.propertyKey
-																	}
-																	renderEmptyValuesErrors={
-																		renderEmptyValuesErrors
-																	}
-																	supportedConjunctions={
-																		supportedConjunctions
-																	}
-																	supportedOperators={
-																		supportedOperators
-																	}
-																	supportedProperties={
-																		criteria.properties
-																	}
-																	supportedPropertyTypes={
-																		supportedPropertyTypes
-																	}
-																/>
-															</React.Fragment>
-														);
-													})}
-											</ClayPanel.Body>
-										</ClayPanel>
-									)}
-
-									{!Liferay.FeatureFlags['LPS-166954'] && (
+																	<CriteriaBuilder
+																		criteria={
+																			criteria.criteriaMap
+																		}
+																		editing={
+																			editing
+																		}
+																		emptyContributors={
+																			emptyContributors
+																		}
+																		entityName={
+																			criteria.entityName
+																		}
+																		modelLabel={
+																			criteria.modelLabel
+																		}
+																		onChange={
+																			this
+																				._handleCriteriaChange
+																		}
+																		propertyKey={
+																			criteria.propertyKey
+																		}
+																		renderEmptyValuesErrors={
+																			renderEmptyValuesErrors
+																		}
+																		supportedConjunctions={
+																			supportedConjunctions
+																		}
+																		supportedOperators={
+																			supportedOperators
+																		}
+																		supportedProperties={
+																			criteria.properties
+																		}
+																		supportedPropertyTypes={
+																			supportedPropertyTypes
+																		}
+																	/>
+																</React.Fragment>
+															);
+														})}
+												</ClayPanel.Body>
+											</ClayPanel>
+										</>
+									) : (
 										<ClayLayout.Sheet>
 											<div className="d-flex flex-wrap justify-content-between mb-4">
 												<h2 className="mb-2 sheet-title">

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -168,33 +168,39 @@ class ContributorBuilder extends React.Component {
 
 							<ClayLayout.ContainerFluid>
 								<div className="content-wrapper">
-									<ClayPanel
-										collapsable
-										defaultExpanded={true}
-										displayTitle={
-											<h2 className="mb-0 size- text-dark">
-												{Liferay.Language.get('scope')}
-											</h2>
-										}
-										displayType="secondary"
-										showCollapseIcon
-									>
-										<ClayPanel.Body className="align-items-center center d-flex justify-content-between">
-											<p className="mb-2 mr-6 mt-2 text-dark">
-												{Liferay.Language.get(
-													'select-the-scope-of-your-segment-to-specify-where-it-can-be-used'
-												)}
-											</p>
+									{Liferay.FeatureFlags['LPS-166954'] && (
+										<ClayPanel
+											collapsable
+											defaultExpanded={true}
+											displayTitle={
+												<h2 className="mb-0 size- text-dark">
+													{Liferay.Language.get(
+														'scope'
+													)}
+												</h2>
+											}
+											displayType="secondary"
+											showCollapseIcon
+										>
+											<ClayPanel.Body className="align-items-center center d-flex justify-content-between">
+												<p className="mb-2 mr-6 mt-2 text-dark">
+													{Liferay.Language.get(
+														'select-the-scope-of-your-segment-to-specify-where-it-can-be-used'
+													)}
+												</p>
 
-											<ClayButton
-												displayType="secondary"
-												small
-												type="button"
-											>
-												{Liferay.Language.get('select')}
-											</ClayButton>
-										</ClayPanel.Body>
-									</ClayPanel>
+												<ClayButton
+													displayType="secondary"
+													small
+													type="button"
+												>
+													{Liferay.Language.get(
+														'select'
+													)}
+												</ClayButton>
+											</ClayPanel.Body>
+										</ClayPanel>
+									)}
 
 									{Liferay.FeatureFlags['LPS-166954'] && (
 										<ClayPanel

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -168,6 +168,34 @@ class ContributorBuilder extends React.Component {
 
 							<ClayLayout.ContainerFluid>
 								<div className="content-wrapper">
+									<ClayPanel
+										collapsable
+										defaultExpanded={true}
+										displayTitle={
+											<h2 className="mb-0 size- text-dark">
+												{Liferay.Language.get('scope')}
+											</h2>
+										}
+										displayType="secondary"
+										showCollapseIcon
+									>
+										<ClayPanel.Body className="align-items-center center d-flex justify-content-between">
+											<p className="mb-2 mr-6 mt-2 text-dark">
+												{Liferay.Language.get(
+													'select-the-scope-of-your-segment-to-specify-where-it-can-be-used'
+												)}
+											</p>
+
+											<ClayButton
+												displayType="secondary"
+												small
+												type="button"
+											>
+												{Liferay.Language.get('select')}
+											</ClayButton>
+										</ClayPanel.Body>
+									</ClayPanel>
+
 									{Liferay.FeatureFlags['LPS-166954'] && (
 										<ClayPanel
 											collapsable

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
@@ -69,6 +69,7 @@ class SegmentEdit extends Component {
 		propertyGroups: PropTypes.array,
 		redirect: PropTypes.string.isRequired,
 		requestMembersCountURL: PropTypes.string,
+		scopeName: PropTypes.string,
 		segmentsConfigurationURL: PropTypes.string,
 		setFieldValue: PropTypes.func,
 		setValues: PropTypes.func,
@@ -290,6 +291,7 @@ class SegmentEdit extends Component {
 				propertyGroups={propertyGroups}
 				renderEmptyValuesErrors={queryHasEmptyValues}
 				requestMembersCountURL={requestMembersCountURL}
+				scopeName={this.props.scopeName}
 				segmentName={segmentName}
 				supportedConjunctions={SUPPORTED_CONJUNCTIONS}
 				supportedOperators={SUPPORTED_OPERATORS}

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.es.js.snap
@@ -759,7 +759,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
           class="container-fluid container-fluid-max-xl"
         >
           <div
-            class="content-wrapper"
+            class="content-wrapper p-4"
           >
             <div
               class="sheet"
@@ -1569,7 +1569,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
           class="container-fluid container-fluid-max-xl"
         >
           <div
-            class="content-wrapper"
+            class="content-wrapper p-4"
           >
             <div
               class="sheet"

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
@@ -647,7 +647,7 @@ exports[`SegmentEdit renders with given values 1`] = `
               class="container-fluid container-fluid-max-xl"
             >
               <div
-                class="content-wrapper"
+                class="content-wrapper p-4"
               >
                 <div
                   class="sheet"


### PR DESCRIPTION
Motivation
=======
We are moving the Segmentation from a site to a global scope. In order to that we need to introduce a tool to manage sites and assign them to Segments. We are using a Scope Card to select sites for this purpose. This PR contains the Front-end part with no site selector, just the Scope Card with the current site.
[Link to the task](https://issues.liferay.com/browse/LPS-168816)
[Link to the story](https://issues.liferay.com/browse/LPS-167025)

Proposed Solution
========
The proposed solution consists in using a ClayPanel to render the Card, where the PanelHeader contains the title "Scope" and the PanelBody contains the Site Name.

Steps to Verify:
----------------
1. Go to People -> Segments.
2. Click on '+' to add a new Segment.
3. Check that the Scope Card is displayed correctly.

Screencaps
---------------
![Captura de pantalla 2022-11-23 a las 11 32 18](https://user-images.githubusercontent.com/5776822/203536430-dcdc5480-196e-41c9-9710-3b29ca4defc0.png)

