### PR TITLE
LPS-195447 Remove image added by ckeditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -417,6 +417,14 @@
 								uploadImageReturnType: '',
 							});
 
+							const ckeditorImage = document.querySelector(
+								'[data-cke-saved-src]'
+							);
+
+							if (ckeditorImage) {
+								ckeditorImage.remove();
+							}
+
 							const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
 								editor.getData()
 							);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195447

When pasting Ctrl - V in blogs, the image is added twice. 
This is due to CKEditor adding the second image and so I removed the second image as it is not needed.

Please let me know if there are any questions or comments about this.
Thank you.