### PR TITLE
[TS] LPS-184014 Cannot auto translate web contents when context is not ROOT

### DIFF
--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -44,7 +44,6 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -114,7 +113,7 @@ public class TranslateDisplayContext {
 
 	public String getAutoTranslateURL() {
 		return PortalUtil.getPortalURL(_httpServletRequest) +
-			Portal.PATH_MODULE + "/translation/auto_translate";
+			PortalUtil.getPathModule() + "/translation/auto_translate";
 	}
 
 	public boolean getBooleanValue(


### PR DESCRIPTION
Motivation
=======
This issue ([LPS-184014](https://issues.liferay.com/browse/LPS-184014)) was reported by a customer. 

The Auto Translate button makes a request that doesn't consider a non-ROOT context in the application server. 

Proposed Solution
========
Instead of directly using `Portal.PATH_MODULE` (aka `/o`), we should use the auxiliary method `PortalUtil.getPathModule()` which will prepend the context if any. This method is used in multiple places throughout the portal.

Steps to Verify
========
Those in ([LPS-184014](https://issues.liferay.com/browse/LPS-184014)). 

Note that if you don't properly configure an external translation, you'll get the expected error: "There is a problem with the translation service. Please contact your administrator."

References to existing code
========


Checklist (optional)
========

CODE:
- [x] I have considered breaking this PR into smaller PRs if the amount of changed code is too large
- [x] I have performed a self-review of my own code following Liferay's code conventions
- [x] I have checked other areas of the product for solutions to similar problems
- [ ] I have added tests that prove my fix is effective or that my feature works

COMMITS:
- [x] My commits organize changes in coherent units
- [x] There are no commits which should be combined into others
- [x] My commits are ordered in a way that ease understanding
- [x] My commit messages are well formatted and concisely describe what was changed and why it was changed

PR TITLE & DESCRIPTION:
- [x] My PR title includes an issue number and a descriptive title
- [x] My PR description explains the motivation for this change
- [x] My PR description explains the proposed solution
- [x] My PR description includes the steps to verify the change
- [x] My PR description includes references to other places where this solution is used (if applies)
- [ ] My PR description includes visual aids to understand what has changed (if applies)
- [ ] My PR description explains alternative approaches considered and why they were discarded (if applies)