### PR TITLE
[Remove Blocking usages]Lps 188914 7 6 2

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/asset/auto/tagger/text/extractor/FileEntryTextExtractor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/asset/auto/tagger/text/extractor/FileEntryTextExtractor.java
@@ -20,13 +20,13 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.util.FileUtil;
 
 import java.io.InputStream;
 
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alicia García
@@ -43,7 +43,7 @@ public class FileEntryTextExtractor implements TextExtractor<FileEntry> {
 			try (InputStream inputStream = fileVersion.getContentStream(
 					false)) {
 
-				return FileUtil.extractText(inputStream);
+				return _textExtractor.extractText(inputStream, -1);
 			}
 		}
 		catch (Exception exception) {
@@ -60,5 +60,8 @@ public class FileEntryTextExtractor implements TextExtractor<FileEntry> {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		FileEntryTextExtractor.class);
+
+	@Reference
+	private com.liferay.portal.kernel.util.TextExtractor _textExtractor;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.RelatedEntryIndexer;
 import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -48,6 +47,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextExtractor;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
@@ -280,7 +280,7 @@ public class DLFileEntryModelDocumentContributor
 			return null;
 		}
 
-		String text = FileUtil.extractText(
+		String text = _textExtractor.extractText(
 			inputStream, PropsValues.DL_FILE_INDEXING_MAX_SIZE);
 
 		if (Validator.isNotNull(text)) {
@@ -365,6 +365,9 @@ public class DLFileEntryModelDocumentContributor
 
 	@Reference
 	private RelatedEntryIndexerRegistry _relatedEntryIndexerRegistry;
+
+	@Reference
+	private TextExtractor _textExtractor;
 
 	@Reference
 	private TrashHelper _trashHelper;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -36,11 +36,11 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextExtractor;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.test.rule.Inject;
@@ -160,9 +160,10 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 	}
 
 	private String _getContents(FileEntry fileEntry) throws Exception {
-		String contents = FileUtil.extractText(
+		String contents = _textExtractor.extractText(
 			_dlFileEntryLocalService.getFileAsStream(
-				fileEntry.getFileEntryId(), fileEntry.getVersion(), false));
+				fileEntry.getFileEntryId(), fileEntry.getVersion(), false),
+			-1);
 
 		return contents.trim();
 	}
@@ -416,5 +417,8 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	private FileEntrySearchFixture _fileEntrySearchFixture;
+
+	@Inject
+	private TextExtractor _textExtractor;
 
 }

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
@@ -66,7 +66,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.upload.FileItem;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -74,6 +73,7 @@ import com.liferay.portal.kernel.util.ProgressTracker;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextExtractor;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
@@ -600,7 +600,8 @@ public class EditInfoItemStrutsActionTest {
 			Assert.assertEquals(
 				attachmentValue,
 				StringUtil.removeSubstring(
-					FileUtil.extractText(dlFileEntry.getContentStream()),
+					_textExtractor.extractText(
+						dlFileEntry.getContentStream(), -1),
 					StringPool.NEW_LINE));
 		}
 
@@ -722,6 +723,9 @@ public class EditInfoItemStrutsActionTest {
 
 	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Inject
+	private TextExtractor _textExtractor;
 
 	private User _user;
 

--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -328,17 +328,6 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 	}
 
 	@Override
-	public String extractText(InputStream inputStream) {
-		return extractText(inputStream, -1);
-	}
-
-	@Override
-	public String extractText(InputStream inputStream, int maxStringLength) {
-		return TextExtractorHolder._textExtractor.extractText(
-			inputStream, maxStringLength);
-	}
-
-	@Override
 	public String getAbsolutePath(File file) {
 		return StringUtil.replace(
 			file.getAbsolutePath(), CharPool.BACK_SLASH, CharPool.SLASH);

--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -28,11 +28,9 @@ import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.FileComparator;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PwdGenerator;
-import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
-import com.liferay.portal.kernel.util.TextExtractor;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -969,14 +967,5 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 	private static final Log _log = LogFactoryUtil.getLog(FileImpl.class);
 
 	private static final FileImpl _fileImpl = new FileImpl();
-
-	private static class TextExtractorHolder {
-
-		private static volatile TextExtractor _textExtractor =
-			ServiceProxyFactory.newServiceTrackedInstance(
-				TextExtractor.class, TextExtractorHolder.class,
-				"_textExtractor", true);
-
-	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
@@ -46,15 +46,43 @@ public interface Document extends Cloneable, Serializable {
 
 	public void addDateSortable(String name, Date[] values);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	public void addFile(String name, byte[] bytes, String fileExt)
 		throws IOException;
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	public void addFile(String name, File file, String fileExt)
 		throws IOException;
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	public void addFile(String name, InputStream inputStream, String fileExt)
 		throws IOException;
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	public void addFile(
 			String name, InputStream inputStream, String fileExt,
 			int maxStringLength)

--- a/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -16,12 +16,10 @@ package com.liferay.portal.kernel.search;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.search.geolocation.GeoLocationPoint;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -30,7 +28,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -128,33 +125,57 @@ public class DocumentImpl implements Document {
 		addKeyword(name, datesString);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	@Override
 	public void addFile(String name, byte[] bytes, String fileExt) {
-		InputStream inputStream = new UnsyncByteArrayInputStream(bytes);
-
-		addFile(name, inputStream, fileExt);
+		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	@Override
 	public void addFile(String name, File file, String fileExt)
 		throws IOException {
 
-		InputStream inputStream = new FileInputStream(file);
-
-		addFile(name, inputStream, fileExt);
+		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	@Override
 	public void addFile(String name, InputStream inputStream, String fileExt) {
-		addText(name, FileUtil.extractText(inputStream));
+		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), no direct replacement but can be
+	 * replaced by combine calling com.liferay.portal.kernel.util.TextExtractor.
+	 * extractText(InputStream inputStream, int maxStringLength) and addText(
+	 * String name, String value)
+	 */
+	@Deprecated
 	@Override
 	public void addFile(
 		String name, InputStream inputStream, String fileExt,
 		int maxStringLength) {
 
-		addText(name, FileUtil.extractText(inputStream, maxStringLength));
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/util/File.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/File.java
@@ -78,10 +78,6 @@ public interface File {
 
 	public boolean exists(String fileName);
 
-	public String extractText(InputStream inputStream);
-
-	public String extractText(InputStream inputStream, int maxStringLength);
-
 	public String getAbsolutePath(java.io.File file);
 
 	public byte[] getBytes(Class<?> clazz, String fileName) throws IOException;

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FileUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FileUtil.java
@@ -134,25 +134,6 @@ public class FileUtil {
 		return _file.exists(fileName);
 	}
 
-	/**
-	 * Extracts the text from the input stream and file name.
-	 *
-	 * @param  inputStream the file's input stream
-	 * @param  fileName the file's full name or extension (e.g., "Test.doc" or
-	 *         ".doc")
-	 * @return the extracted text if it is a supported format or an empty string
-	 *         if it is an unsupported format
-	 */
-	public static String extractText(InputStream inputStream) {
-		return _file.extractText(inputStream);
-	}
-
-	public static String extractText(
-		InputStream inputStream, int maxStringLength) {
-
-		return _file.extractText(inputStream, maxStringLength);
-	}
-
 	public static String getAbsolutePath(File file) {
 		return _file.getAbsolutePath(file);
 	}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/MockFile.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/MockFile.java
@@ -139,16 +139,6 @@ public class MockFile implements com.liferay.portal.kernel.util.File {
 	}
 
 	@Override
-	public String extractText(InputStream inputStream) {
-		return null;
-	}
-
-	@Override
-	public String extractText(InputStream inputStream, int maxStringLength) {
-		return null;
-	}
-
-	@Override
 	public String getAbsolutePath(File file) {
 		return null;
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-188914

This pull deprecate these unused methods from the interface Document instead of removing them directly which aims to remove the unnecessary usages of ServiceProxyFactory.newServiceTrackedInstance with blocking set to true in class FileImpl