### PR TITLE
LPD-3448 When clicking on the simulation area, this entire area stops working

### DIFF
--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/templates/portal_normal.ftl
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/templates/portal_normal.ftl
@@ -33,11 +33,11 @@
 
 	<@liferay.control_menu />
 
-	<div class="position-relative" id="wrapper">
-		<div class="liferay-top">
-			<@liferay_util["include"] page=body_top_include />
-		</div>
+	<div class="liferay-top">
+		<@liferay_util["include"] page=body_top_include />
+	</div>
 
+	<div class="position-relative" id="wrapper">
 		<main class="minium minium-frame" id="minium">
 			<#if show_sidebar>
 				<div class="minium-frame__sidebar">
@@ -79,11 +79,11 @@
 				<@liferay_commerce_ui["search-results"] />
 			</div>
 		</main>
+	</div>
 
-		<div class="liferay-bottom">
+	<div class="liferay-bottom">
 			<@liferay_util["include"] page=body_bottom_include />
 			<@liferay_util["include"] page=bottom_include />
-		</div>
 	</div>
 </body>
 </html>

--- a/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/templates/portal_normal.ftl
+++ b/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/templates/portal_normal.ftl
@@ -13,12 +13,12 @@
 	<body class="speedwell ${css_class}" id="content">
 		<@liferay.control_menu />
 
-		<div class="position-relative" id="wrapper">
-			<div class="liferay-top">
-				<@liferay_ui["quick-access"] contentId="#main-content" />
-				<@liferay_util["include"] page=body_top_include />
-			</div>
+		<div class="liferay-top">
+			<@liferay_ui["quick-access"] contentId="#main-content" />
+			<@liferay_util["include"] page=body_top_include />
+		</div>
 
+		<div class="position-relative" id="wrapper">
 			<main class="speedwell-frame" id="speedwell">
 				<div class="speedwell-frame__topbar">
 					<#include "${full_templates_path}/topbar.ftl" />
@@ -57,11 +57,11 @@
 					</div>
 				</footer>
 			</main>
+		</div>
 
-			<div class="liferay-bottom">
+		<div class="liferay-bottom">
 				<@liferay_util["include"] page=body_bottom_include />
 				<@liferay_util["include"] page=bottom_include />
-			</div>
 		</div>
 
 		<script ${nonceAttribute} src="${javascript_folder}/features/accessibility.js" type="text/javascript"></script>


### PR DESCRIPTION
Hey,

[LPD-3448](https://liferay.atlassian.net/browse/LPD-3448)
The simulation was not working properly, so I moved outside the liferay-bottom and liferay-top divs from their wrapper. It resolved the issue. Please review my change

[LPD-3448]: https://liferay.atlassian.net/browse/LPD-3448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ