### PR TITLE
LPD-31812 Remove LPD-10754 Feature Flag

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -618,20 +618,13 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					);
 				}
 
-				String listTypeDefinitionERC = null;
-				String sourceType = null;
-
-				if (FeatureFlagManagerUtil.isEnabled("LPD-10754")) {
-					listTypeDefinitionERC = MapUtil.getString(
-						properties, "source");
-					sourceType = MapUtil.getString(properties, "sourceType");
-				}
-				else {
-					listTypeDefinitionERC = MapUtil.getString(
-						properties, "listTypeDefinitionERC");
-				}
+				String listTypeDefinitionERC = MapUtil.getString(
+					properties, "source");
 
 				if (Validator.isNotNull(listTypeDefinitionERC)) {
+					String sourceType = MapUtil.getString(
+						properties, "sourceType");
+
 					JSONObject selectionFilterJSONObject = JSONUtil.put(
 						"autocompleteEnabled", true
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/FDSAdminPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/FDSAdminPortlet.java
@@ -425,189 +425,150 @@ public class FDSAdminPortlet extends MVCPortlet {
 						_language.get(locale, "preselected-values"),
 						"preselectedValues", false)));
 
-		if (FeatureFlagManagerUtil.isEnabled("LPD-10754")) {
-			ObjectField itemKeyObjectField = ObjectFieldUtil.createObjectField(
+		ObjectField itemKeyObjectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+			_language.get(locale, "item-key"), "itemKey", false);
+
+		_objectFieldLocalService.addCustomObjectField(
+			itemKeyObjectField.getExternalReferenceCode(), userId,
+			itemKeyObjectField.getListTypeDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
+			itemKeyObjectField.getBusinessType(),
+			itemKeyObjectField.getDBType(), itemKeyObjectField.isIndexed(),
+			itemKeyObjectField.isIndexedAsKeyword(),
+			itemKeyObjectField.getIndexedLanguageId(),
+			itemKeyObjectField.getLabelMap(), false,
+			itemKeyObjectField.getName(), itemKeyObjectField.getReadOnly(),
+			itemKeyObjectField.getReadOnlyConditionExpression(),
+			itemKeyObjectField.isRequired(), itemKeyObjectField.isState(),
+			itemKeyObjectField.getObjectFieldSettings());
+
+		ObjectField itemLabelObjectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+			_language.get(locale, "item-label"), "itemLabel", false);
+
+		_objectFieldLocalService.addCustomObjectField(
+			itemLabelObjectField.getExternalReferenceCode(), userId,
+			itemLabelObjectField.getListTypeDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
+			itemLabelObjectField.getBusinessType(),
+			itemLabelObjectField.getDBType(), itemLabelObjectField.isIndexed(),
+			itemLabelObjectField.isIndexedAsKeyword(),
+			itemLabelObjectField.getIndexedLanguageId(),
+			itemLabelObjectField.getLabelMap(), false,
+			itemLabelObjectField.getName(), itemLabelObjectField.getReadOnly(),
+			itemLabelObjectField.getReadOnlyConditionExpression(),
+			itemLabelObjectField.isRequired(), itemLabelObjectField.isState(),
+			itemLabelObjectField.getObjectFieldSettings());
+
+		ObjectField restApplicationObjectField =
+			ObjectFieldUtil.createObjectField(
 				ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 				ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-				_language.get(locale, "item-key"), "itemKey", false);
+				_language.get(locale, "rest-application"), "restApplication",
+				false);
 
-			_objectFieldLocalService.addCustomObjectField(
-				itemKeyObjectField.getExternalReferenceCode(), userId,
-				itemKeyObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				itemKeyObjectField.getBusinessType(),
-				itemKeyObjectField.getDBType(), itemKeyObjectField.isIndexed(),
-				itemKeyObjectField.isIndexedAsKeyword(),
-				itemKeyObjectField.getIndexedLanguageId(),
-				itemKeyObjectField.getLabelMap(), false,
-				itemKeyObjectField.getName(), itemKeyObjectField.getReadOnly(),
-				itemKeyObjectField.getReadOnlyConditionExpression(),
-				itemKeyObjectField.isRequired(), itemKeyObjectField.isState(),
-				itemKeyObjectField.getObjectFieldSettings());
+		_objectFieldLocalService.addCustomObjectField(
+			restApplicationObjectField.getExternalReferenceCode(), userId,
+			restApplicationObjectField.getListTypeDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
+			restApplicationObjectField.getBusinessType(),
+			restApplicationObjectField.getDBType(),
+			restApplicationObjectField.isIndexed(),
+			restApplicationObjectField.isIndexedAsKeyword(),
+			restApplicationObjectField.getIndexedLanguageId(),
+			restApplicationObjectField.getLabelMap(), false,
+			restApplicationObjectField.getName(),
+			restApplicationObjectField.getReadOnly(),
+			restApplicationObjectField.getReadOnlyConditionExpression(),
+			restApplicationObjectField.isRequired(),
+			restApplicationObjectField.isState(),
+			restApplicationObjectField.getObjectFieldSettings());
 
-			ObjectField itemLabelObjectField =
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					_language.get(locale, "item-label"), "itemLabel", false);
+		ObjectField restEndpointObjectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+			_language.get(locale, "rest-endpoint"), "restEndpoint", false);
 
-			_objectFieldLocalService.addCustomObjectField(
-				itemLabelObjectField.getExternalReferenceCode(), userId,
-				itemLabelObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				itemLabelObjectField.getBusinessType(),
-				itemLabelObjectField.getDBType(),
-				itemLabelObjectField.isIndexed(),
-				itemLabelObjectField.isIndexedAsKeyword(),
-				itemLabelObjectField.getIndexedLanguageId(),
-				itemLabelObjectField.getLabelMap(), false,
-				itemLabelObjectField.getName(),
-				itemLabelObjectField.getReadOnly(),
-				itemLabelObjectField.getReadOnlyConditionExpression(),
-				itemLabelObjectField.isRequired(),
-				itemLabelObjectField.isState(),
-				itemLabelObjectField.getObjectFieldSettings());
+		_objectFieldLocalService.addCustomObjectField(
+			restEndpointObjectField.getExternalReferenceCode(), userId,
+			restEndpointObjectField.getListTypeDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
+			restEndpointObjectField.getBusinessType(),
+			restEndpointObjectField.getDBType(),
+			restEndpointObjectField.isIndexed(),
+			restEndpointObjectField.isIndexedAsKeyword(),
+			restEndpointObjectField.getIndexedLanguageId(),
+			restEndpointObjectField.getLabelMap(), false,
+			restEndpointObjectField.getName(),
+			restEndpointObjectField.getReadOnly(),
+			restEndpointObjectField.getReadOnlyConditionExpression(),
+			restEndpointObjectField.isRequired(),
+			restEndpointObjectField.isState(),
+			restEndpointObjectField.getObjectFieldSettings());
 
-			ObjectField restApplicationObjectField =
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					_language.get(locale, "rest-application"),
-					"restApplication", false);
+		ObjectField restSchemaObjectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+			_language.get(locale, "rest-schema"), "restSchema", false);
 
-			_objectFieldLocalService.addCustomObjectField(
-				restApplicationObjectField.getExternalReferenceCode(), userId,
-				restApplicationObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				restApplicationObjectField.getBusinessType(),
-				restApplicationObjectField.getDBType(),
-				restApplicationObjectField.isIndexed(),
-				restApplicationObjectField.isIndexedAsKeyword(),
-				restApplicationObjectField.getIndexedLanguageId(),
-				restApplicationObjectField.getLabelMap(), false,
-				restApplicationObjectField.getName(),
-				restApplicationObjectField.getReadOnly(),
-				restApplicationObjectField.getReadOnlyConditionExpression(),
-				restApplicationObjectField.isRequired(),
-				restApplicationObjectField.isState(),
-				restApplicationObjectField.getObjectFieldSettings());
+		_objectFieldLocalService.addCustomObjectField(
+			restSchemaObjectField.getExternalReferenceCode(), userId,
+			restSchemaObjectField.getListTypeDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
+			restSchemaObjectField.getBusinessType(),
+			restSchemaObjectField.getDBType(),
+			restSchemaObjectField.isIndexed(),
+			restSchemaObjectField.isIndexedAsKeyword(),
+			restSchemaObjectField.getIndexedLanguageId(),
+			restSchemaObjectField.getLabelMap(), false,
+			restSchemaObjectField.getName(),
+			restSchemaObjectField.getReadOnly(),
+			restSchemaObjectField.getReadOnlyConditionExpression(),
+			restSchemaObjectField.isRequired(), restSchemaObjectField.isState(),
+			restSchemaObjectField.getObjectFieldSettings());
 
-			ObjectField restEndpointObjectField =
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					_language.get(locale, "rest-endpoint"), "restEndpoint",
-					false);
+		ObjectField sourceObjectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+			_language.get(locale, "source"), "source", false);
 
-			_objectFieldLocalService.addCustomObjectField(
-				restEndpointObjectField.getExternalReferenceCode(), userId,
-				restEndpointObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				restEndpointObjectField.getBusinessType(),
-				restEndpointObjectField.getDBType(),
-				restEndpointObjectField.isIndexed(),
-				restEndpointObjectField.isIndexedAsKeyword(),
-				restEndpointObjectField.getIndexedLanguageId(),
-				restEndpointObjectField.getLabelMap(), false,
-				restEndpointObjectField.getName(),
-				restEndpointObjectField.getReadOnly(),
-				restEndpointObjectField.getReadOnlyConditionExpression(),
-				restEndpointObjectField.isRequired(),
-				restEndpointObjectField.isState(),
-				restEndpointObjectField.getObjectFieldSettings());
+		_objectFieldLocalService.addCustomObjectField(
+			sourceObjectField.getExternalReferenceCode(), userId,
+			sourceObjectField.getListTypeDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
+			sourceObjectField.getBusinessType(), sourceObjectField.getDBType(),
+			sourceObjectField.isIndexed(),
+			sourceObjectField.isIndexedAsKeyword(),
+			sourceObjectField.getIndexedLanguageId(),
+			sourceObjectField.getLabelMap(), false, sourceObjectField.getName(),
+			sourceObjectField.getReadOnly(),
+			sourceObjectField.getReadOnlyConditionExpression(),
+			sourceObjectField.isRequired(), sourceObjectField.isState(),
+			sourceObjectField.getObjectFieldSettings());
 
-			ObjectField restSchemaObjectField =
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					_language.get(locale, "rest-schema"), "restSchema", false);
+		ObjectField sourceTypeObjectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+			_language.get(locale, "source-type"), "sourceType", false);
 
-			_objectFieldLocalService.addCustomObjectField(
-				restSchemaObjectField.getExternalReferenceCode(), userId,
-				restSchemaObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				restSchemaObjectField.getBusinessType(),
-				restSchemaObjectField.getDBType(),
-				restSchemaObjectField.isIndexed(),
-				restSchemaObjectField.isIndexedAsKeyword(),
-				restSchemaObjectField.getIndexedLanguageId(),
-				restSchemaObjectField.getLabelMap(), false,
-				restSchemaObjectField.getName(),
-				restSchemaObjectField.getReadOnly(),
-				restSchemaObjectField.getReadOnlyConditionExpression(),
-				restSchemaObjectField.isRequired(),
-				restSchemaObjectField.isState(),
-				restSchemaObjectField.getObjectFieldSettings());
-
-			ObjectField sourceObjectField = ObjectFieldUtil.createObjectField(
-				ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-				ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-				_language.get(locale, "source"), "source", false);
-
-			_objectFieldLocalService.addCustomObjectField(
-				sourceObjectField.getExternalReferenceCode(), userId,
-				sourceObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				sourceObjectField.getBusinessType(),
-				sourceObjectField.getDBType(), sourceObjectField.isIndexed(),
-				sourceObjectField.isIndexedAsKeyword(),
-				sourceObjectField.getIndexedLanguageId(),
-				sourceObjectField.getLabelMap(), false,
-				sourceObjectField.getName(), sourceObjectField.getReadOnly(),
-				sourceObjectField.getReadOnlyConditionExpression(),
-				sourceObjectField.isRequired(), sourceObjectField.isState(),
-				sourceObjectField.getObjectFieldSettings());
-
-			ObjectField sourceTypeObjectField =
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					_language.get(locale, "source-type"), "sourceType", false);
-
-			_objectFieldLocalService.addCustomObjectField(
-				sourceTypeObjectField.getExternalReferenceCode(), userId,
-				sourceTypeObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				sourceTypeObjectField.getBusinessType(),
-				sourceTypeObjectField.getDBType(),
-				sourceTypeObjectField.isIndexed(),
-				sourceTypeObjectField.isIndexedAsKeyword(),
-				sourceTypeObjectField.getIndexedLanguageId(),
-				sourceTypeObjectField.getLabelMap(), false,
-				sourceTypeObjectField.getName(),
-				sourceTypeObjectField.getReadOnly(),
-				sourceTypeObjectField.getReadOnlyConditionExpression(),
-				sourceTypeObjectField.isRequired(),
-				sourceTypeObjectField.isState(),
-				sourceTypeObjectField.getObjectFieldSettings());
-		}
-		else {
-			ObjectField listTypeDefinitionERCObjectField =
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					_language.get(locale, "list-type-definition-erc"),
-					"listTypeDefinitionERC", false);
-
-			_objectFieldLocalService.addCustomObjectField(
-				listTypeDefinitionERCObjectField.getExternalReferenceCode(),
-				userId,
-				listTypeDefinitionERCObjectField.getListTypeDefinitionId(),
-				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
-				listTypeDefinitionERCObjectField.getBusinessType(),
-				listTypeDefinitionERCObjectField.getDBType(),
-				listTypeDefinitionERCObjectField.isIndexed(),
-				listTypeDefinitionERCObjectField.isIndexedAsKeyword(),
-				listTypeDefinitionERCObjectField.getIndexedLanguageId(),
-				listTypeDefinitionERCObjectField.getLabelMap(), false,
-				listTypeDefinitionERCObjectField.getName(),
-				listTypeDefinitionERCObjectField.getReadOnly(),
-				listTypeDefinitionERCObjectField.
-					getReadOnlyConditionExpression(),
-				listTypeDefinitionERCObjectField.isRequired(),
-				listTypeDefinitionERCObjectField.isState(),
-				listTypeDefinitionERCObjectField.getObjectFieldSettings());
-		}
+		_objectFieldLocalService.addCustomObjectField(
+			sourceTypeObjectField.getExternalReferenceCode(), userId,
+			sourceTypeObjectField.getListTypeDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(),
+			sourceTypeObjectField.getBusinessType(),
+			sourceTypeObjectField.getDBType(),
+			sourceTypeObjectField.isIndexed(),
+			sourceTypeObjectField.isIndexedAsKeyword(),
+			sourceTypeObjectField.getIndexedLanguageId(),
+			sourceTypeObjectField.getLabelMap(), false,
+			sourceTypeObjectField.getName(),
+			sourceTypeObjectField.getReadOnly(),
+			sourceTypeObjectField.getReadOnlyConditionExpression(),
+			sourceTypeObjectField.isRequired(), sourceTypeObjectField.isState(),
+			sourceTypeObjectField.getObjectFieldSettings());
 
 		_enableLocalization(fdsDynamicFilterObjectDefinition);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -282,7 +282,7 @@ function Filters({
 						},
 					},
 				],
-				size: Liferay.FeatureFlags['LPD-10754'] ? 'lg' : 'md',
+				size: 'lg',
 				status: 'info',
 				title: Liferay.Language.get('no-fields-available'),
 			});
@@ -309,7 +309,7 @@ function Filters({
 					/>
 				),
 				disableAutoClose: true,
-				size: Liferay.FeatureFlags['LPD-10754'] ? 'lg' : 'md',
+				size: 'lg',
 			});
 		}
 	};
@@ -351,7 +351,7 @@ function Filters({
 				/>
 			),
 			disableAutoClose: true,
-			size: Liferay.FeatureFlags['LPD-10754'] ? 'lg' : 'md',
+			size: 'lg',
 		});
 
 	const onDelete = async ({item}: {item: IFilter}) => {
@@ -393,7 +393,7 @@ function Filters({
 					},
 				},
 			],
-			size: Liferay.FeatureFlags['LPD-10754'] ? 'lg' : 'md',
+			size: 'lg',
 			status: 'warning',
 			title: Liferay.Language.get('delete-filter'),
 		});

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/ClientExtensionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/ClientExtensionFilter.tsx
@@ -97,12 +97,10 @@ function Body({
 	const validate = () => {
 		let isValid = true;
 
-		if (Liferay.FeatureFlags['LPD-10754']) {
-			const isLabelValid = isi18nFilterLabelsValid(i18nFilterLabels);
-			setLabelValidationError(!isLabelValid);
+		const isLabelValid = isi18nFilterLabelsValid(i18nFilterLabels);
+		setLabelValidationError(!isLabelValid);
 
-			isValid = isLabelValid;
-		}
+		isValid = isLabelValid;
 
 		if (!selectedField) {
 			setFieldValidationError(true);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/Configuration.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/Configuration.tsx
@@ -108,19 +108,17 @@ function Configuration({
 
 	return (
 		<>
-			{Liferay.FeatureFlags['LPD-10754'] && (
-				<ClayLayout.SheetSection className="mb-4">
-					<h3 className="sheet-subtitle">
-						{Liferay.Language.get('configuration')}
-					</h3>
+			<ClayLayout.SheetSection className="mb-4">
+				<h3 className="sheet-subtitle">
+					{Liferay.Language.get('configuration')}
+				</h3>
 
-					<ClayForm.Text>
-						{Liferay.Language.get(
-							'add-a-name-for-your-filter-and-select-a-field-to-start-creating-it'
-						)}
-					</ClayForm.Text>
-				</ClayLayout.SheetSection>
-			)}
+				<ClayForm.Text>
+					{Liferay.Language.get(
+						'add-a-name-for-your-filter-and-select-a-field-to-start-creating-it'
+					)}
+				</ClayForm.Text>
+			</ClayLayout.SheetSection>
 
 			<ClayForm.Group
 				className={classNames({
@@ -137,11 +135,11 @@ function Configuration({
 						setI18nFilterLabels(values);
 					}}
 					placeholder={Liferay.Language.get('add-a-name')}
-					required={Liferay.FeatureFlags['LPD-10754']}
+					required={true}
 					translations={i18nFilterLabels}
 				/>
 
-				{Liferay.FeatureFlags['LPD-10754'] && labelValidationError && (
+				{labelValidationError && (
 					<ValidationFeedback />
 				)}
 			</ClayForm.Group>
@@ -149,15 +147,11 @@ function Configuration({
 			<ClayForm.Group
 				className={classNames({
 					'has-error':
-						fieldInUseValidationError ||
-						(Liferay.FeatureFlags['LPD-10754'] &&
-							fieldValidationError),
+						fieldInUseValidationError || fieldValidationError,
 				})}
 			>
 				<label htmlFor={selectedFieldFormElementId}>
-					{Liferay.Language.get('filter-by')}
-
-					{Liferay.FeatureFlags['LPD-10754'] && <RequiredMark />}
+					<RequiredMark />
 				</label>
 
 				<FieldNameDropdown
@@ -183,7 +177,7 @@ function Configuration({
 					/>
 				)}
 
-				{Liferay.FeatureFlags['LPD-10754'] && fieldValidationError && (
+				{fieldValidationError && (
 					<ValidationFeedback />
 				)}
 			</ClayForm.Group>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/Configuration.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/Configuration.tsx
@@ -139,9 +139,7 @@ function Configuration({
 					translations={i18nFilterLabels}
 				/>
 
-				{labelValidationError && (
-					<ValidationFeedback />
-				)}
+				{labelValidationError && <ValidationFeedback />}
 			</ClayForm.Group>
 
 			<ClayForm.Group
@@ -177,9 +175,7 @@ function Configuration({
 					/>
 				)}
 
-				{fieldValidationError && (
-					<ValidationFeedback />
-				)}
+				{fieldValidationError && <ValidationFeedback />}
 			</ClayForm.Group>
 		</>
 	);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/DateRangeFilter.tsx
@@ -99,12 +99,10 @@ function Body({
 	const validate = () => {
 		let isValid = true;
 
-		if (Liferay.FeatureFlags['LPD-10754']) {
-			const isLabelValid = isi18nFilterLabelsValid(i18nFilterLabels);
-			setLabelValidationError(!isLabelValid);
+		const isLabelValid = isi18nFilterLabelsValid(i18nFilterLabels);
+		setLabelValidationError(!isLabelValid);
 
-			isValid = isLabelValid;
-		}
+		isValid = isLabelValid;
 
 		if (!selectedField) {
 			setFieldValidationError(true);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -144,12 +144,10 @@ function Body({
 	const validate = () => {
 		let isValid = true;
 
-		if (Liferay.FeatureFlags['LPD-10754']) {
-			const isLabelValid = isi18nFilterLabelsValid(i18nFilterLabels);
-			setLabelValidationError(!isLabelValid);
+		const isLabelValid = isi18nFilterLabelsValid(i18nFilterLabels);
+		setLabelValidationError(!isLabelValid);
 
-			isValid = isLabelValid;
-		}
+		isValid = isLabelValid;
 
 		if (!selectedField) {
 			setFieldValidationError(true);
@@ -165,20 +163,19 @@ function Body({
 			}
 		}
 
-		if (Liferay.FeatureFlags['LPD-10754'] && !sourceType) {
+		if (!sourceType) {
 			setSourceTypeValidationError(true);
 
 			isValid = false;
 		}
 
-		if (Liferay.FeatureFlags['LPD-10754'] && !source) {
+		if (!source) {
 			setSourceValidationError(true);
 
 			isValid = false;
 		}
 
 		if (
-			Liferay.FeatureFlags['LPD-10754'] &&
 			sourceType &&
 			sourceType === ESelectionFilterSourceType.API_HEADLESS
 		) {
@@ -227,48 +224,39 @@ function Body({
 				label_i18n: i18nFilterLabels,
 			};
 
-			if (Liferay.FeatureFlags['LPD-10754']) {
-				if (sourceType === ESelectionFilterSourceType.API_HEADLESS) {
-					formData = {
-						...formData,
-						itemKey: selectedItemKey,
-						itemLabel: selectedItemLabel,
-						preselectedValues: JSON.stringify(
-							preselectedValues.map((item: any) => ({
-								label: item.label,
-								value: item.value,
-							}))
-						),
-						restApplication: selectedRESTApplication,
-						restEndpoint: selectedRESTEndpoint,
-						restSchema: selectedRESTSchema,
-						source: source as string,
-						sourceType,
-					};
-				}
-
-				if (sourceType === ESelectionFilterSourceType.PICKLIST) {
-					formData = {
-						...formData,
-						preselectedValues: JSON.stringify(
-							preselectedValues.map(
-								(item: any) => item.externalReferenceCode
-							)
-						),
-						source: (source as IPickList)?.externalReferenceCode,
-						sourceType,
-					};
-				}
-			}
-			else {
+			if (sourceType === ESelectionFilterSourceType.API_HEADLESS) {
 				formData = {
 					...formData,
-					listTypeDefinitionERC: (source as IPickList)
-						?.externalReferenceCode,
+					itemKey: selectedItemKey,
+					itemLabel: selectedItemLabel,
+					preselectedValues: JSON.stringify(
+						preselectedValues.map((item: any) => ({
+							label: item.label,
+							value: item.value,
+						}))
+					),
+					restApplication: selectedRESTApplication,
+					restEndpoint: selectedRESTEndpoint,
+					restSchema: selectedRESTSchema,
+					source: source as string,
+					sourceType,
 				};
 			}
 
-			formData = {
+			if (sourceType === ESelectionFilterSourceType.PICKLIST) {
+				formData = {
+					...formData,
+					preselectedValues: JSON.stringify(
+						preselectedValues.map(
+							(item: any) => item.externalReferenceCode
+						)
+					),
+					source: (source as IPickList)?.externalReferenceCode,
+					sourceType,
+				};
+			}
+
+ 			formData = {
 				...formData,
 				include: includeMode === 'include',
 				multiple,
@@ -301,11 +289,7 @@ function Body({
 				setPicklists(items);
 
 				const picklist = items.find((item) =>
-					Liferay.FeatureFlags['LPD-10754']
-						? String(item.externalReferenceCode) ===
-							(filter as any)?.source
-						: String(item.externalReferenceCode) ===
-							(filter as any)?.listTypeDefinitionERC
+					String(item.externalReferenceCode) === (filter as any)?.source
 				);
 
 				if (picklist) {
@@ -399,7 +383,6 @@ function Body({
 	}, [preselectedValueInput, source, sourceType]);
 
 	if (
-		!Liferay.FeatureFlags['LPD-10754'] &&
 		sourceType === ESelectionFilterSourceType.API_HEADLESS &&
 		!picklists.length
 	) {
@@ -444,546 +427,371 @@ function Body({
 
 				{!fieldInUseValidationError && (
 					<>
-						{Liferay.FeatureFlags['LPD-10754'] && (
+						<ClayLayout.SheetSection className="mb-4">
+							<h3 className="sheet-subtitle">
+								{Liferay.Language.get('filter-source')}
+							</h3>
+
+							<ClayForm.Text>
+								{Liferay.Language.get(
+									'the-filter-source-determines-the-values-to-be-offered-in-this-filter-to-the-user'
+								)}
+							</ClayForm.Text>
+						</ClayLayout.SheetSection>
+
+						<ClayForm.Group
+							className={classNames({
+								'has-error': sourceTypeValidationError,
+							})}
+						>
+							<label htmlFor={sourceOptionFormElementId}>
+								{Liferay.Language.get('source')}
+
+								<RequiredMark />
+							</label>
+
+							<ClaySelectWithOption
+								aria-label={Liferay.Language.get(
+									'choose-an-option'
+								)}
+								id={sourceOptionFormElementId}
+								name={sourceOptionFormElementId}
+								onChange={(event) => {
+									const newSourceType = event.target
+										.value as ESelectionFilterSourceType;
+
+									setSourceType(newSourceType);
+									setSourceTypeValidationError(false);
+
+									setSource(undefined);
+									setPreselectedValueInput('');
+
+									setPreselectedValues([]);
+								}}
+								options={[
+									{
+										disabled: true,
+										label: Liferay.Language.get(
+											'choose-an-option'
+										),
+										value: '',
+									},
+									{
+										disabled: false,
+										label: Liferay.Language.get(
+											'api-rest-application'
+										),
+										value: ESelectionFilterSourceType.API_HEADLESS,
+									},
+									{
+										disabled: false,
+										label: Liferay.Language.get(
+											'object-picklist'
+										),
+										value: ESelectionFilterSourceType.PICKLIST,
+									},
+								]}
+								required
+								title={Liferay.Language.get('source')}
+								value={sourceType || ''}
+							/>
+
+							{sourceTypeValidationError && (
+								<ClayForm.FeedbackGroup>
+									<ClayForm.FeedbackItem>
+										<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+
+										{Liferay.Language.get(
+											'this-field-is-required'
+										)}
+									</ClayForm.FeedbackItem>
+								</ClayForm.FeedbackGroup>
+							)}
+						</ClayForm.Group>
+
+						{sourceType &&
+							sourceType ===
+								ESelectionFilterSourceType.PICKLIST && (
+								<ObjectPicklist
+									filter={filter}
+									namespace={namespace}
+									onChange={(item: IPickList) => {
+										setSource(item);
+										setSourceValidationError(false);
+									}}
+									sourceValidationError={
+										sourceValidationError
+									}
+								/>
+							)}
+
+						{sourceType &&
+							sourceType ===
+								ESelectionFilterSourceType.API_HEADLESS && (
+								<ApiRestApplication
+									filter={filter as ISelectionFilter}
+									itemKeyValidationError={
+										itemKeyValidationError
+									}
+									itemLabelValidationError={
+										itemLabelValidationError
+									}
+									namespace={namespace}
+									onChange={({
+										selectedItemKey,
+										selectedItemLabel,
+										selectedRESTApplication,
+										selectedRESTEndpoint,
+										selectedRESTSchema,
+										sourceItems,
+									}) => {
+										setSelectedRESTApplication(
+											selectedRESTApplication
+										);
+										if (selectedRESTApplication) {
+											setRequiredRESTApplicationValidationError(
+												false
+											);
+										}
+
+										setSelectedRESTEndpoint(
+											selectedRESTEndpoint
+										);
+										if (selectedRESTEndpoint) {
+											setRESTEndpointValidationError(
+												false
+											);
+										}
+
+										const source =
+											getAPIHeadlessSourceURL(
+												selectedRESTApplication!.replace(
+													'/v1.0',
+													''
+												),
+												selectedRESTEndpoint
+											);
+
+										setSource(source as string);
+										setSourceValidationError(false);
+
+										setSelectedRESTSchema(
+											selectedRESTSchema
+										);
+										if (selectedRESTSchema) {
+											setRESTSchemaValidationError(
+												false
+											);
+										}
+
+										setSelectedItemKey(
+											selectedItemKey
+										);
+										setItemKeyValidationError(
+											false
+										);
+
+										setSelectedItemLabel(
+											selectedItemLabel
+										);
+										setItemLabelValidationError(
+											false
+										);
+
+										setFilteredSourceItems(
+											sourceItems
+										);
+									}}
+									preselectedValueInput={
+										preselectedValueInput
+									}
+									requiredRESTApplicationValidationError={
+										requiredRESTApplicationValidationError
+									}
+									restApplications={restApplications}
+									restEndpointValidationError={
+										restEndpointValidationError
+									}
+									restSchemaValidationError={
+										restSchemaValidationError
+									}
+									source={source as string}
+								/>
+							)}
+
+						{source && (
 							<>
 								<ClayLayout.SheetSection className="mb-4">
 									<h3 className="sheet-subtitle">
-										{Liferay.Language.get('filter-source')}
-									</h3>
-
-									<ClayForm.Text>
 										{Liferay.Language.get(
-											'the-filter-source-determines-the-values-to-be-offered-in-this-filter-to-the-user'
+											'filter-options'
 										)}
-									</ClayForm.Text>
+									</h3>
 								</ClayLayout.SheetSection>
-
 								<ClayForm.Group
 									className={classNames({
-										'has-error': sourceTypeValidationError,
+										'has-error': !isValidSingleMode,
 									})}
 								>
-									<label htmlFor={sourceOptionFormElementId}>
-										{Liferay.Language.get('source')}
-
-										<RequiredMark />
-									</label>
-
-									<ClaySelectWithOption
-										aria-label={Liferay.Language.get(
-											'choose-an-option'
+									<label
+										htmlFor={
+											preselectedValuesFormElementId
+										}
+									>
+										{Liferay.Language.get(
+											'preselected-values'
 										)}
-										id={sourceOptionFormElementId}
-										name={sourceOptionFormElementId}
-										onChange={(event) => {
-											const newSourceType = event.target
-												.value as ESelectionFilterSourceType;
-
-											setSourceType(newSourceType);
-											setSourceTypeValidationError(false);
-
-											setSource(undefined);
-											setPreselectedValueInput('');
-
-											setPreselectedValues([]);
-										}}
-										options={[
-											{
-												disabled: true,
-												label: Liferay.Language.get(
-													'choose-an-option'
-												),
-												value: '',
-											},
-											{
-												disabled: false,
-												label: Liferay.Language.get(
-													'api-rest-application'
-												),
-												value: ESelectionFilterSourceType.API_HEADLESS,
-											},
-											{
-												disabled: false,
-												label: Liferay.Language.get(
-													'object-picklist'
-												),
-												value: ESelectionFilterSourceType.PICKLIST,
-											},
-										]}
-										required
-										title={Liferay.Language.get('source')}
-										value={sourceType || ''}
-									/>
-
-									{sourceTypeValidationError && (
-										<ClayForm.FeedbackGroup>
-											<ClayForm.FeedbackItem>
-												<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-
-												{Liferay.Language.get(
-													'this-field-is-required'
-												)}
-											</ClayForm.FeedbackItem>
-										</ClayForm.FeedbackGroup>
-									)}
-								</ClayForm.Group>
-							</>
-						)}
-
-						{Liferay.FeatureFlags['LPD-10754'] ? (
-							<>
-								{sourceType &&
-									sourceType ===
-										ESelectionFilterSourceType.PICKLIST && (
-										<ObjectPicklist
-											filter={filter}
-											namespace={namespace}
-											onChange={(item: IPickList) => {
-												setSource(item);
-												setSourceValidationError(false);
-											}}
-											sourceValidationError={
-												sourceValidationError
-											}
-										/>
-									)}
-
-								{sourceType &&
-									sourceType ===
-										ESelectionFilterSourceType.API_HEADLESS && (
-										<ApiRestApplication
-											filter={filter as ISelectionFilter}
-											itemKeyValidationError={
-												itemKeyValidationError
-											}
-											itemLabelValidationError={
-												itemLabelValidationError
-											}
-											namespace={namespace}
-											onChange={({
-												selectedItemKey,
-												selectedItemLabel,
-												selectedRESTApplication,
-												selectedRESTEndpoint,
-												selectedRESTSchema,
-												sourceItems,
-											}) => {
-												setSelectedRESTApplication(
-													selectedRESTApplication
-												);
-												if (selectedRESTApplication) {
-													setRequiredRESTApplicationValidationError(
-														false
-													);
-												}
-
-												setSelectedRESTEndpoint(
-													selectedRESTEndpoint
-												);
-												if (selectedRESTEndpoint) {
-													setRESTEndpointValidationError(
-														false
-													);
-												}
-
-												const source =
-													getAPIHeadlessSourceURL(
-														selectedRESTApplication!.replace(
-															'/v1.0',
-															''
-														),
-														selectedRESTEndpoint
-													);
-
-												setSource(source as string);
-												setSourceValidationError(false);
-
-												setSelectedRESTSchema(
-													selectedRESTSchema
-												);
-												if (selectedRESTSchema) {
-													setRESTSchemaValidationError(
-														false
-													);
-												}
-
-												setSelectedItemKey(
-													selectedItemKey
-												);
-												setItemKeyValidationError(
-													false
-												);
-
-												setSelectedItemLabel(
-													selectedItemLabel
-												);
-												setItemLabelValidationError(
-													false
-												);
-
-												setFilteredSourceItems(
-													sourceItems
-												);
-											}}
-											preselectedValueInput={
-												preselectedValueInput
-											}
-											requiredRESTApplicationValidationError={
-												requiredRESTApplicationValidationError
-											}
-											restApplications={restApplications}
-											restEndpointValidationError={
-												restEndpointValidationError
-											}
-											restSchemaValidationError={
-												restSchemaValidationError
-											}
-											source={source as string}
-										/>
-									)}
-
-								{source && (
-									<>
-										<ClayLayout.SheetSection className="mb-4">
-											<h3 className="sheet-subtitle">
-												{Liferay.Language.get(
-													'filter-options'
-												)}
-											</h3>
-										</ClayLayout.SheetSection>
-										<ClayForm.Group
-											className={classNames({
-												'has-error': !isValidSingleMode,
-											})}
-										>
-											<label
-												htmlFor={
-													preselectedValuesFormElementId
-												}
-											>
-												{Liferay.Language.get(
-													'preselected-values'
-												)}
-
-												<span
-													className="label-icon lfr-portal-tooltip ml-2"
-													title={Liferay.Language.get(
-														'choose-values-to-preselect-for-your-filters-source-option'
-													)}
-												>
-													<ClayIcon symbol="question-circle-full" />
-												</span>
-											</label>
-
-											<CheckboxMultiSelect
-												allowsCustomLabel={false}
-												aria-label={Liferay.Language.get(
-													'preselected-values'
-												)}
-												inputName={
-													preselectedValuesFormElementId
-												}
-												items={preselectedValues.map(
-													(item) => {
-														let valueItem;
-
-														if (
-															sourceType ===
-															ESelectionFilterSourceType.PICKLIST
-														) {
-															valueItem = {
-																label: item.name,
-																value: String(
-																	item.externalReferenceCode
-																),
-															};
-														}
-
-														if (
-															sourceType ===
-															ESelectionFilterSourceType.API_HEADLESS
-														) {
-															valueItem = {
-																label: item.label,
-																value: item.value,
-															};
-														}
-
-														return valueItem as TItem;
-													}
-												)}
-												loadingState={4}
-												onChange={
-													setPreselectedValueInput
-												}
-												onItemsChange={(
-													selectedItems: any
-												) => {
-													let preselectedValues;
-
-													if (
-														sourceType ===
-														ESelectionFilterSourceType.API_HEADLESS
-													) {
-														preselectedValues =
-															selectedItems.map(
-																({
-																	value,
-																}: any) => {
-																	return filteredSourceItems.find(
-																		(
-																			item
-																		) =>
-																			String(
-																				item.value
-																			) ===
-																			String(
-																				value
-																			)
-																	);
-																}
-															);
-													}
-
-													if (
-														sourceType ===
-														ESelectionFilterSourceType.PICKLIST
-													) {
-														preselectedValues =
-															selectedItems.map(
-																({
-																	value,
-																}: any) => {
-																	return (
-																		source as IPickList
-																	).listTypeEntries.find(
-																		(
-																			item
-																		) =>
-																			String(
-																				item.externalReferenceCode
-																			) ===
-																			String(
-																				value
-																			)
-																	);
-																}
-															);
-													}
-
-													setPreselectedValues(
-														preselectedValues
-													);
-
-													setIncludeMode(
-														preselectedValues.length
-															? filter &&
-																(
-																	filter as ISelectionFilter
-																).include
-																? 'include'
-																: 'exclude'
-															: 'include'
-													);
-												}}
-												placeholder={Liferay.Language.get(
-													'select-a-default-value-for-your-filter'
-												)}
-												sourceItems={
-													filteredSourceItems
-												}
-												value={preselectedValueInput}
-											/>
-
-											{!isValidSingleMode && (
-												<ClayForm.FeedbackGroup>
-													<ClayForm.FeedbackItem>
-														<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-
-														{Liferay.Language.get(
-															'only-one-value-is-allowed-in-single-selection-mode'
-														)}
-													</ClayForm.FeedbackItem>
-												</ClayForm.FeedbackGroup>
-											)}
-										</ClayForm.Group>
-
-										<ClayLayout.Row justify="start">
-											<ClayLayout.Col size={6}>
-												<ClayForm.Group>
-													<label
-														htmlFor={
-															multipleFormElementId
-														}
-													>
-														{Liferay.Language.get(
-															'selection'
-														)}
-
-														<span
-															className="label-icon lfr-portal-tooltip ml-2"
-															title={Liferay.Language.get(
-																'determines-how-many-preselected-values-for-the-filter-can-be-added'
-															)}
-														>
-															<ClayIcon symbol="question-circle-full" />
-														</span>
-													</label>
-
-													<ClayRadioGroup
-														name={
-															multipleFormElementId
-														}
-														onChange={(
-															newVal: any
-														) => {
-															const newMultiple =
-																newVal ===
-																'true';
-															setMultiple(
-																newMultiple
-															);
-														}}
-														value={
-															multiple
-																? 'true'
-																: 'false'
-														}
-													>
-														<ClayRadio
-															label={Liferay.Language.get(
-																'multiple'
-															)}
-															value="true"
-														/>
-
-														<ClayRadio
-															label={Liferay.Language.get(
-																'single'
-															)}
-															value="false"
-														/>
-													</ClayRadioGroup>
-												</ClayForm.Group>
-											</ClayLayout.Col>
-
-											{preselectedValues?.length > 0 && (
-												<ClayLayout.Col size={6}>
-													<ClayForm.Group>
-														<label
-															htmlFor={
-																includeModeFormElementId
-															}
-														>
-															{Liferay.Language.get(
-																'filter-mode'
-															)}
-
-															<span
-																className="label-icon lfr-portal-tooltip ml-2"
-																title={Liferay.Language.get(
-																	'include-returns-only-the-selected-values.-exclude-returns-all-except-the-selected-ones'
-																)}
-															>
-																<ClayIcon symbol="question-circle-full" />
-															</span>
-														</label>
-
-														<ClayRadioGroup
-															name={
-																includeModeFormElementId
-															}
-															onChange={(
-																val: any
-															) => {
-																setIncludeMode(
-																	val
-																);
-															}}
-															value={includeMode}
-														>
-															<ClayRadio
-																label={Liferay.Language.get(
-																	'include'
-																)}
-																value="include"
-															/>
-
-															<ClayRadio
-																label={Liferay.Language.get(
-																	'exclude'
-																)}
-																value="exclude"
-															/>
-														</ClayRadioGroup>
-													</ClayForm.Group>
-												</ClayLayout.Col>
-											)}
-										</ClayLayout.Row>
-									</>
-								)}
-							</>
-						) : (
-							<>
-								<ClayForm.Group>
-									<label htmlFor={sourceOptionFormElementId}>
-										{Liferay.Language.get('source-options')}
 
 										<span
 											className="label-icon lfr-portal-tooltip ml-2"
 											title={Liferay.Language.get(
-												'choose-a-picklist-to-associate-with-this-filter'
+												'choose-values-to-preselect-for-your-filters-source-option'
 											)}
 										>
 											<ClayIcon symbol="question-circle-full" />
 										</span>
 									</label>
 
-									<ClaySelectWithOption
+									<CheckboxMultiSelect
+										allowsCustomLabel={false}
 										aria-label={Liferay.Language.get(
-											'source-options'
+											'preselected-values'
 										)}
-										name={sourceOptionFormElementId}
-										onChange={(event) => {
-											const picklist = picklists.find(
-												(item) =>
-													String(
-														item.externalReferenceCode
-													) === event.target.value
+										inputName={
+											preselectedValuesFormElementId
+										}
+										items={preselectedValues.map(
+											(item) => {
+												let valueItem;
+
+												if (
+													sourceType ===
+													ESelectionFilterSourceType.PICKLIST
+												) {
+													valueItem = {
+														label: item.name,
+														value: String(
+															item.externalReferenceCode
+														),
+													};
+												}
+
+												if (
+													sourceType ===
+													ESelectionFilterSourceType.API_HEADLESS
+												) {
+													valueItem = {
+														label: item.label,
+														value: item.value,
+													};
+												}
+
+												return valueItem as TItem;
+											}
+										)}
+										loadingState={4}
+										onChange={
+											setPreselectedValueInput
+										}
+										onItemsChange={(
+											selectedItems: any
+										) => {
+											let preselectedValues;
+
+											if (
+												sourceType ===
+												ESelectionFilterSourceType.API_HEADLESS
+											) {
+												preselectedValues =
+													selectedItems.map(
+														({
+															value,
+														}: any) => {
+															return filteredSourceItems.find(
+																(
+																	item
+																) =>
+																	String(
+																		item.value
+																	) ===
+																	String(
+																		value
+																	)
+															);
+														}
+													);
+											}
+
+											if (
+												sourceType ===
+												ESelectionFilterSourceType.PICKLIST
+											) {
+												preselectedValues =
+													selectedItems.map(
+														({
+															value,
+														}: any) => {
+															return (
+																source as IPickList
+															).listTypeEntries.find(
+																(
+																	item
+																) =>
+																	String(
+																		item.externalReferenceCode
+																	) ===
+																	String(
+																		value
+																	)
+															);
+														}
+													);
+											}
+
+											setPreselectedValues(
+												preselectedValues
 											);
 
-											setSource(picklist);
-
-											setPreselectedValues([]);
+											setIncludeMode(
+												preselectedValues.length
+													? filter &&
+														(
+															filter as ISelectionFilter
+														).include
+														? 'include'
+														: 'exclude'
+													: 'include'
+											);
 										}}
-										options={[
-											{
-												disabled: true,
-												label: Liferay.Language.get(
-													'select'
-												),
-												value: '',
-											},
-											...picklists.map((item) => ({
-												label: item.name,
-												value: item.externalReferenceCode,
-											})),
-										]}
-										title={Liferay.Language.get(
-											'source-options'
+										placeholder={Liferay.Language.get(
+											'select-a-default-value-for-your-filter'
 										)}
-										value={
-											(source as IPickList)
-												?.externalReferenceCode || ''
+										sourceItems={
+											filteredSourceItems
 										}
+										value={preselectedValueInput}
 									/>
+
+									{!isValidSingleMode && (
+										<ClayForm.FeedbackGroup>
+											<ClayForm.FeedbackItem>
+												<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+
+												{Liferay.Language.get(
+													'only-one-value-is-allowed-in-single-selection-mode'
+												)}
+											</ClayForm.FeedbackItem>
+										</ClayForm.FeedbackGroup>
+									)}
 								</ClayForm.Group>
 
-								{source && (
-									<>
+								<ClayLayout.Row justify="start">
+									<ClayLayout.Col size={6}>
 										<ClayForm.Group>
 											<label
-												htmlFor={multipleFormElementId}
+												htmlFor={
+													multipleFormElementId
+												}
 											>
 												{Liferay.Language.get(
 													'selection'
@@ -1000,14 +808,23 @@ function Body({
 											</label>
 
 											<ClayRadioGroup
-												name={multipleFormElementId}
-												onChange={(newVal: any) => {
+												name={
+													multipleFormElementId
+												}
+												onChange={(
+													newVal: any
+												) => {
+													const newMultiple =
+														newVal ===
+														'true';
 													setMultiple(
-														newVal === 'true'
+														newMultiple
 													);
 												}}
 												value={
-													multiple ? 'true' : 'false'
+													multiple
+														? 'true'
+														: 'false'
 												}
 											>
 												<ClayRadio
@@ -1025,108 +842,10 @@ function Body({
 												/>
 											</ClayRadioGroup>
 										</ClayForm.Group>
-										<ClayForm.Group
-											className={classNames({
-												'has-error': !isValidSingleMode,
-											})}
-										>
-											<label
-												htmlFor={
-													preselectedValuesFormElementId
-												}
-											>
-												{Liferay.Language.get(
-													'preselected-values'
-												)}
+									</ClayLayout.Col>
 
-												<span
-													className="label-icon lfr-portal-tooltip ml-2"
-													title={Liferay.Language.get(
-														'choose-values-to-preselect-for-your-filters-source-option'
-													)}
-												>
-													<ClayIcon symbol="question-circle-full" />
-												</span>
-											</label>
-
-											<CheckboxMultiSelect
-												allowsCustomLabel={false}
-												aria-label={Liferay.Language.get(
-													'preselected-values'
-												)}
-												inputName={
-													preselectedValuesFormElementId
-												}
-												items={preselectedValues.map(
-													(item) => ({
-														label: item.name,
-														value: String(
-															item.externalReferenceCode
-														),
-													})
-												)}
-												loadingState={4}
-												onChange={
-													setPreselectedValueInput
-												}
-												onItemsChange={(
-													selectedItems: any
-												) => {
-													const preselectedValues =
-														selectedItems.map(
-															({value}: any) => {
-																return (
-																	source as IPickList
-																).listTypeEntries.find(
-																	(item) =>
-																		String(
-																			item.externalReferenceCode
-																		) ===
-																		String(
-																			value
-																		)
-																);
-															}
-														);
-
-													setPreselectedValues(
-														preselectedValues
-													);
-
-													setIncludeMode(
-														preselectedValues.length
-															? filter &&
-																(
-																	filter as ISelectionFilter
-																).include
-																? 'include'
-																: 'exclude'
-															: 'include'
-													);
-												}}
-												placeholder={Liferay.Language.get(
-													'select-a-default-value-for-your-filter'
-												)}
-												sourceItems={
-													filteredSourceItems
-												}
-												value={preselectedValueInput}
-											/>
-
-											{!isValidSingleMode && (
-												<ClayForm.FeedbackGroup>
-													<ClayForm.FeedbackItem>
-														<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-
-														{Liferay.Language.get(
-															'only-one-value-is-allowed-in-single-selection-mode'
-														)}
-													</ClayForm.FeedbackItem>
-												</ClayForm.FeedbackGroup>
-											)}
-										</ClayForm.Group>
-
-										{preselectedValues?.length > 0 && (
+									{preselectedValues?.length > 0 && (
+										<ClayLayout.Col size={6}>
 											<ClayForm.Group>
 												<label
 													htmlFor={
@@ -1151,9 +870,13 @@ function Body({
 													name={
 														includeModeFormElementId
 													}
-													onChange={(val: any) =>
-														setIncludeMode(val)
-													}
+													onChange={(
+														val: any
+													) => {
+														setIncludeMode(
+															val
+														);
+													}}
 													value={includeMode}
 												>
 													<ClayRadio
@@ -1171,9 +894,9 @@ function Body({
 													/>
 												</ClayRadioGroup>
 											</ClayForm.Group>
-										)}
-									</>
-								)}
+										</ClayLayout.Col>
+									)}
+								</ClayLayout.Row>
 							</>
 						)}
 					</>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -256,7 +256,7 @@ function Body({
 				};
 			}
 
- 			formData = {
+			formData = {
 				...formData,
 				include: includeMode === 'include',
 				multiple,
@@ -288,8 +288,10 @@ function Body({
 			getAllPicklists().then((items) => {
 				setPicklists(items);
 
-				const picklist = items.find((item) =>
-					String(item.externalReferenceCode) === (filter as any)?.source
+				const picklist = items.find(
+					(item) =>
+						String(item.externalReferenceCode) ===
+						(filter as any)?.source
 				);
 
 				if (picklist) {
@@ -563,14 +565,13 @@ function Body({
 											);
 										}
 
-										const source =
-											getAPIHeadlessSourceURL(
-												selectedRESTApplication!.replace(
-													'/v1.0',
-													''
-												),
-												selectedRESTEndpoint
-											);
+										const source = getAPIHeadlessSourceURL(
+											selectedRESTApplication!.replace(
+												'/v1.0',
+												''
+											),
+											selectedRESTEndpoint
+										);
 
 										setSource(source as string);
 										setSourceValidationError(false);
@@ -579,28 +580,16 @@ function Body({
 											selectedRESTSchema
 										);
 										if (selectedRESTSchema) {
-											setRESTSchemaValidationError(
-												false
-											);
+											setRESTSchemaValidationError(false);
 										}
 
-										setSelectedItemKey(
-											selectedItemKey
-										);
-										setItemKeyValidationError(
-											false
-										);
+										setSelectedItemKey(selectedItemKey);
+										setItemKeyValidationError(false);
 
-										setSelectedItemLabel(
-											selectedItemLabel
-										);
-										setItemLabelValidationError(
-											false
-										);
+										setSelectedItemLabel(selectedItemLabel);
+										setItemLabelValidationError(false);
 
-										setFilteredSourceItems(
-											sourceItems
-										);
+										setFilteredSourceItems(sourceItems);
 									}}
 									preselectedValueInput={
 										preselectedValueInput
@@ -623,9 +612,7 @@ function Body({
 							<>
 								<ClayLayout.SheetSection className="mb-4">
 									<h3 className="sheet-subtitle">
-										{Liferay.Language.get(
-											'filter-options'
-										)}
+										{Liferay.Language.get('filter-options')}
 									</h3>
 								</ClayLayout.SheetSection>
 								<ClayForm.Group
@@ -634,9 +621,7 @@ function Body({
 									})}
 								>
 									<label
-										htmlFor={
-											preselectedValuesFormElementId
-										}
+										htmlFor={preselectedValuesFormElementId}
 									>
 										{Liferay.Language.get(
 											'preselected-values'
@@ -660,42 +645,36 @@ function Body({
 										inputName={
 											preselectedValuesFormElementId
 										}
-										items={preselectedValues.map(
-											(item) => {
-												let valueItem;
+										items={preselectedValues.map((item) => {
+											let valueItem;
 
-												if (
-													sourceType ===
-													ESelectionFilterSourceType.PICKLIST
-												) {
-													valueItem = {
-														label: item.name,
-														value: String(
-															item.externalReferenceCode
-														),
-													};
-												}
-
-												if (
-													sourceType ===
-													ESelectionFilterSourceType.API_HEADLESS
-												) {
-													valueItem = {
-														label: item.label,
-														value: item.value,
-													};
-												}
-
-												return valueItem as TItem;
+											if (
+												sourceType ===
+												ESelectionFilterSourceType.PICKLIST
+											) {
+												valueItem = {
+													label: item.name,
+													value: String(
+														item.externalReferenceCode
+													),
+												};
 											}
-										)}
+
+											if (
+												sourceType ===
+												ESelectionFilterSourceType.API_HEADLESS
+											) {
+												valueItem = {
+													label: item.label,
+													value: item.value,
+												};
+											}
+
+											return valueItem as TItem;
+										})}
 										loadingState={4}
-										onChange={
-											setPreselectedValueInput
-										}
-										onItemsChange={(
-											selectedItems: any
-										) => {
+										onChange={setPreselectedValueInput}
+										onItemsChange={(selectedItems: any) => {
 											let preselectedValues;
 
 											if (
@@ -704,13 +683,9 @@ function Body({
 											) {
 												preselectedValues =
 													selectedItems.map(
-														({
-															value,
-														}: any) => {
+														({value}: any) => {
 															return filteredSourceItems.find(
-																(
-																	item
-																) =>
+																(item) =>
 																	String(
 																		item.value
 																	) ===
@@ -728,15 +703,11 @@ function Body({
 											) {
 												preselectedValues =
 													selectedItems.map(
-														({
-															value,
-														}: any) => {
+														({value}: any) => {
 															return (
 																source as IPickList
 															).listTypeEntries.find(
-																(
-																	item
-																) =>
+																(item) =>
 																	String(
 																		item.externalReferenceCode
 																	) ===
@@ -766,9 +737,7 @@ function Body({
 										placeholder={Liferay.Language.get(
 											'select-a-default-value-for-your-filter'
 										)}
-										sourceItems={
-											filteredSourceItems
-										}
+										sourceItems={filteredSourceItems}
 										value={preselectedValueInput}
 									/>
 
@@ -789,9 +758,7 @@ function Body({
 									<ClayLayout.Col size={6}>
 										<ClayForm.Group>
 											<label
-												htmlFor={
-													multipleFormElementId
-												}
+												htmlFor={multipleFormElementId}
 											>
 												{Liferay.Language.get(
 													'selection'
@@ -808,23 +775,14 @@ function Body({
 											</label>
 
 											<ClayRadioGroup
-												name={
-													multipleFormElementId
-												}
-												onChange={(
-													newVal: any
-												) => {
+												name={multipleFormElementId}
+												onChange={(newVal: any) => {
 													const newMultiple =
-														newVal ===
-														'true';
-													setMultiple(
-														newMultiple
-													);
+														newVal === 'true';
+													setMultiple(newMultiple);
 												}}
 												value={
-													multiple
-														? 'true'
-														: 'false'
+													multiple ? 'true' : 'false'
 												}
 											>
 												<ClayRadio
@@ -870,12 +828,8 @@ function Body({
 													name={
 														includeModeFormElementId
 													}
-													onChange={(
-														val: any
-													) => {
-														setIncludeMode(
-															val
-														);
+													onChange={(val: any) => {
+														setIncludeMode(val);
 													}}
 													value={includeMode}
 												>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
@@ -39,10 +39,7 @@ function ObjectPicklist({
 
 	useEffect(() => {
 		const picklist = picklists?.find((item) =>
-			Liferay.FeatureFlags['LPD-10754']
-				? String(item.externalReferenceCode) === (filter as any)?.source
-				: String(item.externalReferenceCode) ===
-					(filter as any)?.listTypeDefinitionERC
+			String(item.externalReferenceCode) === (filter as any)?.source
 		);
 
 		if (picklist) {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
@@ -38,8 +38,9 @@ function ObjectPicklist({
 	}, []);
 
 	useEffect(() => {
-		const picklist = picklists?.find((item) =>
-			String(item.externalReferenceCode) === (filter as any)?.source
+		const picklist = picklists?.find(
+			(item) =>
+				String(item.externalReferenceCode) === (filter as any)?.source
 		);
 
 		if (picklist) {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/env/portal-ext.properties
@@ -1,4 +1,3 @@
-feature.flag.LPD-10754=true
 feature.flag.LPD-15729=true
 feature.flag.LPD-19465=true
 feature.flag.LPS-164563=true

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
@@ -24,7 +24,6 @@ const PICKLIST_VALUE_NAME = 'Sample Value';
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPD-10754': true,
 		'LPS-178052': true,
 	}),
 	filtersPageTest,


### PR DESCRIPTION
In this PR we are removing all usages of `LPD-10754` feature flags, which controls the REST API headless selection filter management in the DSM

This has some implications:

- Data model compatibility: as this changes the way we generate data model, old models created before this FF was created (or when it was off) are no longer compatible
- Testing: some poshi tests related to picklist filters are going to break. This is a temporary situation, which we are managing under https://liferay.atlassian.net/browse/LPD-29346 in charge of migrating them