### PR TITLE
COMMERCE-10604 Make ERC updatable through SKU Patch

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuResourceImpl.java
@@ -344,8 +344,11 @@ public class SkuResourceImpl
 		DateConfig expirationDateConfig = new DateConfig(expirationCalendar);
 
 		cpInstance = _cpInstanceService.updateCPInstance(
-			cpInstance.getExternalReferenceCode(), cpInstance.getCPInstanceId(),
-			sku.getSku(), sku.getGtin(), sku.getManufacturerPartNumber(),
+			GetterUtil.get(
+				sku.getExternalReferenceCode(),
+				cpInstance.getExternalReferenceCode()),
+			cpInstance.getCPInstanceId(), sku.getSku(), sku.getGtin(),
+			sku.getManufacturerPartNumber(),
 			GetterUtil.get(sku.getPurchasable(), cpInstance.isPurchasable()),
 			GetterUtil.get(sku.getWidth(), cpInstance.getWidth()),
 			GetterUtil.get(sku.getHeight(), cpInstance.getHeight()),


### PR DESCRIPTION
> Related Issue: [COMMERCE-10604](https://issues.liferay.com/browse/COMMERCE-10604)
> 
> The ERC was being updated with the saved SKU ERC instead of the one sent by the API. Proposed fix is to change it so the ERC is updated by the one sent by the API

From @victorcdp ,

@andrea-ale-sbarra 