### PR TITLE
[TS] LPS-188466 importing fragments with global scoped sitenavmenu fails

### DIFF
--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/exportimport/data/handler/SiteNavigationMenuStagedModelDataHandler.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/exportimport/data/handler/SiteNavigationMenuStagedModelDataHandler.java
@@ -22,6 +22,8 @@ import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.site.navigation.model.SiteNavigationMenu;
 
+import java.util.Map;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -59,6 +61,28 @@ public class SiteNavigationMenuStagedModelDataHandler
 			siteNavigationMenuElement,
 			ExportImportPathUtil.getModelPath(siteNavigationMenu),
 			siteNavigationMenu);
+	}
+
+	@Override
+	protected void doImportMissingReference(
+			PortletDataContext portletDataContext, String uuid, long groupId,
+			long siteNavigationMenuId)
+		throws Exception {
+
+		SiteNavigationMenu existingSiteNavigationMenu = fetchMissingReference(
+			uuid, groupId);
+
+		if (existingSiteNavigationMenu == null) {
+			return;
+		}
+
+		Map<Long, Long> siteNavigationMenuIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				SiteNavigationMenu.class);
+
+		siteNavigationMenuIds.put(
+			siteNavigationMenuId,
+			existingSiteNavigationMenu.getSiteNavigationMenuId());
 	}
 
 	@Override


### PR DESCRIPTION
Hi Team,

Could you please review this pull request?
https://liferay.atlassian.net/browse/LPS-188466
Thank you!

----
**Reproduction Steps:**

1. Go to the Global Site --> Site Builder --> Navigation menus and add a navigation menu and add to it a URL element (http://www.google.com/)
2. Go to Control Panel --> Sites --> Sites and create a blank site
3. On the Site, go to Design --> Fragments and add a fragment set then create a basic fragment and change its configuration by pasting the following:

```
{

  "fieldSets": [

    {

      "label": "",

      "fields": [

        {

          "name": "source",

          "description": "",

          "label": "Source",

          "type": "navigationMenuSelector"

        }

      ]

    },

    {

      "configurationRole": "style",

      "label": "",

      "fields": [

        {

          "name": "hoveredItemColor",

          "description": "",

          "label": "Couleur de lélément survolé",

          "type": "colorPicker"

        },

        {

          "name": "selectedItemColor",

          "description": "",

          "label": "Couleur de lélément sélectionné",

          "type": "colorPicker"

        }

      ]

    }

  ]

}

```


4. Go to Site Builder --> Pages and add a content (blank) page and add the created fragment to it, then click the fragment (it is so thin to be noticed). Change the “Pages Hierarchy” source by selecting the created navigation menu and then click on “Select this level”, then publish the page.

5. Go to Publishing --> Export and export the Site and download the LAR.

6. Go to Publishing --> Import and import the LAR into the same site.


**Expected Result:*** The import is successful with no issues.
**Actual Result:** The import fails with a UI error:

```
An unexpected error occurred with the publish process. Please check your portal and publishing configuration.
java.lang.UnsupportedOperationException

```
**Solution:**
If there's a reference from a regular site to the global (or basically any other) site, they will be exported as "missing reference". This was not handled in case of the SiteNavigationMenus, so I implemented doImportMissingReference method to do so.
