### PR TITLE
LPD-26845, LPD-25961, LPD-25962, LPD-26854, LPD-26856

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -715,9 +715,8 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private String _getSaveAndContinueRedirect(
-			ActionRequest actionRequest, JournalArticle article,
-			String redirect)
-		throws Exception {
+		String actionName, ActionRequest actionRequest, JournalArticle article,
+		String redirect) {
 
 		return PortletURLBuilder.create(
 			PortletURLFactoryUtil.create(
@@ -733,6 +732,21 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			"articleId", article.getArticleId()
 		).setParameter(
 			"folderId", article.getFolderId()
+		).setParameter(
+			"friendlyURL",
+			() -> {
+				if (!FeatureFlagManagerUtil.isEnabled("LPS-141392") ||
+					!Objects.equals(actionName, "/journal/add_article")) {
+
+					return null;
+				}
+
+				Map<Locale, String> friendlyURLMap =
+					article.getFriendlyURLMap();
+
+				return friendlyURLMap.get(
+					LocaleUtil.fromLanguageId(article.getDefaultLanguageId()));
+			}
 		).setParameter(
 			"groupId", article.getGroupId()
 		).setParameter(
@@ -809,7 +823,7 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			(workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT)) {
 
 			redirect = _getSaveAndContinueRedirect(
-				actionRequest, article, redirect);
+				actionName, actionRequest, article, redirect);
 		}
 		else {
 			redirect = _portal.escapeRedirect(redirect);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -145,6 +145,15 @@ journalEditArticleDisplayContext.setViewAttributes();
 					<div class="c-gap-3 form-group-sm journal-article-button-row mb-0 tbar-section text-right">
 						<c:choose>
 							<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPS-141392") %>'>
+								<div class="align-items-center d-none mx-3 small text-danger" id="<portlet:namespace />lockErrorIndicator">
+									<liferay-ui:message key="alert-helper-error" />
+
+									<clay:icon
+										cssClass="ml-2"
+										symbol="exclamation-full"
+									/>
+								</div>
+
 								<div class="align-items-center d-none mx-3 small" id="<portlet:namespace />savingChangesIndicator">
 									<liferay-ui:message key="saving" />
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -373,18 +373,39 @@ export default function _JournalPortlet({
 				}
 				else {
 					if (!articleId && response.url) {
-						const key = `${namespace}articleId`;
+						const articleIdKey = `${namespace}articleId`;
+						const friendlyURLKey = `${namespace}friendlyURL`;
 						const url = new URL(response.url);
 
-						if (url.searchParams.has(key)) {
-							articleId = url.searchParams.get(key);
+						if (url.searchParams.has(articleIdKey)) {
+							articleId = url.searchParams.get(articleIdKey);
 							document.getElementById(
 								`${namespace}articleId`
 							).value = articleId;
 
 							Liferay.fire('asyncFormSubmission', {articleId});
 						}
+
+						if (url.searchParams.has(friendlyURLKey)) {
+							const friendlyUrlInputComponent = Liferay.component(
+								`${namespace}friendlyURL`
+							);
+
+							if (!friendlyUrlInputComponent.getValue()) {
+								const friendlyURL = url.searchParams.get(
+									friendlyURLKey
+								);
+								friendlyUrlInputComponent.updateInputLanguage(
+									friendlyURL,
+									defaultLanguageId
+								);
+								friendlyUrlInputComponent.updateInput(
+									friendlyURL
+								);
+							}
+						}
 					}
+					lockHolder.lock?.unlock();
 				}
 			})
 			.catch((error) => {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -159,7 +159,7 @@ export default function _JournalPortlet({
 	};
 
 	const handleDDMFormError = (event) => {
-		lockHolder.lock?.unlock();
+		lockHolder.lock?.unlock(true);
 
 		if (event.error?.statusCode) {
 			showAlert(event.error.message);
@@ -218,7 +218,23 @@ export default function _JournalPortlet({
 			availableLocalesInput.value = availableLocales;
 
 			if (autoSaveDraftEnabled) {
-				submitAsyncForm(form, {redirectOnSave});
+				Liferay.componentReady(`${namespace}dataEngineLayoutRenderer`)
+					.then((dataEngineLayoutRenderer) => {
+						const dataEngineLayoutRendererRef =
+							dataEngineLayoutRenderer?.reactComponentRef;
+
+						return dataEngineLayoutRendererRef.current.validate();
+					})
+					.then((validForm) => {
+						if (validForm) {
+							submitAsyncForm(form, {redirectOnSave});
+						}
+						else {
+							Liferay.fire('ddmFormError', {
+								formWrapperId: formId,
+							});
+						}
+					});
 			}
 			else {
 				form.submit();
@@ -236,7 +252,7 @@ export default function _JournalPortlet({
 				);
 			}
 
-			lockHolder.lock?.unlock();
+			lockHolder.lock?.unlock(true);
 		}
 	};
 
@@ -371,9 +387,7 @@ export default function _JournalPortlet({
 			})
 			.catch((error) => {
 				console.error(error);
-			})
-			.finally(() => {
-				lockHolder.lock?.unlock();
+				lockHolder.lock?.unlock(true);
 			});
 	};
 
@@ -457,7 +471,7 @@ export default function _JournalPortlet({
 
 					handleDDMFormValid({
 						redirectOnSave: false,
-						showErrors: false,
+						showErrors: true,
 					});
 				}
 			)

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -381,6 +381,8 @@ export default function _JournalPortlet({
 							document.getElementById(
 								`${namespace}articleId`
 							).value = articleId;
+
+							Liferay.fire('asyncFormSubmission', {articleId});
 						}
 					}
 				}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -15,7 +15,7 @@ import removeAlert from './removeAlert';
 import showAlert from './showAlert';
 
 export default function SaveButtons({
-	articleId,
+	articleId: initialArticleId,
 	defaultLanguageId,
 	displayDate,
 	editingDefaultValues,
@@ -28,6 +28,8 @@ export default function SaveButtons({
 	workflowEnabled,
 }) {
 	const formId = `${portletNamespace}fm1`;
+
+	const [articleId, setArticleId] = useState(initialArticleId);
 
 	const [
 		{publishModalAction, publishModalVisible},
@@ -157,6 +159,19 @@ export default function SaveButtons({
 			}
 		);
 	};
+
+	useEffect(() => {
+		if (Liferay.FeatureFlags['LPS-141392']) {
+			const updateArticleId = ({articleId}) => {
+				setArticleId(articleId);
+			};
+			Liferay.on('asyncFormSubmission', updateArticleId);
+
+			return () => {
+				Liferay.detach('asyncFormSubmission', updateArticleId);
+			};
+		}
+	}, []);
 
 	return (
 		<div className="d-flex">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -38,6 +38,9 @@ export default function SaveButtons({
 
 	useEffect(() => {
 		initializeLock('publishing', {
+			errorIndicator: document.getElementById(
+				`${portletNamespace}lockErrorIndicator`
+			),
 			lockedIndicator: document.getElementById(
 				`${portletNamespace}savingChangesIndicator`
 			),

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/initializeLock.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/initializeLock.js
@@ -5,11 +5,17 @@
 
 export default function initializeLock(
 	name,
-	{lockedIndicator, namespace, onLockChange, unlockedIndicator}
+	{
+		errorIndicator,
+		lockedIndicator,
+		namespace,
+		onLockChange,
+		unlockedIndicator,
+	}
 ) {
 	let locked = false;
 
-	const toggle = (nextValue) => {
+	const toggle = (nextValue, error = false) => {
 		if (nextValue === locked) {
 			throw new Error(
 				`${name} is already ${locked ? 'locked' : 'unlocked'}`
@@ -21,20 +27,29 @@ export default function initializeLock(
 		requestAnimationFrame(() => {
 			onLockChange?.({isLocked: locked});
 
-			if (locked) {
-				lockedIndicator?.classList.replace('d-none', 'd-flex');
+			if (error) {
+				lockedIndicator?.classList.replace('d-flex', 'd-none');
 				unlockedIndicator?.classList.replace('d-flex', 'd-none');
+				errorIndicator?.classList.replace('d-none', 'd-flex');
 			}
 			else {
-				lockedIndicator?.classList.replace('d-flex', 'd-none');
-				unlockedIndicator?.classList.replace('d-none', 'd-flex');
+				if (locked) {
+					lockedIndicator?.classList.replace('d-none', 'd-flex');
+					unlockedIndicator?.classList.replace('d-flex', 'd-none');
+					errorIndicator?.classList.replace('d-flex', 'd-none');
+				}
+				else {
+					lockedIndicator?.classList.replace('d-flex', 'd-none');
+					unlockedIndicator?.classList.replace('d-none', 'd-flex');
+					errorIndicator?.classList.replace('d-flex', 'd-none');
+				}
 			}
 		});
 	};
 
 	Liferay.component(`${namespace}${name}`, {
 		isLocked: () => locked,
-		lock: () => toggle(true),
-		unlock: () => toggle(false),
+		lock: (error) => toggle(true, error),
+		unlock: (error) => toggle(false, error),
 	});
 }

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -141,6 +141,68 @@ autoSaveAsDraftTest(
 	}
 );
 
+autoSaveAsDraftTest(
+	'LPD-26856: Web content should be saved as darft after changing the title and the content',
+	async ({apiHelpers, journalEditArticlePage, page, site}) => {
+		const localizableFieldName = 'Text56789';
+		const structureName = 'Structure 2';
+		const title = getRandomString();
+		const content = getRandomString();
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [{name: localizableFieldName, repeatable: false}],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		await journalEditArticlePage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		await fillAndClickOutside(
+			page,
+			page.getByPlaceholder('Untitled ' + structureName),
+			title
+		);
+
+		const localizableField = page.getByRole('textbox', {
+			name: localizableFieldName,
+		});
+
+		await fillAndClickOutside(page, localizableField, content);
+
+		const changesSavedIndicator = await page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
+		);
+
+		await expect(changesSavedIndicator).toBeVisible();
+
+		await page.getByTitle('Go to Web Content').click();
+
+		await expect(
+			page.getByRole('heading', {name: 'Web Content'})
+		).toBeVisible({timeout: 1000});
+
+		const article = page.getByRole('link', {name: title});
+
+		article.waitFor();
+
+		article.click();
+
+		await expect(page.getByRole('heading', {name: title})).toBeVisible({
+			timeout: 1000,
+		});
+
+		await expect(page.getByLabel(localizableFieldName)).toHaveValue(
+			content,
+			{timeout: 1000}
+		);
+	}
+);
+
 keepTitlesUntranslated(
 	'LPD-20723: Clay link is translating asset titles/names by default in vertical card',
 	async ({apiHelpers, journalPage, page, site}) => {

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -66,6 +66,15 @@ const expect = baseExpect.extend({
 	}),
 });
 
+const autoSaveAsDraftTest = mergeTests(
+	baseTest,
+	featureFlagsTest({
+		'LPD-11228': true,
+		'LPD-15596': true,
+		'LPS-141392': true,
+	})
+);
+
 const keepTitlesUntranslated = mergeTests(baseTest);
 
 const prefixUrlTest = mergeTests(
@@ -98,6 +107,39 @@ const aiCreateImageTest = mergeTests(
 );
 
 const privateContentIconTest = mergeTests(baseTest);
+
+autoSaveAsDraftTest(
+	'LPD-26854: LockIndicator should have an errorState',
+	async ({apiHelpers, journalEditArticlePage, page, site}) => {
+		const localizableFieldName = 'Text56789';
+		const structureName = 'Structure 2';
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [{name: localizableFieldName, repeatable: false}],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		await journalEditArticlePage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		const localizableField = page.getByRole('textbox', {
+			name: localizableFieldName,
+		});
+
+		await fillAndClickOutside(page, localizableField);
+
+		const errorIndicator = await page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_lockErrorIndicator'
+		);
+
+		await expect(errorIndicator).toBeVisible();
+	}
+);
 
 keepTitlesUntranslated(
 	'LPD-20723: Clay link is translating asset titles/names by default in vertical card',


### PR DESCRIPTION
Hey,

# What is this trying to solve?

I sent this in one PR as all of them is connected to resolve the issues under [LPD-24043](https://liferay.atlassian.net/browse/LPD-24043) and [LPD-24020](https://liferay.atlassian.net/browse/LPD-24020)

Explain *what* you're trying to do, without talking about *how* you're doing it. Here, brevity is a virtue, don't get into too much detail. An overview should be more than enough.

# How am I fixing it?

I introduced an errorState for the lock indicator, in case we cannot save the article as draft due to some missing required field like the title, we show an error.

In order to trigger this, I introduced frontend validation to the fields when saving the article as draft, I trigger the same validation what we would do when publishing the web content.

The friendlyURL is a special field, when we first save the web content we create a friendlyURL for the web content. This information is provided now as a parameter in the url, so we can update the field once the first save as draft action happens, so we can avoid friendlyURL exceptions on subsequent update article actions

In order to be able to publish the Article, that was already saved as draft, I had to update the generated articleId within WaveButton.es.js as well, this ensures an update instead of a duplication with a new articleId.

# How can you verify that it works?
"Follow the steps described in (https://liferay.atlassian.net/browse/LPD-24043) and [LPD-24020](https://liferay.atlassian.net/browse/LPD-24020)"

Run the functional tests

[LPD-24043]: https://liferay.atlassian.net/browse/LPD-24043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-24020]: https://liferay.atlassian.net/browse/LPD-24020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-24020]: https://liferay.atlassian.net/browse/LPD-24020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ