### PR TITLE
LPD 39971 Import attachments from URL

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 19.8.1
+Bundle-Version: 19.9.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
@@ -136,6 +136,51 @@ public class FileEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _fileBase64Supplier;
 
+	@Schema(
+		description = "optional field that specifies the source of the file to be downloaded, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.fileSourceURL`)"
+	)
+	public String getFileSourceURL() {
+		if (_fileSourceURLSupplier != null) {
+			fileSourceURL = _fileSourceURLSupplier.get();
+
+			_fileSourceURLSupplier = null;
+		}
+
+		return fileSourceURL;
+	}
+
+	public void setFileSourceURL(String fileSourceURL) {
+		this.fileSourceURL = fileSourceURL;
+
+		_fileSourceURLSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFileSourceURL(
+		UnsafeSupplier<String, Exception> fileSourceURLUnsafeSupplier) {
+
+		_fileSourceURLSupplier = () -> {
+			try {
+				return fileSourceURLUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "optional field that specifies the source of the file to be downloaded, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.fileSourceURL`)"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String fileSourceURL;
+
+	@JsonIgnore
+	private Supplier<String> _fileSourceURLSupplier;
+
 	@Schema
 	@Valid
 	public Folder getFolder() {
@@ -391,6 +436,22 @@ public class FileEntry implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(fileBase64));
+
+			sb.append("\"");
+		}
+
+		String fileSourceURL = getFileSourceURL();
+
+		if (fileSourceURL != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileSourceURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fileSourceURL));
 
 			sb.append("\"");
 		}

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.9.1
+version 1.10.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -35,6 +35,12 @@ components:
                         optional field with the content of the document in Base64, can be embedded with nestedFields
                         (the format of the nested field must be `<attachment field name>.fileBase64`)
                     type: string
+                fileSourceURL:
+                    # @review
+                    description:
+                        optional field that specifies the source of the file to be downloaded, can be embedded with
+                        nestedFields (the format of the nested field must be `<attachment field name>.fileSourceURL`)
+                    type: string
                 folder:
                     $ref: "#/components/schemas/Folder"
                 id:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -51,10 +51,12 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -111,6 +113,9 @@ import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
 import java.io.Serializable;
+
+import java.net.URL;
+import java.net.URLConnection;
 
 import java.text.ParseException;
 
@@ -1395,7 +1400,8 @@ public class DefaultObjectEntryManagerImpl
 
 		if ((fileEntry == null) ||
 			((fileEntry.getExternalReferenceCode() == null) &&
-			 (fileEntry.getFileBase64() == null))) {
+			 (fileEntry.getFileBase64() == null) &&
+			 (fileEntry.getFileSourceURL() == null))) {
 
 			return;
 		}
@@ -1412,14 +1418,31 @@ public class DefaultObjectEntryManagerImpl
 				"File source " + fileSource + " is not supported");
 		}
 
-		com.liferay.portal.kernel.repository.model.FileEntry
-			serviceBuilderFileEntry = null;
-
 		byte[] fileContent = {};
 
 		if (fileEntry.getFileBase64() != null) {
 			fileContent = _decode(fileEntry.getFileBase64());
 		}
+		else if (fileEntry.getFileSourceURL() != null) {
+			URL url = new URL(fileEntry.getFileSourceURL());
+
+			if (Objects.equals(url.getProtocol(), "file")) {
+
+				// TODO Have a more specific Exception
+
+				throw new SystemException("Unsupported URL protocol");
+			}
+
+			URLConnection urlConnection = url.openConnection();
+
+			urlConnection.connect();
+
+			fileContent = StreamUtil.toByteArray(
+				urlConnection.getInputStream());
+		}
+
+		com.liferay.portal.kernel.repository.model.FileEntry
+			serviceBuilderFileEntry = null;
 
 		String groupExternalReferenceCode = null;
 


### PR DESCRIPTION
**Problem**:

Currently, Liferay object entries require attachments to be uploaded as base64 or link it with an existing Document in the document library. This can be cumbersome, especially when dealing with large files or when attachments are stored remotely.

**Solution**:

Introduce a new property to the attachment field type schema: attachmentURL. (we can discuss on the name)

When importing an object entry, if the attachmentURL property is filled, Liferay will:

Fetch the document from the specified URL.

Store the downloaded document in the document library.

Associate the downloaded document with the object entry.

The new mechanism supports both batch imports and individual object entry creation through the POST endpoint.