### PR TITLE
LPS-201627 Use the internal name of the EntityField instead of its name

### DIFF
--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/CollectionEntityField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/CollectionEntityField.java
@@ -22,7 +22,7 @@ public class CollectionEntityField extends EntityField {
 	public CollectionEntityField(EntityField entityField) {
 		super(
 			entityField.getName(), Type.COLLECTION,
-			locale -> entityField.getName(), locale -> entityField.getName(),
+			entityField::getSortableName, entityField::getFilterableName,
 			String::valueOf);
 
 		_entityField = entityField;


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-201627

---

The purpose of this ticket is to fix the usage of the Collection field for sorting purposes. Previously, the field used is the one given by the `getName` method (that is the field of the REST API). However, we need to use the internal one given by the methods `getSortableName` and `getFilterableName`.

For example, for the Headless Delivery REST API, when using the `taxonomyCategoryIds` field in the sort:

```shell
curl -X GET \
      -u test@liferay.com:test \
      http://localhost:8080/o/headless-delivery/v1.0/sites/20119/structured-contents?sort=taxonomyCategoryIds
```

Being the document in ElasticSearch:

```json
          "assetCategoryIds" : [
            "102506",
            "102509"
          ],
```

See the fragment of the query in ElasticSearch

**Before the PR:**

```json
  "sort": [
    {
      "taxonomyCategoryIds": {
        "order": "asc",
        "unmapped_type": "keyword"
      }
    },
```

**After the PR:**

```json
  "sort": [
    {
      "assetCategoryIds": {
        "order": "asc",
        "unmapped_type": "keyword"
      }
    },
```
