### PR TITLE
LPD-29382 Use data-testid as test id attribute for all DSM and fragment tests

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-views-web/config.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'frontend-data-set-views-web',
 	testDir: 'tests/frontend-data-set-views-web',
+	use: {
+		testIdAttribute: 'data-testid',
+	},
 };


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPD-29381

In this PR we are ensuring pw looks for the right testId attribute. The value of this attribute, unfortunately, is not consistent across the entire DXP codebase (at least we have `data-qa-id` and `data-testid`). While a decision is made, we guarantee no surprises in DSM tests because of this by setting a local configuration.