### PR TITLE
LPD-33140 Mitigate flakiness in SitetemplatesUsecase#SiteTemplatePageLinkInWebContentRedirectCorrectly

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
@@ -633,9 +633,13 @@ definition {
 
 			PortletEntry.inputTitle(title = "Web Content Title");
 
+			var cleanEntryExternalURL = StringUtil.replace(${entryExternalURL}, "http://", "");
+
+			WaitForVisible(locator1 = "CKEditor#TOOLBAR_LINK_BUTTON");
+
 			CKEditor.addEntryExternalURL(
 				displayText = ${entryExternalURL},
-				entryExternalURL = ${entryExternalURL},
+				entryExternalURL = ${cleanEntryExternalURL},
 				fieldLabel = "Content");
 
 			PortletEntry.publish();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
@@ -633,9 +633,9 @@ definition {
 
 			PortletEntry.inputTitle(title = "Web Content Title");
 
-			var cleanEntryExternalURL = StringUtil.replace(${entryExternalURL}, "http://", "");
-
 			WaitForVisible(locator1 = "CKEditor#TOOLBAR_LINK_BUTTON");
+
+			var cleanEntryExternalURL = StringUtil.replace(${entryExternalURL}, "http://", "");
 
 			CKEditor.addEntryExternalURL(
 				displayText = ${entryExternalURL},


### PR DESCRIPTION
The link button doesn't load completely when the page loads, so a wait for visible was added.