### PR TITLE
LPS-159239

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java
@@ -419,7 +419,17 @@ public class PortletTracker
 
 			Class<?> portletClazz = portlet.getClass();
 
-			portletModel.setPortletClass(portletClazz.getName());
+			String portletClass = portletClazz.getName();
+
+			if (portlet instanceof InvokerPortlet) {
+				InvokerPortlet invokerPortlet = (InvokerPortlet)portlet;
+
+				if (invokerPortlet.isFacesPortlet()) {
+					portletClass = "javax.portlet.faces.GenericFacesPortlet";
+				}
+			}
+
+			portletModel.setPortletClass(portletClass);
 
 			_collectJxPortletFeatures(serviceReference, portletModel);
 			_collectLiferayFeatures(serviceReference, portletModel);


### PR DESCRIPTION
…) missed the case(Bean portlet, it will be registered as osgi service, please refer to RegistrationUtil.registerBeanPortlet method). And the fix applies the previous fix logic to the usage. The root issue is portlet's portletClass hadn't been assigned to the right value(<portlet-class> of WEB-INF/portlet.xml), its wrong/using value is "com.liferay.bean.portlet.registration.internal.BeanPortletInvokerPortlet". When render the portlet in Content page, RuntimeTag#_isHeaderPortlet() returns false. Back to RegistrationUtil.registerBeanPortlet method, beanPortlet.getBeanMethods() value is from PortletDescriptorParser#_populateBeanPortlets()->PortletScannerUtil.scanNonannotatedBeanMethods(), the process used <portlet-class> value.