### PR TITLE
LPS-194725 - Support doc links do not render

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -241,16 +241,16 @@ renderResponse.setTitle(categoryDisplayName);
 							</c:choose>
 
 							<aui:button cssClass="ml-3" href="<%= redirect %>" name="cancel" type="cancel" />
-
-							<c:if test="<%= Validator.isNotNull(configurationModel.getLiferayLearnMessageKey()) && Validator.isNotNull(configurationModel.getLiferayLearnMessageResource()) %>">
-								<div class="btn float-right">
-									<liferay-learn:message
-										key="<%= configurationModel.getLiferayLearnMessageKey() %>"
-										resource="<%= configurationModel.getLiferayLearnMessageResource() %>"
-									/>
-								</div>
-							</c:if>
 						</aui:button-row>
+
+						<c:if test="<%= Validator.isNotNull(configurationModel.getLiferayLearnMessageKey()) && Validator.isNotNull(configurationModel.getLiferayLearnMessageResource()) %>">
+							<div class="float-right">
+								<liferay-learn:message
+									key="<%= configurationModel.getLiferayLearnMessageKey() %>"
+									resource="<%= configurationModel.getLiferayLearnMessageResource() %>"
+								/>
+							</div>
+						</c:if>
 					</c:if>
 				</aui:form>
 			</clay:sheet>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -230,27 +230,27 @@ renderResponse.setTitle(categoryDisplayName);
 					<liferay-util:dynamic-include key='<%= "com.liferay.configuration.admin.web#/edit_configuration.jsp#" + configurationModel.getFactoryPid() + "#post" %>' />
 
 					<c:if test="<%= !configurationModel.isReadOnly() %>">
-						<aui:button-row>
-							<c:choose>
-								<c:when test="<%= configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) %>">
-									<aui:button name="update" type="submit" value="update" />
-								</c:when>
-								<c:otherwise>
-									<aui:button name="save" type="submit" value="save" />
-								</c:otherwise>
-							</c:choose>
+						<div class="align-items-center d-flex justify-content-between">
+							<aui:button-row>
+								<c:choose>
+									<c:when test="<%= configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) %>">
+										<aui:button name="update" type="submit" value="update" />
+									</c:when>
+									<c:otherwise>
+										<aui:button name="save" type="submit" value="save" />
+									</c:otherwise>
+								</c:choose>
 
-							<aui:button cssClass="ml-3" href="<%= redirect %>" name="cancel" type="cancel" />
-						</aui:button-row>
+								<aui:button cssClass="ml-3" href="<%= redirect %>" name="cancel" type="cancel" />
+							</aui:button-row>
 
-						<c:if test="<%= Validator.isNotNull(configurationModel.getLiferayLearnMessageKey()) && Validator.isNotNull(configurationModel.getLiferayLearnMessageResource()) %>">
-							<div class="float-right">
+							<c:if test="<%= Validator.isNotNull(configurationModel.getLiferayLearnMessageKey()) && Validator.isNotNull(configurationModel.getLiferayLearnMessageResource()) %>">
 								<liferay-learn:message
 									key="<%= configurationModel.getLiferayLearnMessageKey() %>"
 									resource="<%= configurationModel.getLiferayLearnMessageResource() %>"
 								/>
-							</div>
-						</c:if>
+							</c:if>
+						</div>
 					</c:if>
 				</aui:form>
 			</clay:sheet>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-194725

This fixes the issue and properly aligns the link with the button row, but it is still odd that this broke in the first place. This fix makes more sense than the initial implementation since the link to documentation doesn't actually belong in the button row since it has no effect on the form.