### PR TITLE
LPS-183137 Fix DeepL Translator authentication

### DIFF
--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -154,7 +154,9 @@ public class DeepLTranslator implements Translator {
 		options.addHeader(
 			HttpHeaders.CONTENT_TYPE,
 			ContentTypes.APPLICATION_X_WWW_FORM_URLENCODED);
-		options.addPart("auth_key", _deepLTranslatorConfiguration.authKey());
+		options.addHeader(
+			HttpHeaders.AUTHORIZATION,
+			"DeepL-Auth-Key " + _deepLTranslatorConfiguration.authKey());
 		options.setLocation(url);
 
 		try {
@@ -207,6 +209,9 @@ public class DeepLTranslator implements Translator {
 		options.addPart("target_lang", targetLanguageCode);
 		options.addPart("text", text);
 		options.setMethod(Http.Method.POST);
+		options.addHeader(
+			HttpHeaders.AUTHORIZATION,
+			"DeepL-Auth-Key " + _deepLTranslatorConfiguration.authKey());
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			_invoke(options, _deepLTranslatorConfiguration.url()));


### PR DESCRIPTION
According to the documentation the authentication key for DeepL has to transfered in the header:

> The authentication key is provided by setting the Authorization HTTP
> header to DeepL-Auth-Key [yourAuthKey].

https://www.deepl.com/de/docs-api/api-access/authentication/

Experimentally it was found, that both the languages and translate endpoints need to be authenticated.