### PR TITLE
LPS-191479 - Normalized URL doesn't point to the same source as the accented version did

### DIFF
--- a/modules/apps/friendly-url/friendly-url-api/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL API
 Bundle-SymbolicName: com.liferay.friendly.url.api
-Bundle-Version: 6.4.2
+Bundle-Version: 6.5.0
 Export-Package:\
 	com.liferay.friendly.url.configuration,\
 	com.liferay.friendly.url.exception,\

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -244,7 +244,17 @@ public interface FriendlyURLEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, Class<?> clazz, String urlTitle,
+		boolean normalizeWithAccent);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle,
+		boolean normalizeWithAccent);
 
 	/**
 	 * Returns the friendly url entry matching the UUID and group.

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -282,10 +282,26 @@ public class FriendlyURLEntryLocalServiceUtil {
 	}
 
 	public static FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, Class<?> clazz, String urlTitle,
+		boolean normalizeWithAccent) {
+
+		return getService().fetchFriendlyURLEntry(
+			groupId, clazz, urlTitle, normalizeWithAccent);
+	}
+
+	public static FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle) {
 
 		return getService().fetchFriendlyURLEntry(
 			groupId, classNameId, urlTitle);
+	}
+
+	public static FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle,
+		boolean normalizeWithAccent) {
+
+		return getService().fetchFriendlyURLEntry(
+			groupId, classNameId, urlTitle, normalizeWithAccent);
 	}
 
 	/**

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -316,10 +316,28 @@ public class FriendlyURLEntryLocalServiceWrapper
 
 	@Override
 	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, Class<?> clazz, String urlTitle,
+		boolean normalizeWithAccent) {
+
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+			groupId, clazz, urlTitle, normalizeWithAccent);
+	}
+
+	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle) {
 
 		return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
 			groupId, classNameId, urlTitle);
+	}
+
+	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle,
+		boolean normalizeWithAccent) {
+
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+			groupId, classNameId, urlTitle, normalizeWithAccent);
 	}
 
 	/**

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -301,12 +301,37 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	@Override
 	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, Class<?> clazz, String urlTitle,
+		boolean normalizeWithAccent) {
+
+		return fetchFriendlyURLEntry(
+			groupId, _classNameLocalService.getClassNameId(clazz), urlTitle,
+			normalizeWithAccent);
+	}
+
+	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle) {
+
+		return fetchFriendlyURLEntry(groupId, classNameId, urlTitle, false);
+	}
+
+	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String urlTitle,
+		boolean normalizeWithAccent) {
 
 		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
 			friendlyURLEntryLocalizationPersistence.fetchByG_C_U_First(
 				groupId, classNameId,
 				_friendlyURLNormalizer.normalizeWithEncoding(urlTitle), null);
+
+		if (normalizeWithAccent && (friendlyURLEntryLocalization == null)) {
+			friendlyURLEntryLocalization =
+				friendlyURLEntryLocalizationPersistence.fetchByG_C_U_First(
+					groupId, classNameId,
+					_friendlyURLNormalizer.normalize(urlTitle), null);
+		}
 
 		if (friendlyURLEntryLocalization != null) {
 			return friendlyURLEntryPersistence.fetchByPrimaryKey(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1932,7 +1932,7 @@ public class JournalArticleLocalServiceImpl
 
 		FriendlyURLEntry friendlyURLEntry =
 			friendlyURLEntryLocalService.fetchFriendlyURLEntry(
-				groupId, JournalArticle.class, urlTitle);
+				groupId, JournalArticle.class, urlTitle, true);
 
 		if (friendlyURLEntry != null) {
 			JournalArticle article = fetchLatestArticle(


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPS-191479
@dacousalr
 
Rebase Error

# Problem Description
Previously, it was possible to create web content containing accented links in the application. However, due to recent changes, this functionality was removed, resulting in broken accented links for customers who created content during the period when this option was available. This situation has caused disruptions and a negative impact on the user experience, as well as the integrity of friendly URLs.

# Solution Objective
The proposed solution aims to restore the functionality of the existing accented links, allowing them to function correctly, even though it will no longer be possible to create new links with accents in the future. The focus is on ensuring the continuity of the integrity of friendly URLs and providing a consistent user experience.