### PR TITLE
LPD-29518 Fix SAML#SSOLoginLogoutWorkSameWhenSitesConfiguredAsSP test failure

### DIFF
--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.saml.internal.servlet.filter;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.saml.helper.SamlHttpRequestHelper;
@@ -50,7 +51,9 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
-		if (_samlProviderConfigurationHelper.isEnabled() &&
+		if ((_samlProviderConfigurationHelper.isEnabled() ||
+			 StringPool.SLASH.equalsIgnoreCase(
+				 _samlHttpRequestHelper.getRequestPath(httpServletRequest))) &&
 			(httpServletRequest.getSession(false) != null)) {
 
 			return true;


### PR DESCRIPTION
This PR fixes both test's 
[LPD-29518](https://liferay.atlassian.net/browse/LPD-29518) and [LPD-25310](https://liferay.atlassian.net/browse/LPD-25310)

[LPD-29518]: https://liferay.atlassian.net/browse/LPD-29518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-25310]: https://liferay.atlassian.net/browse/LPD-25310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ