### PR TITLE
LPD-31114 Fix flaky test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntryTag.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntryTag.testcase
@@ -531,6 +531,10 @@ definition {
 		task ("Then only the matching tag is displayed") {
 			Questions.viewTags(tagName = "tag1");
 
+			Questions.search(
+				searchKey = "tag1",
+				searchTag = "true");
+
 			Questions.viewNoTags(tagsList = "tag2,tag3");
 
 			Click(


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-31114
The test QuestionsEntryTag#QuestionTagsCanBeSearchedInTagsTab fails sometimes when the search box clears before testing if tags that should not be on the page.

# How am I fixing it?
I am searching for tag1 again to ensure the search results are accurate.

# How can you verify that it works?
Run the test for QuestionsEntryTag#QuestionTagsCanBeSearchedInTagsTab