### PR TITLE
LPD-24968 fix OpenIDConnect#AssertUserIsLoggedOutWhenAccessTokenIsExpiredByOIDCProvider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/functions/Refresh.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/Refresh.function
@@ -27,6 +27,16 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
+	function refreshNoLiferayLog() {
+		WaitForSPARefresh();
+
+		selenium.refresh();
+
+		selenium.assertJavaScriptErrors("true");
+
+		selenium.assertLiferayErrors();
+	}
+
 	function refreshNoSPARefresh() {
 		selenium.refresh();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
@@ -229,7 +229,7 @@ definition {
 			while (IsElementPresent(locator1 = "UserBar#USER_AVATAR_IMAGE")) {
 				Pause(value1 = 1000);
 
-				Refresh();
+				Refresh.refreshNoLiferayLog();
 			}
 
 			User.viewLoggedOutPG();


### PR DESCRIPTION
[LPD-24968](https://liferay.atlassian.net/browse/LPD-24968)

Created a new function within Refresh() class as per advice from members of poshi team.
After using this function the test passed, see: https://github.com/liferay-appsec/liferay-portal/pull/1868#issuecomment-2262183905

Opened this new PR to organize and squash commits.

[LPD-24968]: https://liferay.atlassian.net/browse/LPD-24968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ