### PR TITLE
LPD-24098 Fix a11y error with autocomplete and checkboxes

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
@@ -41,7 +41,7 @@ CategoryFacetPortletInstanceConfiguration categoryFacetPortletInstanceConfigurat
 		<aui:input name="<%= HtmlUtil.escapeAttribute(assetCategoriesSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= assetCategoriesSearchFacetDisplayContext.getParameterValue() %>" />
 	</c:when>
 	<c:otherwise>
-		<aui:form action="#" method="post" name="fm">
+		<aui:form action="#" autocomplete="off" method="post" name="fm">
 			<aui:input name="<%= HtmlUtil.escapeAttribute(assetCategoriesSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= assetCategoriesSearchFacetDisplayContext.getParameterValue() %>" />
 			<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= assetCategoriesSearchFacetDisplayContext.getParameterName() %>" />
 			<aui:input cssClass="start-parameter-name" name="start-parameter-name" type="hidden" value="<%= assetCategoriesSearchFacetDisplayContext.getPaginationStartParameterName() %>" />

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -37,7 +37,7 @@ CustomFacetPortletInstanceConfiguration customFacetPortletInstanceConfiguration 
 		<aui:input name="<%= HtmlUtil.escapeAttribute(customFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= customFacetDisplayContext.getParameterValue() %>" />
 	</c:when>
 	<c:otherwise>
-		<aui:form action="#" method="post" name="fm">
+		<aui:form action="#" autocomplete="off" method="post" name="fm">
 			<aui:input name="<%= HtmlUtil.escapeAttribute(customFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= customFacetDisplayContext.getParameterValue() %>" />
 			<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= customFacetDisplayContext.getParameterName() %>" />
 			<aui:input cssClass="start-parameter-name" name="start-parameter-name" type="hidden" value="<%= customFacetDisplayContext.getPaginationStartParameterName() %>" />

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/date/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/date/facet/view.jsp
@@ -37,7 +37,7 @@ DateFacetPortletInstanceConfiguration dateFacetPortletInstanceConfiguration = da
 %>
 
 <c:if test="<%= !dateFacetDisplayContext.isRenderNothing() %>">
-	<aui:form action="#" method="get" name="fm">
+	<aui:form action="#" autocomplete="off" method="get" name="fm">
 		<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= HtmlUtil.escapeAttribute(dateFacetDisplayContext.getParameterName()) %>" />
 		<aui:input name="start-parameter-name" type="hidden" value="<%= dateFacetDisplayContext.getPaginationStartParameterName() %>" />
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
@@ -41,7 +41,7 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 		<aui:input name="<%= HtmlUtil.escapeAttribute(folderSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= folderSearchFacetDisplayContext.getParameterValue() %>" />
 	</c:when>
 	<c:otherwise>
-		<aui:form action="#" method="post" name="fm">
+		<aui:form action="#" autocomplete="off" method="post" name="fm">
 			<aui:input name="<%= HtmlUtil.escapeAttribute(folderSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= folderSearchFacetDisplayContext.getParameterValue() %>" />
 			<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= folderSearchFacetDisplayContext.getParameterName() %>" />
 			<aui:input cssClass="start-parameter-name" name="start-parameter-name" type="hidden" value="<%= folderSearchFacetDisplayContext.getPaginationStartParameterName() %>" />
@@ -97,7 +97,6 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 									<div class="custom-checkbox custom-control">
 										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 											<input
-												autocomplete="off"
 												class="custom-control-input facet-term"
 												data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
 												disabled

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
@@ -40,7 +40,7 @@ ModifiedFacetPortletInstanceConfiguration modifiedFacetPortletInstanceConfigurat
 %>
 
 <c:if test="<%= !modifiedFacetDisplayContext.isRenderNothing() %>">
-	<aui:form action="#" method="get" name="fm">
+	<aui:form action="#" autocomplete="off" method="get" name="fm">
 		<aui:input name="inputFacetName" type="hidden" value="modified" />
 		<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= HtmlUtil.escapeAttribute(modifiedFacetDisplayContext.getParameterName()) %>" />
 		<aui:input name="start-parameter-name" type="hidden" value="<%= modifiedFacetDisplayContext.getPaginationStartParameterName() %>" />

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
@@ -41,7 +41,7 @@ SiteFacetPortletInstanceConfiguration siteFacetPortletInstanceConfiguration = sc
 		<aui:input name="<%= HtmlUtil.escapeAttribute(scopeSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= scopeSearchFacetDisplayContext.getParameterValue() %>" />
 	</c:when>
 	<c:otherwise>
-		<aui:form action="#" method="post" name="fm">
+		<aui:form action="#" autocomplete="off" method="post" name="fm">
 			<aui:input name="<%= HtmlUtil.escapeAttribute(scopeSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= scopeSearchFacetDisplayContext.getParameterValue() %>" />
 			<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= scopeSearchFacetDisplayContext.getParameterName() %>" />
 			<aui:input cssClass="start-parameter-name" name="start-parameter-name" type="hidden" value="<%= scopeSearchFacetDisplayContext.getPaginationStartParameterName() %>" />
@@ -97,7 +97,6 @@ SiteFacetPortletInstanceConfiguration siteFacetPortletInstanceConfiguration = sc
 									<div class="custom-checkbox custom-control">
 										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 											<input
-												autocomplete="off"
 												class="custom-control-input facet-term"
 												data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
 												disabled

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
@@ -41,7 +41,7 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 		<aui:input name="<%= HtmlUtil.escapeAttribute(assetTagsSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= assetTagsSearchFacetDisplayContext.getParameterValue() %>" />
 	</c:when>
 	<c:otherwise>
-		<aui:form action="#" method="post" name="fm">
+		<aui:form action="#" autocomplete="off" method="post" name="fm">
 			<aui:input name="<%= HtmlUtil.escapeAttribute(assetTagsSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= assetTagsSearchFacetDisplayContext.getParameterValue() %>" />
 			<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= assetTagsSearchFacetDisplayContext.getParameterName() %>" />
 			<aui:input cssClass="start-parameter-name" name="start-parameter-name" type="hidden" value="<%= assetTagsSearchFacetDisplayContext.getPaginationStartParameterName() %>" />
@@ -97,7 +97,6 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 									<div class="custom-checkbox custom-control">
 										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 											<input
-												autocomplete="off"
 												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 												class="custom-control-input facet-term"
 												data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
@@ -41,7 +41,7 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 		<aui:input name="<%= HtmlUtil.escapeAttribute(assetEntriesSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= assetEntriesSearchFacetDisplayContext.getParameterValue() %>" />
 	</c:when>
 	<c:otherwise>
-		<aui:form action="#" method="post" name="fm">
+		<aui:form action="#" autocomplete="off" method="post" name="fm">
 			<aui:input name="<%= HtmlUtil.escapeAttribute(assetEntriesSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= assetEntriesSearchFacetDisplayContext.getParameterValue() %>" />
 			<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= assetEntriesSearchFacetDisplayContext.getParameterName() %>" />
 			<aui:input cssClass="start-parameter-name" name="start-parameter-name" type="hidden" value="<%= assetEntriesSearchFacetDisplayContext.getPaginationStartParameterName() %>" />
@@ -97,7 +97,6 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 									<div class="custom-checkbox custom-control">
 										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 											<input
-												autocomplete="off"
 												class="custom-control-input facet-term"
 												data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
 												disabled

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
@@ -41,7 +41,7 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 		<aui:input name="<%= HtmlUtil.escapeAttribute(userSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= userSearchFacetDisplayContext.getParameterValue() %>" />
 	</c:when>
 	<c:otherwise>
-		<aui:form action="#" method="post" name="fm">
+		<aui:form action="#" autocomplete="off" method="post" name="fm">
 			<aui:input name="<%= HtmlUtil.escapeAttribute(userSearchFacetDisplayContext.getParameterName()) %>" type="hidden" value="<%= userSearchFacetDisplayContext.getParameterValue() %>" />
 			<aui:input cssClass="facet-parameter-name" name="facet-parameter-name" type="hidden" value="<%= userSearchFacetDisplayContext.getParameterName() %>" />
 			<aui:input cssClass="start-parameter-name" name="start-parameter-name" type="hidden" value="<%= userSearchFacetDisplayContext.getPaginationStartParameterName() %>" />
@@ -97,7 +97,6 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 									<div class="custom-checkbox custom-control">
 										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 											<input
-												autocomplete="off"
 												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 												class="custom-control-input facet-term"
 												data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
@@ -51,7 +51,6 @@
 								<div class="custom-checkbox custom-control">
 									<label>
 										<input
-											autocomplete="off"
 											${selected?then("checked", "")}
 											class="custom-control-input facet-term"
 											data-term-id=${id}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
@@ -30,7 +30,6 @@
 						<div class="custom-checkbox custom-control">
 							<label class="facet-checkbox-label" for="${namespace}${entry.getBucketText()}">
 								<input
-									autocomplete="off"
 									${(entry.isSelected())?then("checked", "")}
 									class="custom-control-input facet-term"
 									data-term-id="${htmlUtil.escape(entry.getBucketText())}"
@@ -66,7 +65,6 @@
 				<div class="custom-checkbox custom-control">
 					<label class="facet-checkbox-label" for="${namespace}${customRangeBucketDisplayContext.getBucketText()}">
 						<input
-							autocomplete="off"
 							${(customRangeBucketDisplayContext.isSelected())?then("checked", "")}
 							class="custom-control-input facet-term"
 							data-term-id="${htmlUtil.escape(customRangeBucketDisplayContext.getBucketText())}"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -30,7 +30,6 @@
 						<div class="custom-control custom-radio">
 							<label class="facet-checkbox-label" for="${namespace}${entry.getBucketText()}">
 								<input
-									autocomplete="off"
 									${(entry.isSelected())?then("checked", "")}
 									class="custom-control-input facet-term"
 									disabled
@@ -64,7 +63,6 @@
 				<div class="custom-control custom-radio">
 					<label class="facet-checkbox-label" for="${namespace}${customRangeBucketDisplayContext.getBucketText()}">
 						<input
-							autocomplete="off"
 							${(customRangeBucketDisplayContext.isSelected())?then("checked", "")}
 							class="custom-control-input facet-term"
 							disabled

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -30,7 +30,6 @@
 						<div class="custom-control custom-radio">
 							<label class="facet-checkbox-label" for="${namespace}${entry.getBucketText()}">
 								<input
-									autocomplete="off"
 									${(entry.isSelected())?then("checked", "")}
 									class="custom-control-input facet-term"
 									disabled
@@ -64,7 +63,6 @@
 				<div class="custom-control custom-radio">
 					<label class="facet-checkbox-label" for="${namespace}${customRangeBucketDisplayContext.getBucketText()}">
 						<input
-							autocomplete="off"
 							${(customRangeBucketDisplayContext.isSelected())?then("checked", "")}
 							class="custom-control-input facet-term"
 							disabled


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-24098 - Accessibility issue with checkboxes and attribute 'autocomplete'

This [w3c rule](https://rocketvalidator.com/html-validation/attribute-autocomplete-is-only-allowed-when-the-input-type-is-color-date-datetime-local-email-hidden-month-number-password-range-search-tel-text-time-url-or-week) states that `autocomplete` is not a valid attribute for checkbox inputs, but originally `autocomplete=off` was added to address [this bug](https://liferay.atlassian.net/browse/LPS-168259). I tried it out on my Firefox 125.0.2, but I'm not able to reproduce that bug anymore.

I didn't want to just remove the attribute altogether, but the related Stack Overflow solution mentions that another way would be to add it onto the `form` instead: https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing

A few weeks ago, there was another [a11y error](https://liferay.atlassian.net/browse/LPD-20841) about having `autocomplete` for `hidden` inputs, so this change to add it to the encompassing `form` might address some concerns we may have had about regressions there too. 👍 

Let me know if this is fine, thanks for taking a look! 