### PR TITLE
LPS-176871 Considering context path when searching for suggestions

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -109,7 +109,7 @@ export default function SearchBar({
 					scope: scopeValue,
 					search: searchValue,
 				},
-				suggestionsURL
+				Liferay.ThemeDisplay.getPathContext() + suggestionsURL
 			),
 			{
 				body: _getSuggestionsContributorConfiguration(),


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

This is a regression bug from [this commit](https://github.com/liferay/liferay-portal/commit/778d476814176c7e427607a7523cd2cf242cd2c8#diff-9a251bfad674e84ebf27c67d0afd76a68233753cd93fe47bc929c080d1ba6a0cL42) where we stopped considering context path.

Thanks.

Regards.