### PR TITLE
[TS] LPD-22030 Add the objectField's label value to the site default locales if it's missing and the object definition default locale is not the same

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
@@ -32,6 +32,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -180,7 +181,7 @@ public class ObjectFieldUtil {
 	}
 
 	public static com.liferay.object.model.ObjectField toObjectField(
-		boolean enableLocalization,
+		Locale defaultLocale, boolean enableLocalization,
 		ListTypeDefinitionLocalService listTypeDefinitionLocalService,
 		ObjectField objectField,
 		ObjectFieldLocalService objectFieldLocalService,
@@ -223,8 +224,21 @@ public class ObjectFieldUtil {
 			GetterUtil.getBoolean(objectField.getIndexedAsKeyword()));
 		serviceBuilderObjectField.setIndexedLanguageId(
 			objectField.getIndexedLanguageId());
-		serviceBuilderObjectField.setLabelMap(
-			LocalizedMapUtil.getLocalizedMap(objectField.getLabel()));
+
+		Map<Locale, String> labelMap = LocalizedMapUtil.getLocalizedMap(
+			objectField.getLabel());
+
+		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
+
+		if (!Objects.equals(defaultLocale, siteDefaultLocale) &&
+			Validator.isNull(labelMap.get(siteDefaultLocale)) &&
+			Validator.isNotNull(labelMap.get(defaultLocale))) {
+
+			labelMap.put(siteDefaultLocale, labelMap.get(defaultLocale));
+		}
+
+		serviceBuilderObjectField.setLabelMap(labelMap);
+
 		serviceBuilderObjectField.setLocalized(
 			GetterUtil.getBoolean(
 				objectField.getLocalized(), enableLocalization));

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -66,6 +66,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -236,6 +237,8 @@ public class ObjectDefinitionResourceImpl
 					transformToList(
 						objectDefinition.getObjectFields(),
 						objectField -> ObjectFieldUtil.toObjectField(
+							LocaleUtil.fromLanguageId(
+								objectDefinition.getDefaultLanguageId()),
 							GetterUtil.getBoolean(
 								objectDefinition.getEnableLocalization()),
 							_listTypeDefinitionLocalService, objectField,
@@ -277,6 +280,8 @@ public class ObjectDefinitionResourceImpl
 									ObjectFieldConstants.
 										BUSINESS_TYPE_RELATIONSHIP)),
 						objectField -> ObjectFieldUtil.toObjectField(
+							LocaleUtil.fromLanguageId(
+								objectDefinition.getDefaultLanguageId()),
 							GetterUtil.getBoolean(
 								objectDefinition.getEnableLocalization()),
 							_listTypeDefinitionLocalService, objectField,
@@ -329,6 +334,8 @@ public class ObjectDefinitionResourceImpl
 								ObjectFieldConstants.
 									BUSINESS_TYPE_AGGREGATION)),
 						objectField -> ObjectFieldUtil.toObjectField(
+							LocaleUtil.fromLanguageId(
+								objectDefinition.getDefaultLanguageId()),
 							false, _listTypeDefinitionLocalService, objectField,
 							_objectFieldLocalService,
 							_objectFieldSettingLocalService,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -215,7 +216,8 @@ public class ObjectRelationshipResourceImpl
 				GetterUtil.getBoolean(objectRelationship.getSystem()),
 				objectRelationship.getTypeAsString(),
 				ObjectFieldUtil.toObjectField(
-					false, _listTypeDefinitionLocalService,
+					LocaleUtil.getSiteDefault(), false,
+					_listTypeDefinitionLocalService,
 					objectRelationship.getObjectField(),
 					_objectFieldLocalService, _objectFieldSettingLocalService,
 					_objectFilterLocalService)));
@@ -263,7 +265,8 @@ public class ObjectRelationshipResourceImpl
 				GetterUtil.getBoolean(objectRelationship.getEdge()),
 				LocalizedMapUtil.getLocalizedMap(objectRelationship.getLabel()),
 				ObjectFieldUtil.toObjectField(
-					false, _listTypeDefinitionLocalService,
+					LocaleUtil.getSiteDefault(), false,
+					_listTypeDefinitionLocalService,
 					objectRelationship.getObjectField(),
 					_objectFieldLocalService, _objectFieldSettingLocalService,
 					_objectFilterLocalService)));


### PR DESCRIPTION
Hi Team,
https://liferay.atlassian.net/browse/LPD-22030

Issue:
Object definition JSON import fails when it has different labels of different language than the instance’s default locale.
For example: when the JSON has labels in German and the instance we are importing to has English as the default language and the default locale is English.

Solution:
I made a tentative for a fix but following our discussion with @carolmariaabb she provided a different approach "the solution should be in the resource layer instead of changing the service layer".

I tested in my local environment and following the fix, the Object definition import was successful.

Please review my PR!

Thank you and best regards,
Évi