### PR TITLE
[TS] LPS-184728 Objects not scoped by virtual instance when COMMERCE-8087 feature flag is enabled

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -83,7 +83,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 				_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
 					companyId)) {
 
-			if (!_isBatchPlannerEnabled(entityClassName, export)) {
+			if (!_isBatchPlannerEnabled(entityClassName, export, companyId)) {
 				continue;
 			}
 
@@ -115,15 +115,15 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private boolean _isBatchPlannerEnabled(
-		String entityClassName, boolean export) {
+		String entityClassName, boolean export, long companyId) {
 
 		if (export) {
 			return _vulcanBatchEngineTaskItemDelegateRegistry.
-				isBatchPlannerExportEnabled(entityClassName);
+				isBatchPlannerExportEnabled(companyId, entityClassName);
 		}
 
 		return _vulcanBatchEngineTaskItemDelegateRegistry.
-			isBatchPlannerImportEnabled(entityClassName);
+			isBatchPlannerImportEnabled(companyId, entityClassName);
 	}
 
 	private boolean _isExport(String value) {

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -75,13 +75,13 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private Map<String, String> _getInternalClassNameCategories(
-		boolean export) {
+		boolean export, long companyId) {
 
 		Map<String, String> internalClassNameCategories = new HashMap<>();
 
 		for (String entityClassName :
-				_vulcanBatchEngineTaskItemDelegateRegistry.
-					getEntityClassNames()) {
+				_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
+					companyId)) {
 
 			if (!_isBatchPlannerEnabled(entityClassName, export)) {
 				continue;
@@ -90,7 +90,8 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 			VulcanBatchEngineTaskItemDelegate
 				vulcanBatchEngineTaskItemDelegate =
 					_vulcanBatchEngineTaskItemDelegateRegistry.
-						getVulcanBatchEngineTaskItemDelegate(entityClassName);
+						getVulcanBatchEngineTaskItemDelegate(
+							companyId, entityClassName);
 
 			internalClassNameCategories.put(
 				entityClassName,
@@ -134,11 +135,13 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private String _render(RenderRequest renderRequest) throws PortalException {
+		long companyId = _portal.getCompanyId(renderRequest);
+
 		boolean export = _isExport(
 			ParamUtil.getString(renderRequest, "navigation"));
 
 		Map<String, String> internalClassNameCategories =
-			_getInternalClassNameCategories(export);
+			_getInternalClassNameCategories(export, companyId);
 
 		long batchPlannerPlanId = ParamUtil.getLong(
 			renderRequest, "batchPlannerPlanId");
@@ -149,8 +152,8 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 					WebKeys.PORTLET_DISPLAY_CONTEXT,
 					new EditBatchPlannerPlanDisplayContext(
 						_batchPlannerPlanService.getBatchPlannerPlans(
-							_portal.getCompanyId(renderRequest), true, true,
-							QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+							companyId, true, true, QueryUtil.ALL_POS,
+							QueryUtil.ALL_POS, null),
 						internalClassNameCategories, renderRequest, null));
 
 				return "/export/edit_batch_planner_plan.jsp";

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -568,6 +568,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					).put(
 						"batch.planner.import.enabled", "true"
 					).put(
+						"companyId", objectDefinition.getCompanyId()
+					).put(
 						"entity.class.name",
 						ObjectEntry.class.getName() + "#" + osgiJaxRsName
 					).put(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 35.2.1
+Bundle-Version: 36.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
@@ -23,6 +23,12 @@ public interface VulcanBatchEngineTaskItemDelegateRegistry {
 
 	public Set<String> getEntityClassNames();
 
+	public Set<String> getEntityClassNames(long companyId);
+
+	public VulcanBatchEngineTaskItemDelegate
+		getVulcanBatchEngineTaskItemDelegate(
+			long companyId, String entityClassName);
+
 	public VulcanBatchEngineTaskItemDelegate
 		getVulcanBatchEngineTaskItemDelegate(String entityClassName);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
@@ -32,7 +32,13 @@ public interface VulcanBatchEngineTaskItemDelegateRegistry {
 	public VulcanBatchEngineTaskItemDelegate
 		getVulcanBatchEngineTaskItemDelegate(String entityClassName);
 
+	public boolean isBatchPlannerExportEnabled(
+		long companyId, String entityClassName);
+
 	public boolean isBatchPlannerExportEnabled(String entityClassName);
+
+	public boolean isBatchPlannerImportEnabled(
+		long companyId, String entityClassName);
 
 	public boolean isBatchPlannerImportEnabled(String entityClassName);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 4.4.0
+version 5.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -97,8 +97,42 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 	}
 
 	@Override
+	public boolean isBatchPlannerExportEnabled(
+		long companyId, String entityClassName) {
+
+		Boolean batchPlannerExportEnabled = _batchPlannerExportEnabledMap.get(
+			entityClassName);
+
+		if (batchPlannerExportEnabled != null) {
+			return batchPlannerExportEnabled;
+		}
+
+		Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+			_companyScopedBatchPlannerExportEnabledMap.get(companyId);
+
+		return companyBatchPlannerExportEnabledMap.get(entityClassName);
+	}
+
+	@Override
 	public boolean isBatchPlannerExportEnabled(String entityClassName) {
 		return _batchPlannerExportEnabledMap.get(entityClassName);
+	}
+
+	@Override
+	public boolean isBatchPlannerImportEnabled(
+		long companyId, String entityClassName) {
+
+		Boolean batchPlannerImportEnabled = _batchPlannerImportEnabledMap.get(
+			entityClassName);
+
+		if (batchPlannerImportEnabled != null) {
+			return batchPlannerImportEnabled;
+		}
+
+		Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+			_companyScopedBatchPlannerImportEnabledMap.get(companyId);
+
+		return companyBatchPlannerImportEnabledMap.get(entityClassName);
 	}
 
 	@Override
@@ -130,6 +164,10 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 		new HashMap<>();
 	private final Map<String, Boolean> _batchPlannerImportEnabledMap =
 		new HashMap<>();
+	private final Map<Long, Map<String, Boolean>>
+		_companyScopedBatchPlannerExportEnabledMap = new HashMap<>();
+	private final Map<Long, Map<String, Boolean>>
+		_companyScopedBatchPlannerImportEnabledMap = new HashMap<>();
 	private final Map<Long, Map<String, VulcanBatchEngineTaskItemDelegate<?>>>
 		_companyScopedVulcanBatchEngineTaskItemDelegateMap = new HashMap<>();
 	private ServiceTracker<?, ?> _serviceTracker;
@@ -153,27 +191,59 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
-			_batchPlannerExportEnabledMap.put(
-				entityClassName,
-				GetterUtil.getBoolean(
-					serviceReference.getProperty(
-						"batch.planner.export.enabled")));
-
-			_batchPlannerImportEnabledMap.put(
-				entityClassName,
-				GetterUtil.getBoolean(
-					serviceReference.getProperty(
-						"batch.planner.import.enabled")));
-
 			Object companyIdProperty = serviceReference.getProperty(
 				"companyId");
 
 			if (companyIdProperty == null) {
+				_batchPlannerExportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.export.enabled")));
+
+				_batchPlannerImportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.import.enabled")));
+
 				_vulcanBatchEngineTaskItemDelegateMap.put(
 					entityClassName, vulcanBatchEngineTaskItemDelegate);
 			}
 			else {
 				long companyId = GetterUtil.getLong(companyIdProperty);
+
+				Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+					_companyScopedBatchPlannerExportEnabledMap.get(companyId);
+
+				if (companyBatchPlannerExportEnabledMap == null) {
+					companyBatchPlannerExportEnabledMap = new HashMap<>();
+
+					_companyScopedBatchPlannerExportEnabledMap.put(
+						companyId, companyBatchPlannerExportEnabledMap);
+				}
+
+				companyBatchPlannerExportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.export.enabled")));
+
+				Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+					_companyScopedBatchPlannerImportEnabledMap.get(companyId);
+
+				if (companyBatchPlannerImportEnabledMap == null) {
+					companyBatchPlannerImportEnabledMap = new HashMap<>();
+
+					_companyScopedBatchPlannerImportEnabledMap.put(
+						companyId, companyBatchPlannerImportEnabledMap);
+				}
+
+				companyBatchPlannerImportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.import.enabled")));
 
 				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
 					companyVulcanBatchEngineTaskItemDelegateMap =
@@ -213,21 +283,33 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
-			_batchPlannerExportEnabledMap.remove(entityClassName);
-
-			_batchPlannerImportEnabledMap.remove(entityClassName);
-
 			Object companyIdProperty = serviceReference.getProperty(
 				"companyId");
 
 			if (companyIdProperty == null) {
+				_batchPlannerExportEnabledMap.remove(entityClassName);
+
+				_batchPlannerImportEnabledMap.remove(entityClassName);
+
 				_vulcanBatchEngineTaskItemDelegateMap.remove(entityClassName);
 			}
 			else {
+				long companyId = GetterUtil.getLong(companyIdProperty);
+
+				Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+					_companyScopedBatchPlannerExportEnabledMap.get(companyId);
+
+				companyBatchPlannerExportEnabledMap.remove(entityClassName);
+
+				Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+					_companyScopedBatchPlannerImportEnabledMap.get(companyId);
+
+				companyBatchPlannerImportEnabledMap.remove(entityClassName);
+
 				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
 					companyVulcanBatchEngineTaskItemDelegateMap =
 						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
-							GetterUtil.getLong(companyIdProperty));
+							companyId);
 
 				companyVulcanBatchEngineTaskItemDelegateMap.remove(
 					entityClassName);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -85,6 +85,8 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 		new HashMap<>();
 	private final Map<String, Boolean> _batchPlannerImportEnabledMap =
 		new HashMap<>();
+	private final Map<Long, Map<String, VulcanBatchEngineTaskItemDelegate<?>>>
+		_companyScopedVulcanBatchEngineTaskItemDelegateMap = new HashMap<>();
 	private ServiceTracker<?, ?> _serviceTracker;
 	private final Map<String, VulcanBatchEngineTaskItemDelegate<?>>
 		_vulcanBatchEngineTaskItemDelegateMap = new HashMap<>();
@@ -118,8 +120,32 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 					serviceReference.getProperty(
 						"batch.planner.import.enabled")));
 
-			_vulcanBatchEngineTaskItemDelegateMap.put(
-				entityClassName, vulcanBatchEngineTaskItemDelegate);
+			Object companyIdProperty = serviceReference.getProperty(
+				"companyId");
+
+			if (companyIdProperty == null) {
+				_vulcanBatchEngineTaskItemDelegateMap.put(
+					entityClassName, vulcanBatchEngineTaskItemDelegate);
+			}
+			else {
+				long companyId = GetterUtil.getLong(companyIdProperty);
+
+				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+					companyVulcanBatchEngineTaskItemDelegateMap =
+						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+							companyId);
+
+				if (companyVulcanBatchEngineTaskItemDelegateMap == null) {
+					companyVulcanBatchEngineTaskItemDelegateMap =
+						new HashMap<>();
+
+					_companyScopedVulcanBatchEngineTaskItemDelegateMap.put(
+						companyId, companyVulcanBatchEngineTaskItemDelegateMap);
+				}
+
+				companyVulcanBatchEngineTaskItemDelegateMap.put(
+					entityClassName, vulcanBatchEngineTaskItemDelegate);
+			}
 
 			return vulcanBatchEngineTaskItemDelegate;
 		}
@@ -146,7 +172,21 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 
 			_batchPlannerImportEnabledMap.remove(entityClassName);
 
-			_vulcanBatchEngineTaskItemDelegateMap.remove(entityClassName);
+			Object companyIdProperty = serviceReference.getProperty(
+				"companyId");
+
+			if (companyIdProperty == null) {
+				_vulcanBatchEngineTaskItemDelegateMap.remove(entityClassName);
+			}
+			else {
+				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+					companyVulcanBatchEngineTaskItemDelegateMap =
+						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+							GetterUtil.getLong(companyIdProperty));
+
+				companyVulcanBatchEngineTaskItemDelegateMap.remove(
+					entityClassName);
+			}
 		}
 
 		private VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateRegistry;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,6 +43,50 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 	@Override
 	public Set<String> getEntityClassNames() {
 		return _vulcanBatchEngineTaskItemDelegateMap.keySet();
+	}
+
+	@Override
+	public Set<String> getEntityClassNames(long companyId) {
+		Set<String> entityClassNames = new HashSet<>();
+
+		entityClassNames.addAll(_vulcanBatchEngineTaskItemDelegateMap.keySet());
+
+		Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+			companyVulcanBatchEngineTaskItemDelegateMap =
+				_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+					companyId);
+
+		if (companyVulcanBatchEngineTaskItemDelegateMap != null) {
+			entityClassNames.addAll(
+				companyVulcanBatchEngineTaskItemDelegateMap.keySet());
+		}
+
+		return entityClassNames;
+	}
+
+	@Override
+	public VulcanBatchEngineTaskItemDelegate<?>
+		getVulcanBatchEngineTaskItemDelegate(
+			long companyId, String entityClassName) {
+
+		VulcanBatchEngineTaskItemDelegate<?> vulcanBatchEngineTaskItemDelegate =
+			_vulcanBatchEngineTaskItemDelegateMap.get(entityClassName);
+
+		if (vulcanBatchEngineTaskItemDelegate != null) {
+			return vulcanBatchEngineTaskItemDelegate;
+		}
+
+		Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+			companyVulcanBatchEngineTaskItemDelegateMap =
+				_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+					companyId);
+
+		if (companyVulcanBatchEngineTaskItemDelegateMap != null) {
+			return companyVulcanBatchEngineTaskItemDelegateMap.get(
+				entityClassName);
+		}
+
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
Ticket: [LPS-184728](https://issues.liferay.com/browse/LPS-184728).

I included c5624c24b21e7d17a29cea0a752a09fd35207223 and 207558ba0715e63a2ad9dddc62fbd0275aac2167 because I saw that if multiple companies had Object Definitions with the same name, it would try to register them with the same entity name. However, after testing it, I also noticed that there were bugs that seemed to prevent the services from being registered/unregistered successfully in this case. This is something we should fix eventually, but I think it is out of the scope of this ticket. I'm not sure whether the proper fix for it would be to alter the entityName to be based on the companyId in addition to the ObjectDefinition name (so that the entityName is unique). If that is the proper fix, then we can revert those two commits.