### PR TITLE
LPD-41509 Revert "LPD-37385 Use template literal and use native Intl.…

### DIFF
--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -5,6 +5,7 @@
 
 import {expect, mergeTests} from '@playwright/test';
 import {createReadStream} from 'fs';
+import moment from 'moment';
 import path from 'path';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
@@ -125,19 +126,11 @@ test(
 		await expect(toastAlertContainer).toBeVisible();
 
 		await expect(toastAlertContainer).toHaveText(
-			`Success:${title} will be published on ${new Intl.DateTimeFormat(
-				'en-US',
-				{
-					day: 'numeric',
-					hour: 'numeric',
-					hour12: true,
-					minute: 'numeric',
-					month: 'numeric',
-					year: '2-digit',
-				}
-			)
-				.format(new Date(scheduleDate))
-				.replace(',', '')}.`
+			'Success:' +
+				title +
+				' will be published on ' +
+				moment(new Date(scheduleDate)).format('M/D/YY h:mm A') +
+				'.'
 		);
 	}
 );


### PR DESCRIPTION
…DateTimeFormat instead of moment"

This reverts commit c036b580ea4964725ec3f34bd419b46a7907e903.