### PR TITLE
[TECHNICAL-SUPPORT] LPS-172281 Wrong permissions appear for user when selecting Documents from Search results

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
@@ -42,6 +42,8 @@ if (searchFolderId > 0) {
 String keywords = ParamUtil.getString(request, "keywords");
 
 DLAdminDisplayContext dlAdminDisplayContext = (DLAdminDisplayContext)request.getAttribute(DLAdminDisplayContext.class.getName());
+DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDisplayContext(liferayPortletRequest, liferayPortletResponse);
+
 DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletInstanceSettingsHelper(dlRequestHelper);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletResponse);
@@ -93,6 +95,11 @@ entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletRespons
 						}
 
 						String thumbnailSrc = DLURLHelperUtil.getThumbnailSrc(fileEntry, latestFileVersion, themeDisplay);
+
+						row.setData(
+							HashMapBuilder.<String, Object>put(
+								"actions", StringUtil.merge(dlViewEntriesDisplayContext.getAvailableActions(fileEntry))
+							).build());
 
 						row.setPrimaryKey(String.valueOf(fileEntry.getFileEntryId()));
 						%>


### PR DESCRIPTION
Original PR comment:

> Dear Team,
> 
> Could you please review this pull request?
> 
> Motivation
> =======
> While a user does not have permission for a given action in Documents and Media, if the user runs a search and selects Documents from there, it appears that the user has that permission because the icon belonging to that action on the management toolbar is not greyed out.
> This is not the case when the files are listed without searching. Then, the deactivation of the icons is happening properly.
> 
> Proposed Solution
> ========
> The [frontend code](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js#L36-L37) of the management toolbar checks if the action belonging to the toolbar dropdown item is among the actions available to the user.
> 
> The available actions are [passed to the row object](https://github.com/liferay/liferay-portal/blob/master/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp#L39-L41) when the files are listed without searching.
> 
> This should be done to the search result rows as well.
> 
> Steps to Verify
> ========
> Please see the reproductions steps in the LPS.
> https://issues.liferay.com/browse/LPS-172281
> 
> Thank you and best regards,
> István

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3902.