### PR TITLE
LPS-2035100: Unify headless search API search result summaries for Objects

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -16,14 +16,15 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
-import com.liferay.portal.kernel.search.IndexerPostProcessor;
+import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
@@ -33,7 +34,6 @@ import com.liferay.portal.kernel.search.generic.MatchAllQuery;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -57,7 +57,6 @@ import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
-import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -71,21 +70,15 @@ import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MultivaluedMap;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -307,31 +300,12 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 			com.liferay.portal.kernel.search.Field.ENTRY_CLASS_PK);
 	}
 
-	private ModelSummaryContributor _getModelSummaryContributor(
-		String entryClassName) {
-
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-		try {
-			Collection<ServiceReference<ModelSummaryContributor>>
-				serviceReferences = bundleContext.getServiceReferences(
-					ModelSummaryContributor.class,
-					"(indexer.class.name=" + entryClassName + ")");
-
-			if (serviceReferences.isEmpty()) {
-				return null;
-			}
-
-			Iterator<ServiceReference<ModelSummaryContributor>> iterator =
-				serviceReferences.iterator();
-
-			return bundleContext.getService(iterator.next());
-		}
-		catch (InvalidSyntaxException invalidSyntaxException) {
-			_log.error(invalidSyntaxException);
+	private Indexer<Object> _getIndexer(String entryClassName) {
+		if (_indexerRegistry != null) {
+			return _indexerRegistry.getIndexer(entryClassName);
 		}
 
-		return null;
+		return IndexerRegistryUtil.getIndexer(entryClassName);
 	}
 
 	private Summary _getSummary(
@@ -342,39 +316,23 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 			return null;
 		}
 
-		ModelSummaryContributor modelSummaryContributor =
-			_getModelSummaryContributor(entryClassName);
+		Indexer<?> indexer = _getIndexer(entryClassName);
 
-		if (modelSummaryContributor == null) {
+		if (indexer == null) {
 			return null;
 		}
 
-		Locale originalThemeDisplayLocale =
-			LocaleThreadLocal.getThemeDisplayLocale();
-
-		LocaleThreadLocal.setThemeDisplayLocale(
-			contextAcceptLanguage.getPreferredLocale());
-
-		String snippet = legacyDocument.get(
-			com.liferay.portal.kernel.search.Field.SNIPPET);
-
-		Summary summary = modelSummaryContributor.getSummary(
-			legacyDocument, contextAcceptLanguage.getPreferredLocale(),
-			snippet);
-
-		if (summary != null) {
-			List<IndexerPostProcessor> indexerPostProcessors =
-				_indexerRegistry.getIndexerPostProcessors(entryClassName);
-
-			indexerPostProcessors.forEach(
-				indexerPostProcessor -> indexerPostProcessor.postProcessSummary(
-					summary, legacyDocument,
-					contextAcceptLanguage.getPreferredLocale(), snippet));
+		try {
+			return indexer.getSummary(
+				legacyDocument, contextAcceptLanguage.getPreferredLocale(),
+				legacyDocument.get(
+					com.liferay.portal.kernel.search.Field.SNIPPET));
+		}
+		catch (SearchException searchException) {
+			_log.error(searchException);
 		}
 
-		LocaleThreadLocal.setThemeDisplayLocale(originalThemeDisplayLocale);
-
-		return summary;
+		return null;
 	}
 
 	private boolean _isAllowedSearchContextAttribute(String key) {
@@ -649,8 +607,8 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 				}
 
 				_setDescription(
-					assetRenderer, legacyDocument, entryClassName, fields,
-					searchResult);
+					assetRenderer, legacyDocument, _getEntryClassName(document),
+					fields, searchResult);
 
 				_setDTOFields(
 					embedded, entryClassName, entryClassPK, fields,

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
@@ -141,6 +141,13 @@ public class DefaultIndexer<T extends BaseModel<?>> implements Indexer<T> {
 	}
 
 	@Override
+	public Summary getSummary(Document document, Locale locale, String snippet)
+		throws SearchException {
+
+		return _indexerSummaryBuilder.getSummary(document, snippet, locale);
+	}
+
+	@Override
 	public Summary getSummary(
 			Document document, String snippet, PortletRequest portletRequest,
 			PortletResponse portletResponse)

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 60.0.0
+version 60.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Indexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Indexer.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 
 import java.util.Collection;
+import java.util.Locale;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -48,6 +49,13 @@ public interface Indexer<T> {
 	 */
 	@Deprecated
 	public String getSortField(String orderByCol);
+
+	public default Summary getSummary(
+			Document document, Locale locale, String snippet)
+		throws SearchException {
+
+		return null;
+	}
 
 	public Summary getSummary(
 			Document document, String snippet, PortletRequest portletRequest,

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 20.2.0
+version 20.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 71.0.0
+version 71.1.0


### PR DESCRIPTION
(Sending directly because of unrelated CI errors)

- Story: https://liferay.atlassian.net/browse/LPS-202739
- Subtask: https://liferay.atlassian.net/browse/LPS-203510

This PR unifies the search result summaries in the headless search API with the search widgets for Objects. With the Indexer API modification It also simplifies the summary creation for the other asset types.
