### PR TITLE
LPS-198064 Changed data type for API Filter/Sort expression field to allow bigger oData expressions

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.batch-engine-data.json
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.batch-engine-data.json
@@ -24,8 +24,8 @@
 			"name": "APISort",
 			"objectFields": [
 				{
-					"DBType": "String",
-					"businessType": "Text",
+					"DBType": "Clob",
+					"businessType": "LongText",
 					"externalReferenceCode": "ODATA_SORT",
 					"indexed": true,
 					"indexedAsKeyword": false,
@@ -33,6 +33,16 @@
 						"en_US": "OData Sort"
 					},
 					"name": "oDataSort",
+					"objectFieldSettings": [
+						{
+							"name": "showCounter",
+							"value": true
+						},
+						{
+							"name": "maxLength",
+							"value": 1000
+						}
+					],
 					"required": true,
 					"state": false,
 					"system": true,
@@ -59,8 +69,8 @@
 			"name": "APIFilter",
 			"objectFields": [
 				{
-					"DBType": "String",
-					"businessType": "Text",
+					"DBType": "Clob",
+					"businessType": "LongText",
 					"externalReferenceCode": "ODATA_FILTER",
 					"indexed": true,
 					"indexedAsKeyword": false,
@@ -68,6 +78,16 @@
 						"en_US": "OData Filter"
 					},
 					"name": "oDataFilter",
+					"objectFieldSettings": [
+						{
+							"name": "showCounter",
+							"value": true
+						},
+						{
+							"name": "maxLength",
+							"value": 1000
+						}
+					],
 					"required": true,
 					"state": false,
 					"system": true,

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
@@ -188,6 +188,33 @@ public class APIFilterRelevantObjectEntryModelListenerTest
 			JSONCompareMode.LENIENT);
 	}
 
+	@Test
+	public void testPostFilterOverExpressionLimit() throws Exception {
+		_addAPIApplication(
+			_objectDefinitionJSONObject.getString("externalReferenceCode"));
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title",
+				"Object entry value exceeds the maximum length of 1000 " +
+					"characters for object field \"oDataFilter\""
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"objectFieldERC", RandomTestUtil.randomString()
+				).put(
+					"oDataFilter", RandomTestUtil.randomString(1001)
+				).put(
+					"r_apiEndpointToAPIFilters_c_apiEndpointERC",
+					_API_ENDPOINT_ERC
+				).toString(),
+				"headless-builder/filters", Http.Method.POST
+			).toString(),
+			JSONCompareMode.LENIENT);
+	}
+
 	private void _addAPIApplication(
 			String objectDefinitionExternalReferenceCode)
 		throws Exception {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
@@ -107,6 +107,33 @@ public class APISortRelevantObjectEntryModelListenerTest extends BaseTestCase {
 			JSONCompareMode.LENIENT);
 	}
 
+	@Test
+	public void testPostSortOverExpressionLimit() throws Exception {
+		_addAPIApplication(
+			_objectDefinitionJSONObject.getString("externalReferenceCode"));
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title",
+				"Object entry value exceeds the maximum length of 1000 " +
+					"characters for object field \"oDataSort\""
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"objectFieldERC", RandomTestUtil.randomString()
+				).put(
+					"oDataSort", RandomTestUtil.randomString(1001)
+				).put(
+					"r_apiEndpointToAPISorts_c_apiEndpointERC",
+					_API_ENDPOINT_ERC
+				).toString(),
+				"headless-builder/sorts", Http.Method.POST
+			).toString(),
+			JSONCompareMode.LENIENT);
+	}
+
 	private void _addAPIApplication(
 			String objectDefinitionExternalReferenceCode)
 		throws Exception {


### PR DESCRIPTION
**What's changed?:**
- Swapped the previous "text" type field using during the generation of the API Filters and API Sorts for the oData Expression for a "LongText" limited to 1000 characters to follow the specification.

**What's new?:**
- Added new tests that check this new limitation.

See the following **Jira ticket:** [LPS-198064](https://liferay.atlassian.net/browse/LPS-198064)