### PR TITLE
LPS-174133 User without Segment's portlet permissions can access

### DIFF
--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/application/list/SegmentsPanelApp.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/application/list/SegmentsPanelApp.java
@@ -48,10 +48,6 @@ public class SegmentsPanelApp extends BasePanelApp {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-166954"))) {
-			return true;
-		}
-
 		if (group.isLayoutSetPrototype() || group.isUser()) {
 			return false;
 		}


### PR DESCRIPTION
Motivation
=======
User without Segment's portlet permissions can access to segments administration when the FF is activated.

Proposed Solution
========

Delete FF check in isShow method because it was avoiding the  portal permission check.

Steps to Verify:
----------------

1. Create a role Segmentator
2. Add Access to the Control Panel permission to the Segmentator role
3. Create a user u1
4. Add the role Segmentator to the user u1
5. Login with the user u1
6. User1 won't have permission to access to the segment administration
7. Add Segments/ Application permissions / Access in Control Panel permission to the Segmentator role
8. Login again withe the user u1 and now you can see the segment administration
 


