### PR TITLE
LPD-24968 Fix OpenIDConnect#AssertUserIsLoggedOutWhenAccessTokenIsExpiredByOIDCProvider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
@@ -197,7 +197,7 @@ definition {
 	@priority = 5
 	test AssertUserIsLoggedOutWhenAccessTokenIsExpiredByOIDCProvider {
 		property osgi.module.configuration.file.names = "com.liferay.portal.security.sso.openid.connect.configuration.OpenIdConnectConfiguration.config";
-		property osgi.module.configurations = "enabled=\"true\"${line.separator}tokenRefreshOffset=\"30\"";
+		property osgi.module.configurations = "enabled=\"true\"${line.separator}tokenRefreshOffset=\"30\"${line.separator}tokenRefreshSchedulerInterval=\"50\"";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -223,6 +223,8 @@ definition {
 			// This pause is required to allow the test to wait for the access token to expire.
 
 			Pause(value1 = 60000);
+
+			Refresh();
 		}
 
 		task ("Assert that user is logged out as OIDC provider session is over") {


### PR DESCRIPTION
[LPD-24968](https://liferay.atlassian.net/browse/LPD-24968)

Made changes to expire the session using the scheduler (setting the refresh to 50 instead of default value of 480).
Adding a refresh after the 60 seconds pause to assert the status after the expiration

[LPD-24968]: https://liferay.atlassian.net/browse/LPD-24968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ