### PR TITLE
many-to-many translation in french

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -12222,7 +12222,7 @@ one-or-more-user-groups-are-associated-with-deactivated-users.-do-you-want-to-pr
 one-or-more-users-were-not-removed-since-they-belong-to-a-user-group=Un ou plusieurs utilisateurs ont été supprimés parce qu'ils n'appartiennent à ce groupe d'utilisateurs.
 one-record-of=Un enregistrement de
 one-time-price=Prix unique
-one-to-many=Un à beaucoup
+one-to-many=Un à plusieurs
 one-to-one=Un à un
 onedrive=OneDrive
 onedrive-client-id-description=Définissez l'ID de client OAuth 2.0 pour l'API OneDrive. Allez dans {0} pour le créer.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -10147,7 +10147,7 @@ manually-specify-additional-javamail-properties-to-override-the-above-configurat
 manufacturer-part-number=Numéro d'élément de fabriquant
 manufacturer-part-number-x=Numéro de pièce fabriquant : {0}
 many-records-of=De nombreux enregistrements de
-many-to-many=Beaucoup à beaucoup
+many-to-many=Plusieurs à plusieurs
 maori=Maori
 map=Carte
 map-a-x-field-it-will-be-used-as-x=Cartographiez un champ {0}, il sera utilisé en tant que {1}.


### PR DESCRIPTION

many-to-many translation in french in the context of database cardinality has to be translated by plusieurs à plusieurs