### PR TITLE
LPS-167150 Migrate Experience Selector in view mode to Picker component

### DIFF
--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/experience_picker.scss
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/experience_picker.scss
@@ -1,0 +1,10 @@
+@import 'cadmin-variables';
+
+a.experience-picker-option {
+	color: $cadmin-gray-900;
+
+	&:hover {
+		color: $cadmin-gray-900;
+		text-decoration: none;
+	}
+}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/ExperiencePicker.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/ExperiencePicker.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {Option, Picker, Text} from '@clayui/core';
+import Label from '@clayui/label';
+import Layout from '@clayui/layout';
+import React from 'react';
+
+const TriggerLabel = React.forwardRef(({selectedItem, ...otherProps}, ref) => {
+	return (
+		<div ref={ref} {...otherProps} tabIndex={0}>
+			<Layout.ContentRow verticalAlign="center">
+				<Layout.ContentCol expand>
+					<Text size={3} weight="semi-bold">
+						{selectedItem.segmentsExperienceName}
+					</Text>
+				</Layout.ContentCol>
+
+				<Layout.ContentCol>
+					<Label
+						displayType={
+							selectedItem.active ? 'success' : 'secondary'
+						}
+					>
+						{selectedItem.statusLabel}
+					</Label>
+				</Layout.ContentCol>
+			</Layout.ContentRow>
+		</div>
+	);
+});
+
+const ExperiencePicker = ({experiences, selectedExperience}) => {
+	return (
+		<Picker
+			as={TriggerLabel}
+			items={experiences}
+			selectedItem={selectedExperience}
+		>
+			{(item) => (
+				<Option
+					key={item.segmentsExperienceId}
+					selectedItem={selectedExperience}
+					textValue={item.segmentsExperienceName}
+				>
+					<a href={item.url}>
+						<Layout.ContentRow>
+							<Layout.ContentCol expand>
+								<Text
+									id={`${item.segmentsExperienceName}-title`}
+									size={3}
+									weight="semi-bold"
+								>
+									{item.segmentsExperienceName}
+								</Text>
+
+								<Text
+									aria-hidden
+									color="secondary"
+									id={`${item.segmentsExperienceName}-description`}
+									size={2}
+								>
+									{`${Liferay.Language.get('segment')}:
+									${item.segmentsEntryName}`}
+								</Text>
+							</Layout.ContentCol>
+
+							<Layout.ContentCol>
+								<Label
+									aria-hidden
+									displayType={
+										item.active ? 'success' : 'secondary'
+									}
+									id={`${item.segmentsExperienceName}-status`}
+								>
+									{item.statusLabel}
+								</Label>
+							</Layout.ContentCol>
+						</Layout.ContentRow>
+					</a>
+				</Option>
+			)}
+		</Picker>
+	);
+};
+
+export default ExperiencePicker;

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/ExperiencePicker.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/ExperiencePicker.js
@@ -17,27 +17,36 @@ import Label from '@clayui/label';
 import Layout from '@clayui/layout';
 import React from 'react';
 
+import '../../css/experience_picker.scss';
+
 const TriggerLabel = React.forwardRef(({selectedItem, ...otherProps}, ref) => {
 	return (
-		<div ref={ref} {...otherProps} tabIndex={0}>
-			<Layout.ContentRow verticalAlign="center">
-				<Layout.ContentCol expand>
-					<Text size={3} weight="semi-bold">
-						{selectedItem.segmentsExperienceName}
-					</Text>
-				</Layout.ContentCol>
+		<button
+			{...otherProps}
+			className="btn btn-sm btn-unstyled form-control-select"
+			ref={ref}
+			tabIndex={0}
+		>
+			<div className="c-inner" tabIndex="-1">
+				<Layout.ContentRow verticalAlign="center">
+					<Layout.ContentCol className="mr-2" expand>
+						<Text size={4} truncate>
+							{selectedItem.segmentsExperienceName}
+						</Text>
+					</Layout.ContentCol>
 
-				<Layout.ContentCol>
-					<Label
-						displayType={
-							selectedItem.active ? 'success' : 'secondary'
-						}
-					>
-						{selectedItem.statusLabel}
-					</Label>
-				</Layout.ContentCol>
-			</Layout.ContentRow>
-		</div>
+					<Layout.ContentCol>
+						<Label
+							displayType={
+								selectedItem.active ? 'success' : 'secondary'
+							}
+						>
+							{selectedItem.statusLabel}
+						</Label>
+					</Layout.ContentCol>
+				</Layout.ContentRow>
+			</div>
+		</button>
 	);
 });
 
@@ -54,7 +63,7 @@ const ExperiencePicker = ({experiences, selectedExperience}) => {
 					selectedItem={selectedExperience}
 					textValue={item.segmentsExperienceName}
 				>
-					<a href={item.url}>
+					<a className="experience-picker-option" href={item.url}>
 						<Layout.ContentRow>
 							<Layout.ContentCol expand>
 								<Text

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_experience_selector.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_experience_selector.jsp
@@ -18,75 +18,21 @@
 
 <%
 SegmentsExperienceSelectorDisplayContext segmentsExperienceSelectorDisplayContext = (SegmentsExperienceSelectorDisplayContext)request.getAttribute(SegmentsExperienceSelectorDisplayContext.class.getName());
+
+JSONObject segmentsExperienceSelectedJSONObject = segmentsExperienceSelectorDisplayContext.getSegmentsExperienceSelectedJSONObject();
+
+JSONArray segmentsExperiencesJSONArray = segmentsExperienceSelectorDisplayContext.getSegmentsExperiencesJSONArray();
 %>
 
 <div class="border-left border-secondary control-menu-nav-item ml-3 pl-3">
-	<div class="dropdown">
-		<button aria-expanded="false" aria-haspopup="true" class="btn btn-sm btn-unstyled dropdown-toggle" id="<portlet:namespace />dropdownToggle" type="button">
-			<span class="align-items-center c-inner d-flex" tabindex="-1">
-
-				<%
-				JSONObject segmentsExperienceSelectedJSONObject = segmentsExperienceSelectorDisplayContext.getSegmentsExperienceSelectedJSONObject();
-				%>
-
-				<span class="lfr-portal-tooltip mr-2 text-truncate" title="<%= HtmlUtil.escapeAttribute(segmentsExperienceSelectedJSONObject.getString("segmentsExperienceName")) %>">
-					<%= segmentsExperienceSelectedJSONObject.getString("segmentsExperienceName") %>
-				</span>
-
-				<div class="autofit-col">
-					<span class="label label-<%= segmentsExperienceSelectedJSONObject.getBoolean("active")?"success":"secondary" %> bg-transparent m-0">
-						<span class="label-item label-item-expand">
-							<%= segmentsExperienceSelectedJSONObject.getString("statusLabel") %>
-						</span>
-					</span>
-				</div>
-
-				<clay:icon
-					cssClass="flex-shrink-0"
-					symbol="caret-double"
-				/>
-			</span>
-		</button>
-
-		<ul aria-labelledby="<portlet:namespace />dropdownToggle" class="dropdown-menu" id="<portlet:namespace />dropdown">
-
-			<%
-			JSONArray segmentsExperiencesJSONArray = segmentsExperienceSelectorDisplayContext.getSegmentsExperiencesJSONArray();
-
-			for (int i = 0; i < segmentsExperiencesJSONArray.length(); i++) {
-				JSONObject segmentsExperiencesJSONObject = segmentsExperiencesJSONArray.getJSONObject(i);
-			%>
-
-				<li>
-					<a class="border-0 dropdown-item list-group-item list-group-item-flex rounded-0" href="<%= segmentsExperiencesJSONObject.getString("url") %>">
-						<div class="autofit-col autofit-col-expand">
-							<p class="lfr-portal-tooltip list-group-title text-truncate" title="<%= HtmlUtil.escapeAttribute(segmentsExperiencesJSONObject.getString("segmentsExperienceName")) %>">
-								<%= segmentsExperiencesJSONObject.getString("segmentsExperienceName") %>
-							</p>
-
-							<p class="lfr-portal-tooltip list-group-text text-secondary text-truncate" title="<%= HtmlUtil.escapeAttribute(segmentsExperiencesJSONObject.getString("segmentsEntryName")) %>">
-								<liferay-ui:message arguments='<%= segmentsExperiencesJSONObject.getString("segmentsEntryName") %>' key="segment-x" />
-							</p>
-						</div>
-
-						<div class="autofit-col">
-							<span class="label label-<%= segmentsExperiencesJSONObject.getBoolean("active")?"success":"secondary" %> bg-transparent m-0">
-								<span class="label-item label-item-expand">
-									<%= segmentsExperiencesJSONObject.getString("statusLabel") %>
-								</span>
-							</span>
-						</div>
-					</a>
-				</li>
-
-			<%
-			}
-			%>
-
-		</ul>
-	</div>
+	<react:component
+		module="js/components/ExperiencePicker"
+		props='<%=
+				HashMapBuilder.<String, Object>put(
+					"selectedExperience", segmentsExperienceSelectedJSONObject
+				).put(
+					"experiences", segmentsExperiencesJSONArray
+				).build()
+			%>'
+	/>
 </div>
-
-<liferay-frontend:component
-	module="js/ExperienceSelector"
-/>


### PR DESCRIPTION
**This PR depends on** https://github.com/liferay/clay/issues/5271 .

Motivation
=======
The Screen Reader is not announcing the exact role and state for the select experience combo box.
[Link to ticket](https://issues.liferay.com/browse/LPS-167150)

Proposed Solution
========
Migrate the experience selector to the new Picker component https://clayui.com/docs/components/picker.html. This new component add the role correctly.

Steps to Verify:
----------------

1. Go to Top Menu > Edit
2. Navigate to Default Experience Combo Box
3. Create and publish a New Experience
4. Navigate to Default Combo box
5. Listen to Screen Reader


Screenshots (optional):
-----------------------
