### PR TITLE
LPS-187926 Cannot save workflow when Scripted Assignment script language is not manually selected

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/serializeUtil.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/serializeUtil.js
@@ -264,7 +264,7 @@ function appendXMLAssignments(
 					XMLUtil.create('script', cdata(item)),
 					createTagWithEscapedContent(
 						'scriptLanguage',
-						dataAssignments.scriptLanguage
+						dataAssignments.scriptLanguage || DEFAULT_LANGUAGE
 					),
 					xmlScriptedAssignment.close
 				);


### PR DESCRIPTION
A solution to LPS-187926 was originally sent with a solution to LPS-186252 in https://github.com/liferay-workflow/liferay-portal/pull/942, but a new solution just for LPS-186252 was sent separately.

Please let me know if you have any questions.

Thanks!

