### PR TITLE
LPS-187977 Remove VIEW permissions to Guest users this will stop including Staging Bar portlet javascript headers when the user is Guest

### DIFF
--- a/modules/apps/staging/staging-bar-web/src/main/resources/portlet.properties
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/portlet.properties
@@ -1,0 +1,7 @@
+include-and-override=portlet-ext.properties
+
+#
+# Input a list of comma delimited resource action configurations that will be
+# read from the class path.
+#
+resource.actions.configs=resource-actions/default.xml

--- a/modules/apps/staging/staging-bar-web/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/resource-actions/default.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!DOCTYPE resource-action-mapping PUBLIC "-//Liferay//DTD Resource Action Mapping 7.4.0//EN" "http://www.liferay.com/dtd/liferay-resource-action-mapping_7_4_0.dtd">
+
+<resource-action-mapping>
+	<portlet-resource>
+		<portlet-name>com_liferay_staging_bar_web_portlet_StagingBarPortlet</portlet-name>
+		<permissions>
+			<supports>
+				<action-key>VIEW</action-key>
+			</supports>
+			<site-member-defaults>
+				<action-key>VIEW</action-key>
+			</site-member-defaults>
+			<guest-defaults />
+			<guest-unsupported>
+				<action-key>VIEW</action-key>
+			</guest-unsupported>
+		</permissions>
+	</portlet-resource>
+</resource-action-mapping>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-187977

Guest users never have access to the StagingBarPortlet but its javascript headers are always included to the page.
This increases page size, penalizing SEO score.

To avoid the issue I am removing the VIEW permission to the Guest users, this will prevent the frontend infraestructure from adding the javascript header when generating the page headers.
After analyzing current logic where the javascript headers are added, I don't think there is other alternative without manually hardcoding some Staging logic on the Frontend side.

For more information about this frontend logic, see:
 - https://github.com/liferay/liferay-portal/blob/bc45ce41d977adbdffd7e2fdd5ea15e82fb58acb/portal-web/docroot/html/common/themes/top_head.jsp#L34
 - https://github.com/liferay/liferay-portal/blob/bc45ce41d977adbdffd7e2fdd5ea15e82fb58acb/portal-web/docroot/html/common/themes/top_portlet_resources_js.jspf#L20
 - https://github.com/liferay/liferay-portal/blob/bc45ce41d977adbdffd7e2fdd5ea15e82fb58acb/portal-kernel/src/com/liferay/portal/kernel/portlet/render/PortletRenderUtil.java#L147
 
If a portlet doesn't have any defined `portlet.properties` and `resource-actions/default.xml` files, the default effective permissions are: https://github.com/liferay/liferay-portal/blob/bc45ce41d977adbdffd7e2fdd5ea15e82fb58acb/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java#L752-L792:

- **Owner:** ACCESS_IN_CONTROL_PANEL, ADD_TO_PAGE, CONFIGURATION, PERMISSIONS, PREFERENCES, VIEW
- **Group:** VIEW 
- **Guest:** VIEW

With my changes, I am setting the default permissions of StagingBarPortlet:
- **Owner:** VIEW
- **Group:** VIEW 
- **Guest:** None
- **Guest unsupported:** VIEW

Let me know if you need more information