### PR TITLE
[TS] LPS-169318 Overloading getPermissionWherePredicate with userIdColumn to be able to call the method with an explicitly given userIdColumn

### DIFF
--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -83,6 +83,15 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 	@Override
 	public <T extends Table<T>> Predicate getPermissionWherePredicate(
+		Class<?> modelClass, Column<T, Long> classPKColumn,
+		Column<T, Long> userIdColumn, long... groupIds) {
+
+		return getPermissionWherePredicate(
+			modelClass.getName(), classPKColumn, userIdColumn, groupIds);
+	}
+
+	@Override
+	public <T extends Table<T>> Predicate getPermissionWherePredicate(
 		Class<?> modelClass, Column<T, Long> classPKColumn, long... groupIds) {
 
 		return getPermissionWherePredicate(
@@ -92,7 +101,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 	@Override
 	public <T extends Table<T>> Predicate getPermissionWherePredicate(
 		String modelClassName, Column<T, Long> classPKColumn,
-		long... groupIds) {
+		Column<T, Long> userIdColumn, long... groupIds) {
 
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -108,7 +117,21 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		}
 
 		return _getPermissionPredicate(
-			permissionChecker, modelClassName, classPKColumn, groupIds);
+			permissionChecker, modelClassName, classPKColumn, userIdColumn,
+			groupIds);
+	}
+
+	@Override
+	public <T extends Table<T>> Predicate getPermissionWherePredicate(
+		String modelClassName, Column<T, Long> classPKColumn,
+		long... groupIds) {
+
+		T table = classPKColumn.getTable();
+
+		Column<T, Long> userIdColumn = table.getColumn("userId", Long.class);
+
+		return getPermissionWherePredicate(
+			modelClassName, classPKColumn, userIdColumn, groupIds);
 	}
 
 	@Override
@@ -414,11 +437,10 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 	private <T extends Table<T>> Predicate _getPermissionPredicate(
 		PermissionChecker permissionChecker, String modelClassName,
-		Column<T, Long> classPKColumn, long[] groupIds) {
+		Column<T, Long> classPKColumn, Column<T, Long> userIdColumn,
+		long[] groupIds) {
 
 		T table = classPKColumn.getTable();
-
-		Column<T, Long> userIdColumn = table.getColumn("userId", Long.class);
 
 		DSLQuery resourcePermissionDSLQuery = _getResourcePermissionQuery(
 			permissionChecker, modelClassName, userIdColumn, groupIds);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryFinderImpl.java
@@ -970,7 +970,7 @@ public class DLFileEntryFinderImpl
 								getPermissionWherePredicate(
 									DLFileEntry.class,
 									DLFileVersionTable.INSTANCE.fileEntryId,
-									groupId);
+									null, groupId);
 						}
 
 						return null;

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/InlineSQLHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/InlineSQLHelper.java
@@ -30,7 +30,15 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface InlineSQLHelper {
 
 	public <T extends Table<T>> Predicate getPermissionWherePredicate(
+		Class<?> modelClass, Column<T, Long> classPKColumn,
+		Column<T, Long> userIdColumn, long... groupIds);
+
+	public <T extends Table<T>> Predicate getPermissionWherePredicate(
 		Class<?> modelClass, Column<T, Long> classPKColumn, long... groupIds);
+
+	public <T extends Table<T>> Predicate getPermissionWherePredicate(
+		String modelClassName, Column<T, Long> classPKColumn,
+		Column<T, Long> userIdColumn, long... groupIds);
 
 	public <T extends Table<T>> Predicate getPermissionWherePredicate(
 		String modelClassName, Column<T, Long> classPKColumn, long... groupIds);

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/InlineSQLHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/InlineSQLHelperUtil.java
@@ -27,6 +27,14 @@ import com.liferay.portal.kernel.util.ServiceProxyFactory;
 public class InlineSQLHelperUtil {
 
 	public static <T extends Table<T>> Predicate getPermissionWherePredicate(
+		Class<?> modelClass, Column<T, Long> classPKColumn,
+		Column<T, Long> userIdColumn, long... groupIds) {
+
+		return _inlineSQLPermission.getPermissionWherePredicate(
+			modelClass, classPKColumn, userIdColumn, groupIds);
+	}
+
+	public static <T extends Table<T>> Predicate getPermissionWherePredicate(
 		Class<?> modelClass, Column<T, Long> classPKColumn, long... groupIds) {
 
 		return _inlineSQLPermission.getPermissionWherePredicate(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
@@ -1,1 +1,1 @@
-version 6.2.0
+version 6.3.0


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-169318

Previous PR caused regression:https://github.com/liferay-core-infra/liferay-portal/pull/2697

**Solution:**
On [PTR-3540](https://issues.liferay.com/browse/PTR-3540?focusedCommentId=2819004&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2819004) I was advised to either change the failing test, or update InlineSQLHelper and create a new variation of getPermissionWherePredicate which accepts a specified userIdColumn. 
I chose this approach because this way I can fix a specific issue without changing the current behavior.

I tested in my local environment, and it worked like it is intended, the old query is called when we add null as userIdColumn.

Best regards,
Évi