### PR TITLE
[SF] LPS-154671 Allow filtered `SELECT` queries on Company table

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
@@ -136,6 +136,10 @@ public class CompanyIterationCheck extends BaseCheck {
 		Matcher matcher = _selectCompanySQLPattern.matcher(stringLiteral);
 
 		if (matcher.find()) {
+			if (stringLiteral.contains(" where ")) {
+				return;
+			}
+
 			if (_isCoreUpgrade()) {
 				if (Objects.equals(matcher.group(1), "companyId")) {
 					log(methodCallDetailAST, _MSG_USE_PORTAL_INSTANCES);


### PR DESCRIPTION
This is an update for [LPS-154671](https://issues.liferay.com/browse/LPS-154671). This pull request allows `SELECT` queries on the `Company` that use the `WHERE` clause. This is to allow cases like this: [WebIdToCompanyConfigurationPluginImpl.java](https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-configuration/portal-configuration-plugin-impl/src/main/java/com/liferay/portal/configuration/plugin/internal/WebIdToCompanyConfigurationPluginImpl.java#L83).