### PR TITLE
LPD-38849 Missing "There are no patches installed" and "The following patches are installed" INFO log traces during server startup

### DIFF
--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -74,7 +74,7 @@
 		<Logger level="ERROR" name="com.liferay.portal.events.LogoutPreAction" />
 		<Logger level="ERROR" name="com.liferay.portal.events.ServicePreAction" />
 		<Logger level="INFO" name="com.liferay.portal.events.StartupAction" />
-		<Logger level="WARN" name="com.liferay.portal.events.StartupHelperUtil" />
+		<Logger level="INFO" name="com.liferay.portal.events.StartupHelperUtil" />
 		<Logger level="ERROR" name="com.liferay.portal.image.ImageToolImpl" />
 		<Logger level="INFO" name="com.liferay.portal.internal.servlet.MainServlet" />
 		<Logger level="WARN" name="com.liferay.portal.json.jabsorb.serializer.LiferayJSONDeserializationWhitelist" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-38849

During the startup process of Liferay, we should have some INFO log traces that informs about the installed patches of the customer:
```
2024-08-06 07:29:33.619 INFO  [main][StartupHelperUtil:76] There are no patches installed
```

or 
```
2024-02-07 20:19:09.268 INFO [main][StartupHelperUtil:79] The following patches are installed: hotfix-80
```

But after [LPD-28798](https://liferay.atlassian.net/browse/LPD-28798) code changes these traces are no longer written to the log file.

This information is very useful from the support department perspective: when the customer sends their log file, we also have their exact patch information.

It is also the most useful and quick way of checking the exact version of LXC customers.

For more information see this slack thread: https://liferay.slack.com/archives/C01FP01V5L0/p1728297313799899 


**Steps to reproduce**

1. Start a Liferay installation
2. Open the log file and search for `There are no patches installed` or `The following patches are installed` 
      - Expected behavior: The log traces are present 
      - Wrong behavior: The log traces aren’t present 

