### PR TITLE
Added new ArrayList due add in list taken from DynamicQuery cause UnsupportedOperationException

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1113,7 +1113,8 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		dynamicQuery.add(typeProperty.eq(type));
 
-		List<Layout> layouts = layoutLocalService.dynamicQuery(dynamicQuery);
+		List<Layout> layouts = new ArrayList<>(
+			layoutLocalService.dynamicQuery(dynamicQuery));
 
 		Group group = _groupPersistence.findByPrimaryKey(groupId);
 


### PR DESCRIPTION
Added new ArrayList due add in list taken from DynamicQuery cause UnsupportedOperationException in layouts.add method:

```java
if (checkedPlids.add(userGroupPlid)) {
	layouts.add(userGroupLayout);
	checkParentLayoutIds.add(userGroupLayout.getLayoutId());
}
```