### PR TITLE
[TS] LPS-183708 - Language.properties should be used if no language key exists for a specific locale

### DIFF
--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
@@ -142,13 +142,12 @@ public class LanguageResourcesExtender
 
 			String urlPath = url.getPath();
 
-			String languageId = "";
+			String languageId = StringPool.BLANK;
 
-			int start = path.length() + name.length() + 2;
-			int end = urlPath.length() - ".properties".length();
-
-			if (start < end) {
-				languageId = urlPath.substring(start, end);
+			if (urlPath.contains(StringPool.UNDERLINE)) {
+				languageId = urlPath.substring(
+					path.length() + name.length() + 2,
+					urlPath.length() - ".properties".length());
 			}
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
@@ -131,7 +131,7 @@ public class LanguageResourcesExtender
 		}
 
 		Enumeration<URL> enumeration = bundle.findEntries(
-			path, name.concat("_*.properties"), false);
+			path, name.concat("*.properties"), false);
 
 		if (enumeration == null) {
 			return;
@@ -142,9 +142,14 @@ public class LanguageResourcesExtender
 
 			String urlPath = url.getPath();
 
-			String languageId = urlPath.substring(
-				path.length() + name.length() + 2,
-				urlPath.length() - ".properties".length());
+			String languageId = "";
+
+			int start = path.length() + name.length() + 2;
+			int end = urlPath.length() - ".properties".length();
+
+			if (start < end) {
+				languageId = urlPath.substring(start, end);
+			}
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);
 

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -63,6 +63,41 @@ public class LanguageResourcesTest {
 	}
 
 	@Test
+	public void testLanguageResource() {
+		String key = "year";
+
+		String defaultValue = _language.get(new Locale("", ""), key);
+		String frenchValue = _language.get(LocaleUtil.FRANCE, key);
+
+		Locale defaultLocale = LocaleUtil.FRANCE;
+
+		LocaleUtil.setDefault(
+			defaultLocale.getLanguage(), defaultLocale.getCountry(),
+			defaultLocale.getVariant());
+
+		Assert.assertEquals(
+			frenchValue, _language.get(LocaleUtil.getDefault(), key, null));
+
+		Locale locale = new Locale("ps", "AF");
+
+		_serviceRegistration1 = _bundleContext.registerService(
+			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
+			HashMapDictionaryBuilder.<String, Object>put(
+				Constants.SERVICE_RANKING, 0
+			).put(
+				"language.id", _language.getLanguageId(locale)
+			).build());
+
+		Assert.assertEquals(
+			_VALUE_1,
+			_language.get(locale, TestResourceBundle.class.getName(), null));
+		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
+
+		LocaleUtil.setDefault(
+			_locale.getLanguage(), _locale.getCountry(), _locale.getVariant());
+	}
+
+	@Test
 	public void testLanguageResourceServiceTrackerCustomizer() {
 		_assertValue(null);
 

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -66,35 +66,14 @@ public class LanguageResourcesTest {
 	public void testLanguageResource() {
 		String key = "year";
 
-		String defaultValue = _language.get(new Locale("", ""), key);
-		String frenchValue = _language.get(LocaleUtil.FRANCE, key);
-
-		Locale defaultLocale = LocaleUtil.FRANCE;
-
-		LocaleUtil.setDefault(
-			defaultLocale.getLanguage(), defaultLocale.getCountry(),
-			defaultLocale.getVariant());
+		String expectedTranslation = "Year";
 
 		Assert.assertEquals(
-			frenchValue, _language.get(LocaleUtil.getDefault(), key, null));
+			expectedTranslation, _language.get(_locale, key, null));
 
-		Locale locale = new Locale("ps", "AF");
+		_serviceRegistration1 = _register(_VALUE_1, 0, _languageId);
 
-		_serviceRegistration1 = _bundleContext.registerService(
-			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
-			HashMapDictionaryBuilder.<String, Object>put(
-				Constants.SERVICE_RANKING, 0
-			).put(
-				"language.id", _language.getLanguageId(locale)
-			).build());
-
-		Assert.assertEquals(
-			_VALUE_1,
-			_language.get(locale, TestResourceBundle.class.getName(), null));
-		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
-
-		LocaleUtil.setDefault(
-			_locale.getLanguage(), _locale.getCountry(), _locale.getVariant());
+		_assertValue(_VALUE_1, _locale);
 	}
 
 	@Test
@@ -155,19 +134,64 @@ public class LanguageResourcesTest {
 		_assertValue(null);
 	}
 
+	@Test
+	public void testLanguageResourceUsingSupportedLocale() {
+		String key = "year";
+
+		String expectedTranslation = "Année";
+
+		Locale locale = LocaleUtil.FRANCE;
+
+		Assert.assertEquals(
+			expectedTranslation, _language.get(locale, key, null));
+
+		_serviceRegistration1 = _register(
+			_VALUE_1, 0, _language.getLanguageId(locale));
+
+		_assertValue(_VALUE_1, locale);
+	}
+
+	@Test
+	public void testLanguageResourceUsingUnsupportedLocale() {
+		String key = "year";
+
+		String expectedBaseLanguagePropertiesTranslation = "Year";
+
+		Locale locale = new Locale("ps", "AF");
+
+		Assert.assertEquals(
+			expectedBaseLanguagePropertiesTranslation,
+			_language.get(locale, key, null));
+
+		_serviceRegistration1 = _register(
+			_VALUE_1, 0, _language.getLanguageId(locale));
+
+		_assertValue(_VALUE_1, locale);
+	}
+
 	private void _assertValue(String expectedValue) {
+		_assertValue(expectedValue, _locale);
+	}
+
+	private void _assertValue(String expectedValue, Locale locale) {
 		Assert.assertEquals(
 			expectedValue,
-			_language.get(_locale, TestResourceBundle.class.getName(), null));
+			_language.get(locale, TestResourceBundle.class.getName(), null));
 	}
 
 	private ServiceRegistration<?> _register(String value, int serviceRanking) {
+		return _register(value, serviceRanking, _languageId);
+	}
+
+	private ServiceRegistration<?> _register(
+		String value, int serviceRanking, String languageId) {
+
 		return _bundleContext.registerService(
 			ResourceBundle.class, new TestResourceBundle(value),
 			HashMapDictionaryBuilder.<String, Object>put(
 				Constants.SERVICE_RANKING, serviceRanking
 			).put(
-				"language.id", _languageId
+				"language.id", languageId
 			).build());
 	}
 


### PR DESCRIPTION
This fix addresses an issue where we currently default to the default locale language bundle instead of the Language.properties file (which is what we should be defaulting to, per our documentation). The fix involves making sure that we include the default Language.properties file when loading our language resources. A test is included as well. For more context see the PTR here: https://liferay.atlassian.net/browse/PTR-3987

Please let me know if there's any questions or concerns. Thanks!

CC: @ericyanLr 