### PR TITLE
LPS-177882 Considering context path for Blueprints options widget

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
@@ -125,7 +125,7 @@ function SXPBlueprintAttributes({onBlur, onChange, touched, value}) {
 			setSXPBlueprint({loading: true, title: ''});
 
 			fetch(
-				`${window.location.origin}/o/search-experiences-rest/v1.0/sxp-blueprints/${value.attributes?.sxpBlueprintId}`,
+				`/o/search-experiences-rest/v1.0/sxp-blueprints/${value.attributes?.sxpBlueprintId}`,
 				{
 					headers: new Headers({
 						'Accept': 'application/json',

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/SelectSXPBlueprintModal.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/SelectSXPBlueprintModal.js
@@ -76,7 +76,8 @@ const SelectSXPBlueprintModal = ({observer, onClose, onSubmit, selectedId}) => {
 		fetchRetry: {
 			attempts: 0,
 		},
-		link: `${window.location.origin}/o/search-experiences-rest/v1.0/sxp-blueprints`,
+		link: `${window.location.origin}${Liferay.ThemeDisplay.getPathContext()}
+		/o/search-experiences-rest/v1.0/sxp-blueprints`,
 		onNetworkStatusChange: (status) => {
 			setNetworkState({
 				error: status === 5,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/SelectSXPBlueprintModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/SelectSXPBlueprintModal.js
@@ -73,7 +73,8 @@ const SelectSXPBlueprintModal = ({observer, onClose, onSubmit, selectedId}) => {
 		fetchRetry: {
 			attempts: 0,
 		},
-		link: `${window.location.origin}/o/search-experiences-rest/v1.0/sxp-blueprints`,
+		link: `${window.location.origin}${Liferay.ThemeDisplay.getPathContext()}
+		/o/search-experiences-rest/v1.0/sxp-blueprints`,
 		onNetworkStatusChange: (status) => {
 			setNetworkState({
 				error: status === 5,


### PR DESCRIPTION
Continued from https://github.com/liferay-search/liferay-portal/pull/826
https://issues.liferay.com/browse/LPS-177882 - Blueprints option widget not working with non root context

> Hey guys,
> 
> Can you have a look at this pull request, please?
> 
> You can get more information in [LPS-177882](https://issues.liferay.com/browse/LPS-177882).
> 
> Thanks.
> 
> Regards.

Looks good! Just a few updates: 
- Added new line to hopefully pass formatting
- Used abridged URL when using `fetch` (for `SearchBarConfigurationSuggestions`) since it should add origin and context
- Split commit into two since it affects two modules, search-web and search-experiences-web

Thank you @antonio-ortega for working on this!! 🔥 