### PR TITLE
[TS] LPD-15250 Make possible to parse different dateTime formats and also handle dateFormat "yyyy-MM-dd"

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/validation/util/DateParameterUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/validation/util/DateParameterUtil.java
@@ -27,7 +27,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -36,6 +38,10 @@ import java.util.TimeZone;
  * @author Carolina Barbosa
  */
 public class DateParameterUtil {
+
+	public static final List<String> datePatterns = Arrays.asList(
+		"yyyy-MM-dd H:mm", "yyyy-MM-dd HH:mm:ss",
+		"EEE MMM dd HH:mm:ss zzz yyyy");
 
 	public static LocalDate getLocalDate(String dateString) {
 		if (Validator.isNull(dateString)) {
@@ -62,8 +68,25 @@ public class DateParameterUtil {
 			return null;
 		}
 
-		return LocalDateTime.parse(
-			dateTimeString, DateTimeFormatter.ofPattern("yyyy-MM-dd H:mm"));
+		String parseException = null;
+
+		for (String datePattern : datePatterns) {
+			try {
+				return LocalDateTime.parse(
+					dateTimeString, DateTimeFormatter.ofPattern(datePattern));
+			}
+			catch (DateTimeParseException dateTimeParseException) {
+				parseException = String.valueOf(dateTimeParseException);
+			}
+		}
+
+		if (parseException != null) {
+			_log.error(parseException);
+		}
+
+		return getLocalDate(
+			dateTimeString
+		).atStartOfDay();
 	}
 
 	public static String getParameter(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/FutureDatesFunction.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/FutureDatesFunction.java
@@ -7,14 +7,9 @@ package com.liferay.dynamic.data.mapping.form.evaluator.internal.function;
 
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFunction;
 import com.liferay.dynamic.data.mapping.form.validation.util.DateParameterUtil;
-import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.text.Format;
-
-import java.time.LocalDate;
-
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * @author Bruno Oliveira
@@ -31,19 +26,12 @@ public class FutureDatesFunction
 			return false;
 		}
 
-		LocalDate localDate = DateParameterUtil.getLocalDate(
+		LocalDateTime localDateTime = DateParameterUtil.getLocalDateTime(
 			object1.toString());
 
-		String dateString = object2.toString();
+		if (localDateTime.isBefore(
+				DateParameterUtil.getLocalDateTime(object2.toString()))) {
 
-		if (object2 instanceof Date) {
-			Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
-				"yyyy-MM-dd");
-
-			dateString = format.format(object2);
-		}
-
-		if (localDate.isBefore(DateParameterUtil.getLocalDate(dateString))) {
 			return false;
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/PastDatesFunction.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/PastDatesFunction.java
@@ -9,7 +9,7 @@ import com.liferay.dynamic.data.mapping.expression.DDMExpressionFunction;
 import com.liferay.dynamic.data.mapping.form.validation.util.DateParameterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * @author Carolina Barbosa
@@ -25,11 +25,11 @@ public class PastDatesFunction
 			return false;
 		}
 
-		LocalDate localDate = DateParameterUtil.getLocalDate(
+		LocalDateTime localDateTime = DateParameterUtil.getLocalDateTime(
 			object1.toString());
 
-		if (localDate.isAfter(
-				DateParameterUtil.getLocalDate(object2.toString()))) {
+		if (localDateTime.isAfter(
+				DateParameterUtil.getLocalDateTime(object2.toString()))) {
 
 			return false;
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/FutureDatesFunctionTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/FutureDatesFunctionTest.java
@@ -8,6 +8,7 @@ package com.liferay.dynamic.data.mapping.form.evaluator.internal.function;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import org.junit.Assert;
@@ -38,6 +39,7 @@ public class FutureDatesFunctionTest {
 	@Test
 	public void testApplyTrue() {
 		LocalDate tomorrowLocalDate = _todayLocalDate.plusDays(1);
+		LocalDateTime tomorrowLocalDateTime = _todayLocalDateTime.plusDays(1);
 
 		Assert.assertTrue(
 			_futureDatesFunction.apply(
@@ -46,6 +48,19 @@ public class FutureDatesFunctionTest {
 		Assert.assertTrue(
 			_futureDatesFunction.apply(
 				_todayLocalDate.toString(), _todayLocalDate.toString()));
+
+		Assert.assertTrue(
+			_futureDatesFunction.apply(
+				tomorrowLocalDateTime.toString(),
+				_todayLocalDateTime.toString()));
+
+		Assert.assertTrue(
+			_futureDatesFunction.apply(
+				tomorrowLocalDate.toString(), _todayLocalDateTime.toString()));
+
+		Assert.assertTrue(
+			_futureDatesFunction.apply(
+				tomorrowLocalDateTime.toString(), _todayLocalDate.toString()));
 	}
 
 	@Test
@@ -59,5 +74,7 @@ public class FutureDatesFunctionTest {
 	private final FutureDatesFunction _futureDatesFunction =
 		new FutureDatesFunction();
 	private final LocalDate _todayLocalDate = LocalDate.now(ZoneId.of("UTC"));
+	private final LocalDateTime _todayLocalDateTime = LocalDateTime.now(
+		ZoneId.of("UTC"));
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/PastDatesFunctionTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/PastDatesFunctionTest.java
@@ -8,6 +8,7 @@ package com.liferay.dynamic.data.mapping.form.evaluator.internal.function;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import org.junit.Assert;
@@ -37,6 +38,7 @@ public class PastDatesFunctionTest {
 	@Test
 	public void testApplyTrue() {
 		LocalDate yesterdayLocalDate = _todayLocalDate.minusDays(1);
+		LocalDateTime yesterdayLocalDateTime = _todayLocalDateTime.minusDays(1);
 
 		Assert.assertTrue(
 			_pastDatesFunction.apply(
@@ -45,6 +47,19 @@ public class PastDatesFunctionTest {
 		Assert.assertTrue(
 			_pastDatesFunction.apply(
 				_todayLocalDate.toString(), _todayLocalDate.toString()));
+
+		Assert.assertTrue(
+			_pastDatesFunction.apply(
+				yesterdayLocalDateTime.toString(),
+				_todayLocalDateTime.toString()));
+
+		Assert.assertTrue(
+			_pastDatesFunction.apply(
+				yesterdayLocalDate.toString(), _todayLocalDateTime.toString()));
+
+		Assert.assertTrue(
+			_pastDatesFunction.apply(
+				yesterdayLocalDateTime.toString(), _todayLocalDate.toString()));
 	}
 
 	@Test
@@ -58,5 +73,7 @@ public class PastDatesFunctionTest {
 	private final PastDatesFunction _pastDatesFunction =
 		new PastDatesFunction();
 	private final LocalDate _todayLocalDate = LocalDate.now(ZoneId.of("UTC"));
+	private final LocalDateTime _todayLocalDateTime = LocalDateTime.now(
+		ZoneId.of("UTC"));
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/form/validation/util/DateParameterUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/form/validation/util/DateParameterUtilTest.java
@@ -63,6 +63,29 @@ public class DateParameterUtilTest {
 	}
 
 	@Test
+	public void testGetLocalDateTime2() {
+		Assert.assertEquals(
+			"2021-10-28T00:00",
+			String.valueOf(DateParameterUtil.getLocalDateTime("2021-10-28")));
+
+		Assert.assertEquals(
+			"2021-10-28T01:00",
+			String.valueOf(
+				DateParameterUtil.getLocalDateTime("2021-10-28 01:00:00")));
+
+		Assert.assertEquals(
+			"2021-10-28T01:00",
+			String.valueOf(
+				DateParameterUtil.getLocalDateTime("2021-10-28 1:00")));
+
+		Assert.assertEquals(
+			"2024-02-06T14:43:44",
+			String.valueOf(
+				DateParameterUtil.getLocalDateTime(
+					"Tue Feb 06 14:43:44 GMT 2024")));
+	}
+
+	@Test
 	public void testGetParameterBlank() {
 		Assert.assertEquals(
 			StringPool.BLANK,


### PR DESCRIPTION
Hi Team,

https://liferay.atlassian.net/browse/LPD-17472 

Issue:
Because of the only date pattern ("yyyy-MM-dd") given in DateParameterUtil, the methods in PastDatesFunction and FutureDatesFunction are failing with nullPointerException when we call the pastDates and futureDates methods in the User Object's expression builder, since the date that comes as input is "EEE MMM dd HH:mm:ss zzz yyyy".
So conditions using these methods are failing and won't work.

Solution:
I changed the method called in PastDatesFunction and FutureDatesFunction to getLocalDateTime to be able to compare time too (hours, minutes, seconds) not just dates, because it is more precise to compare dates down to seconds, and it can be necessary.
I also added more date time patterns to parse the possible dateTimes, and I kept the original date pattern too.

Please review my PR!

Thank you and best regards,
Évi