### PR TITLE
LRAC-12180 The documentDownloaded event is not triggered in the browser console when using the download icon with Show Actions enabled (7.4)

### DIFF
--- a/modules/apps/document-library/document-library-analytics/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/document-library/document-library-analytics/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -58,16 +58,19 @@
 				sendAnalyticsEvent(event.target.parentNode);
 			}
 			else if (
+				(event.target.title &&
+					event.target.title.toLowerCase() === 'download') ||
 				event.target.dataset.action === 'download' ||
 				event.target.querySelector('.lexicon-icon-download') ||
 				event.target.classList.contains('lexicon-icon-download') ||
 				(event.target.parentNode &&
+					(event.target.parentNode.title && event.target.parentNode.title.toLowerCase() === 'download') ||
 					event.target.parentNode.classList.contains(
 						'lexicon-icon-download'
 					))
 			) {
 				var selectedFiles = document.querySelectorAll(
-					'.portlet-document-library .entry-selector:checked'
+					'.form .custom-control-input:checked'
 				);
 
 				selectedFiles.forEach(({value}) => {


### PR DESCRIPTION
LRAC-12180: [Jira Issue](https://issues.liferay.com/browse/LRAC-12180)