### PR TITLE
LPS-184533 With toggle controls off you can rename a widget

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -119,4 +119,8 @@ body.portlet {
 	.portlet-topper {
 		display: none !important;
 	}
+
+	.portlet-title-editable {
+		pointer-events: none;
+	}
 }


### PR DESCRIPTION
Hey,
https://issues.liferay.com/browse/LPS-184533

I made the portlet title non-editable when toggle control is off.
Please review it.

Thanks,