### PR TITLE
LPS-206169 use DB.getIndexResultSet for ORA-38029

### DIFF
--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/v1_1_0/CommercePriceEntryUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/v1_1_0/CommercePriceEntryUpgradeProcess.java
@@ -10,6 +10,8 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -18,7 +20,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -119,10 +120,10 @@ public class CommercePriceEntryUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CPDAvailabilityEstimateUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CPDAvailabilityEstimateUpgradeProcess.java
@@ -8,6 +8,8 @@ package com.liferay.commerce.internal.upgrade.v2_1_0;
 import com.liferay.commerce.model.impl.CPDAvailabilityEstimateModelImpl;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -16,7 +18,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -101,10 +102,10 @@ public class CPDAvailabilityEstimateUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceOrderItemUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceOrderItemUpgradeProcess.java
@@ -10,6 +10,8 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -18,7 +20,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -108,10 +109,10 @@ public class CommerceOrderItemUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceSubscriptionEntryUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceSubscriptionEntryUpgradeProcess.java
@@ -10,6 +10,8 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -18,7 +20,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -119,10 +120,10 @@ public class CommerceSubscriptionEntryUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -11,6 +11,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -25,6 +26,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -597,6 +599,44 @@ public class DBTest {
 		Assert.assertArrayEquals(
 			new String[] {_dbInspector.normalizeName("id")},
 			_db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME_2));
+	}
+
+	@Test
+	public void testGetIndexResultSet() throws Exception {
+		_addIndex(new String[] {"typeVarchar"});
+
+		if (_db.getDBType() == DBType.ORACLE) {
+			Statement statement = _connection.createStatement();
+
+			statement.execute(
+				StringBundler.concat(
+					"CALL dbms_stats.lock_table_stats(ownname => '",
+					_connection.getSchema(), "', tabname => '", _TABLE_NAME_1,
+					"')"));
+
+			statement.close();
+		}
+
+		try (ResultSet indexResultSet = _db.getIndexResultSet(
+				_connection, _TABLE_NAME_1)) {
+
+			while (indexResultSet.next()) {
+				Assert.assertEquals(
+					"typeVarchar", indexResultSet.getString("INDEX_NAME"));
+			}
+		}
+
+		if (_db.getDBType() == DBType.ORACLE) {
+			Statement statement = _connection.createStatement();
+
+			statement.execute(
+				StringBundler.concat(
+					"CALL dbms_stats.unlock_table_stats(ownname => '",
+					_connection.getSchema(), "', tabname => '", _TABLE_NAME_1,
+					"')"));
+
+			statement.close();
+		}
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -15,6 +15,7 @@ import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.configuration.Filter;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
@@ -1255,6 +1256,8 @@ public abstract class BaseDB implements DB {
 
 		DatabaseMetaData databaseMetaData = connection.getMetaData();
 
+		DB db = DBManagerUtil.getDB();
+
 		DBInspector dbInspector = new DBInspector(connection);
 
 		String catalog = dbInspector.getCatalog();
@@ -1281,9 +1284,8 @@ public abstract class BaseDB implements DB {
 				normalizedTableName = dbInspector.normalizeName(
 					tableResultSet.getString("TABLE_NAME"), databaseMetaData);
 
-				try (ResultSet indexResultSet = databaseMetaData.getIndexInfo(
-						catalog, schema, normalizedTableName, onlyUnique,
-						false)) {
+				try (ResultSet indexResultSet = db.getIndexResultSet(
+						connection, normalizedTableName)) {
 
 					boolean unique = false;
 


### PR DESCRIPTION
Ticket:
[LPS-206169](https://liferay.atlassian.net/browse/LPS-206169)

Issue:
If a customer has locked the statistics for a table(Oracle Only) then the indexeResultSet cannot be aquired.
This was already handled in [LPS-141855](https://liferay.atlassian.net/browse/LPS-141855).

This fix  just applies the same method  in places where the old method was used.

A source format rule was added here:
https://liferay.atlassian.net/browse/LPS-206492

[LPS-206169]: https://liferay.atlassian.net/browse/LPS-206169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPS-141855]: https://liferay.atlassian.net/browse/LPS-141855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

A test was added for getIndexResultSet.