### PR TITLE
LPS-188818 - Keep pagination info when navigating tabs

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -57,6 +57,7 @@ interface IFDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 }
 
@@ -140,6 +141,11 @@ const FDSView = ({
 						fdsView={fdsView}
 						fdsViewsURL={fdsViewsURL}
 						namespace={namespace}
+						onFDSViewUpdate={(
+							updatedViewData: FDSViewType
+						): void => {
+							setFDSView({...fdsView, ...updatedViewData});
+						}}
 						saveFDSFieldsURL={saveFDSFieldsURL}
 					/>
 				)

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
@@ -27,6 +27,7 @@ const Details = ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface) => {
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
@@ -70,6 +71,8 @@ const Details = ({
 					fdsViewLabelRef.current?.value ?? ''
 				);
 			}
+
+			onFDSViewUpdate(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
@@ -27,6 +27,7 @@ function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface) {
 	const [listOfItemsPerPage, setListOfItemsPerPage] = useState(
 		fdsView.listOfItemsPerPage
@@ -131,7 +132,8 @@ function Pagination({
 				),
 				type: 'success',
 			});
-			setListOfItemsPerPage(itemsPerPage);
+
+			onFDSViewUpdate(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -22,6 +22,7 @@ interface IFDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 }
 interface IFDSViewInterface {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
@@ -19,5 +19,6 @@ declare const Details: ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface) => JSX.Element;
 export default Details;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
@@ -19,5 +19,6 @@ declare function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface): JSX.Element;
 export default Pagination;


### PR DESCRIPTION
Follows https://github.com/liferay-frontend/liferay-portal/pull/3502

### Problem
In the FDS View component the user could change information using the different tabs available. When a user changes the pagination info , save it, navigate to other tab and come back to the Pagination one, the old information is still visible.
The same problem occurs in the Details tab.

When the FDS View first render, it request the **general view** data, that is passed as a prop to the different tabs. To trigger a new data request the only dependency is the viewId, that it is something that does not change among the tabs, so whenever a user changes the tab, is loading stale **general view** data. This is also happening with the other tabs, but don't have relevant data to update the UI.

### Proposed solution
The parent FDS View passes an update function to the components that need to update the view after saving the data.
In the current PR, I'm only passing the callback to the Details and Pagination tabs, but could be passed to all of them to be consistent. 

### Before
[before.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/415b2f81-b2bc-4a76-a9f7-f4540c96046f)

### After
[after.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/a18ca721-df08-434a-9201-a4701776cea8)