### PR TITLE
LPD-32891 Remove digest creation from user creation

### DIFF
--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserSetDigestTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserSetDigestTest.java
@@ -64,19 +64,16 @@ public class UserSetDigestTest {
 	}
 
 	@Test
-	public void testSetDigestAfterPrerequisites() throws Exception {
-		User user = _userLocalService.createUser(RandomTestUtil.nextLong());
+	public void testDigestIsEmptyAfterCreatingUser() throws Exception {
+		User user = _testAddUserWithWorkflowHelper(
+			RandomTestUtil.randomString(), _generateRandomEmailAddress());
 
-		user.setScreenName(RandomTestUtil.randomString());
-		user.setEmailAddress(_generateRandomEmailAddress());
-
-		String digest = user.getDigest(RandomTestUtil.randomString());
-
-		Assert.assertNotNull(digest);
-
-		user.setDigest(digest);
-
-		Assert.assertEquals(digest, user.getDigest());
+		Assert.assertEquals(
+			"User digest should be empty after user creation", user.getDigest(),
+			"");
+		Assert.assertTrue(
+			user.getDigest(
+			).isEmpty());
 	}
 
 	private String _generateRandomEmailAddress() {
@@ -85,7 +82,7 @@ public class UserSetDigestTest {
 			RandomTestUtil.randomString(), ".com");
 	}
 
-	private void _testAddUserWithWorkflowHelper(
+	private User _testAddUserWithWorkflowHelper(
 			String screenName, String emailAddress)
 		throws Exception {
 
@@ -115,7 +112,7 @@ public class UserSetDigestTest {
 		long[] userGroupIds = null;
 		boolean sendEmail = false;
 
-		_userLocalService.addUserWithWorkflow(
+		return _userLocalService.addUserWithWorkflow(
 			creatorUserId, TestPropsValues.getCompanyId(), autoPassword,
 			password1, password2, autoScreenName, screenName, emailAddress,
 			locale, firstName, middleName, lastName, prefixListTypeId,

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1286,8 +1286,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setScreenName(screenName);
 		user.setEmailAddress(emailAddress);
 
-		user.setDigest(user.getDigest(password1));
-
 		Long ldapServerId = null;
 
 		if (serviceContext != null) {


### PR DESCRIPTION
Hi Team,
https://liferay.atlassian.net/browse/LPD-32891

Issue:
During user creation, we generate a digest token for WebDav, but no digest should be set when the user is created based on the expected behavior.

Solution:
Remove the logic that sets the digest.

Test fix:
https://liferay.atlassian.net/browse/LPD-1763
After the logic changed, there's no point in fixing and bringing back:
testSetDigestBeforePrerequisites
testSetEmailAndDigestBeforeScreenName
testSetScreenNameAndDigestBeforeEmailAddress

Instead, I created a test case that checks if the digest is not set after creating a user.

Please review my PR!

Thanks!