### PR TITLE
Just a test adding a markup example for search context type picker

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -72,7 +72,10 @@ const SearchControls = ({
 							}
 						}}
 					>
-						<ClayInput.GroupItem>
+						<ClayInput.GroupItem className="input-group-item-shrink input-group-prepend">
+							<button aria-labelledby="picker-label" aria-expanded="false" aria-haspopup="listbox" class="form-control form-control-s form-control-select form-control-select-secondary" role="combobox" tabindex="0" type="button">All</button>
+						</ClayInput.GroupItem>
+						<ClayInput.GroupItem className="input-group-append">
 							<ClayInput
 								aria-label={`${Liferay.Language.get(
 									'search'


### PR DESCRIPTION
Example of the markup for adding a search picker

<img width="1299" alt="image" src="https://github.com/liferay/liferay-portal/assets/7963804/df794b7f-cac5-4807-9de8-bb54ba07d9cd">

<img width="659" alt="image" src="https://github.com/liferay/liferay-portal/assets/7963804/31d2f8a7-2373-4e02-a77a-465978bb6e42">
