### PR TITLE
LPS-167073 HR_15 When user activates "Page Audit" button and Side panel pop-up, Focus is not moving to Side panel window

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/App.js
@@ -30,37 +30,42 @@ export default function App(props) {
 		`${portletNamespace}layoutReportsPanelToggleId`
 	);
 
-
-
 	layoutReportsPanelToggle.setAttribute('aria-pressed', false);
 
 	const layoutReportsPanelId = document.getElementById(
 		`${portletNamespace}layoutReportsPanelId`
 	);
 
+	const sidenavInstance = Liferay.SideNavigation.instance(
+		layoutReportsPanelToggle
+	);
+
 	const handleKeydownToggle = (event) => {
-		if (event.key === 'Enter'){
+		if (event.key === 'Enter') {
 			layoutReportsPanelToggle.setAttribute('aria-pressed', true);
 		}
 	};
 
+	const handleKeydownPanel = (event) => {
+		if (event.key === 'Escape') {
+			layoutReportsPanelToggle.setAttribute('aria-pressed', false);
+			sidenavInstance.toggle();
+		}
+	};
 
 	useEffect(() => {
-		const sidenavInstance = Liferay.SideNavigation.instance(
-			layoutReportsPanelToggle
-		);
-
 		sidenavInstance.on('open.lexicon.sidenav', () => {
 			setSessionValue(
 				'com.liferay.layout.reports.web_layoutReportsPanelState',
 				'open'
 			);
 
-			if (layoutReportsPanelToggle.getAttribute('aria-pressed') === 'true'){
+			if (
+				layoutReportsPanelToggle.getAttribute('aria-pressed') === 'true'
+			) {
 				layoutReportsPanelId.setAttribute('tabindex', '0');
 				layoutReportsPanelId.focus();
 			}
-
 		});
 
 		sidenavInstance.on('closed.lexicon.sidenav', () => {
@@ -68,18 +73,41 @@ export default function App(props) {
 				'com.liferay.layout.reports.web_layoutReportsPanelState',
 				'closed'
 			);
+
+			if (
+				layoutReportsPanelToggle.getAttribute('aria-pressed') ===
+				'false'
+			) {
+				layoutReportsPanelToggle.setAttribute('tabindex', '0');
+				layoutReportsPanelToggle.focus();
+			}
 		});
 
 		Liferay.once('screenLoad', () => {
 			Liferay.SideNavigation.destroy(layoutReportsPanelToggle);
 		});
-	}, [layoutReportsPanelToggle, portletNamespace]);
+	}, [
+		layoutReportsPanelToggle,
+		portletNamespace,
+		layoutReportsPanelId,
+		sidenavInstance,
+	]);
 
 	const [eventTriggered, setEventTriggered] = useState(false);
 
-	useEventListener('keydown', handleKeydownToggle, {once: false}
-		, layoutReportsPanelToggle);
+	useEventListener(
+		'keydown',
+		handleKeydownToggle,
+		{once: false},
+		layoutReportsPanelToggle
+	);
 
+	useEventListener(
+		'keydown',
+		handleKeydownPanel,
+		{once: false},
+		layoutReportsPanelId
+	);
 
 	useEventListener(
 		'mouseenter',

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/App.js
@@ -30,6 +30,21 @@ export default function App(props) {
 		`${portletNamespace}layoutReportsPanelToggleId`
 	);
 
+
+
+	layoutReportsPanelToggle.setAttribute('aria-pressed', false);
+
+	const layoutReportsPanelId = document.getElementById(
+		`${portletNamespace}layoutReportsPanelId`
+	);
+
+	const handleKeydownToggle = (event) => {
+		if (event.key === 'Enter'){
+			layoutReportsPanelToggle.setAttribute('aria-pressed', true);
+		}
+	};
+
+
 	useEffect(() => {
 		const sidenavInstance = Liferay.SideNavigation.instance(
 			layoutReportsPanelToggle
@@ -40,6 +55,12 @@ export default function App(props) {
 				'com.liferay.layout.reports.web_layoutReportsPanelState',
 				'open'
 			);
+
+			if (layoutReportsPanelToggle.getAttribute('aria-pressed') === 'true'){
+				layoutReportsPanelId.setAttribute('tabindex', '0');
+				layoutReportsPanelId.focus();
+			}
+
 		});
 
 		sidenavInstance.on('closed.lexicon.sidenav', () => {
@@ -55,6 +76,10 @@ export default function App(props) {
 	}, [layoutReportsPanelToggle, portletNamespace]);
 
 	const [eventTriggered, setEventTriggered] = useState(false);
+
+	useEventListener('keydown', handleKeydownToggle, {once: false}
+		, layoutReportsPanelToggle);
+
 
 	useEventListener(
 		'mouseenter',


### PR DESCRIPTION
Motivation
=======
This ticket resolves a Accessibility bug about the usage of the Page Audit panel, related to the focus when navigating with the keyboard. 

[Link to the bug](https://issues.liferay.com/browse/LPS-167073)

Proposed Solution
========
The proposed solution consists in use two eventHandlers to manage the keyboard events when opening and closing the Panel and a function to change the aria-pressed for the Page Audit Toggle so is it possibly to save its state.

Steps to Verify:
----------------
1. Navigate through the Control Menu Navbar pressing  the Tab button and focus on the Page Audit button.
2. Press the Enter button and check that the panel opens up and the Panel is focused on.
3. Click the Tab button and check that he focus moves into the panel.
4. Click the Exit button and checked that the panel is closed and the focused goes back to the toggle Page Audit button.

Screencaps
---------------
![Screenshot 2022-12-12 at 18 45 16](https://user-images.githubusercontent.com/91207948/207116562-186c9b07-2a98-4073-9cbf-4f90cd0910e1.png)
