### PR TITLE
LPD-39308 Only one LogoSelector should be change at a time

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/java/com/liferay/frontend/taglib/sample/web/internal/display/context/SampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/java/com/liferay/frontend/taglib/sample/web/internal/display/context/SampleDisplayContext.java
@@ -50,6 +50,14 @@ public class SampleDisplayContext {
 				"Input Localized"
 			).build(),
 			NavigationItemBuilder.setActive(
+				navigation.equals("logo-selector")
+			).setHref(
+				_renderResponse.createRenderURL(), "navigation",
+				"logo-selector"
+			).setLabel(
+				"Logo Selector"
+			).build(),
+			NavigationItemBuilder.setActive(
 				navigation.equals("search-iterator")
 			).setHref(
 				_renderResponse.createRenderURL(), "navigation",

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/java/com/liferay/frontend/taglib/sample/web/internal/display/context/SampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/java/com/liferay/frontend/taglib/sample/web/internal/display/context/SampleDisplayContext.java
@@ -52,8 +52,7 @@ public class SampleDisplayContext {
 			NavigationItemBuilder.setActive(
 				navigation.equals("logo-selector")
 			).setHref(
-				_renderResponse.createRenderURL(), "navigation",
-				"logo-selector"
+				_renderResponse.createRenderURL(), "navigation", "logo-selector"
 			).setLabel(
 				"Logo Selector"
 			).build(),

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/logo_selector.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/logo_selector.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/logo_selector.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/logo_selector.jsp
@@ -1,0 +1,15 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-frontend:logo-selector
+    label="First Logo"
+/>
+<liferay-frontend:logo-selector
+    label="Second Logo"
+/>

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/logo_selector.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/logo_selector.jsp
@@ -8,8 +8,9 @@
 <%@ include file="/init.jsp" %>
 
 <liferay-frontend:logo-selector
-    label="First Logo"
+	label="First Logo"
 />
+
 <liferay-frontend:logo-selector
-    label="Second Logo"
+	label="Second Logo"
 />

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,6 +26,9 @@ String navigation = ParamUtil.getString(request, "navigation", "fieldset");
 	<c:when test='<%= navigation.equals("input-localized") %>'>
 		<liferay-util:include page="/partials/input_localized.jsp" servletContext="<%= application %>" />
 	</c:when>
+	<c:when test='<%= navigation.equals("logo-selector") %>'>
+		<liferay-util:include page="/partials/logo_selector.jsp" servletContext="<%= application %>" />
+	</c:when>
 	<c:when test='<%= navigation.equals("search-iterator") %>'>
 		<liferay-util:include page="/partials/search_iterator.jsp" servletContext="<%= application %>" />
 	</c:when>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/logo_selector/LogoSelector.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/logo_selector/LogoSelector.js
@@ -18,6 +18,7 @@ export default function LogoSelector({
 	portletNamespace,
 	selectLogoURL,
 }) {
+	const [changingLogo, setChangingLogo] = useState(false);
 	const [values, setValues] = useState({
 		deleteLogo: false,
 		fileEntryId: '',
@@ -40,6 +41,8 @@ export default function LogoSelector({
 				escape(logoURL)
 			),
 		});
+
+		setChangingLogo(true);
 	};
 
 	const onClearLogo = () => {
@@ -57,12 +60,16 @@ export default function LogoSelector({
 			previewURL,
 			tempImageFileName,
 		}) => {
-			setValues({
-				deleteLogo: false,
-				fileEntryId,
-				logoName: tempImageFileName,
-				logoURL: previewURL,
-			});
+			if (changingLogo) {
+				setValues({
+					deleteLogo: false,
+					fileEntryId,
+					logoName: tempImageFileName,
+					logoURL: previewURL,
+				});
+
+				setChangingLogo(false);
+			}
 		};
 
 		Liferay.on('changeLogo', handleChangeLogo);
@@ -70,7 +77,7 @@ export default function LogoSelector({
 		return () => {
 			Liferay.detach('changeLogo', handleChangeLogo);
 		};
-	}, []);
+	}, [changingLogo]);
 
 	const {deleteLogo, fileEntryId, logoName, logoURL} = values;
 

--- a/modules/test/playwright/tests/frontend-taglib/logoSelector.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/logoSelector.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {taglibSamplePageTest} from './fixtures/taglibSamplePageTest';
+
+export const test = mergeTests(
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	taglibSamplePageTest
+);
+
+const linkName = 'Logo Selector';
+
+test(
+	'Logo selector changes do not affect to every selector in the page',
+	{tag: '@LPD-39308'},
+	async ({page, site, taglibSamplePage}) => {
+
+		await test.step('Create a content site and the taglib sample widget', async () => {
+			await taglibSamplePage.setupTaglibSampleWidget({
+				site,
+			});
+		});
+
+		await test.step('Select Panel link', async () => {
+			await taglibSamplePage.selectLink(linkName);
+		});
+
+		await test.step('Open modal to change first logo selector and fire change event', async () => {
+            await page.getByLabel('Change First Logo').click();
+
+            await page.evaluate(() => {
+                Liferay.fire('changeLogo', {tempImageFileName: 'New Logo Name'})
+            });
+
+            await page.frameLocator('iframe[title="Upload First Logo"]').getByRole('button', { name: 'Done' }).click();
+               
+		});
+
+		await test.step('Check second logo selector has not been changed', async () => {
+            const secondInput = page
+                .locator('div')
+                .filter({ hasText: /^Second Logo$/ })
+                .locator('[id^="_com_liferay_sample_web_portlet_TaglibSamplePortlet_INSTANCE_"]');
+
+            const secondLogoSection = page.
+                locator('div')
+                .filter({hasText: /^Second Logo$/ });
+
+            const secondLogoInput = secondLogoSection
+                .locator('[id^="_com_liferay_sample_web_portlet_TaglibSamplePortlet_INSTANCE_"]');
+            
+            await expect(secondInput).toHaveValue('Default');
+		});
+	}
+);

--- a/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
@@ -5,10 +5,10 @@
 
 import {Locator, expect, mergeTests} from '@playwright/test';
 
-import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
-import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
-import {loginTest} from '../../fixtures/loginTest';
-import {taglibSamplePageTest} from './fixtures/taglibSamplePageTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {samplePageTest} from '../../fixtures/samplePageTest';
 
 export const test = mergeTests(
 	featureFlagsTest({
@@ -16,7 +16,7 @@ export const test = mergeTests(
 	}),
 	isolatedSiteTest,
 	loginTest(),
-	taglibSamplePageTest
+	samplePageTest
 );
 
 const linkName = 'Logo Selector';
@@ -24,16 +24,16 @@ const linkName = 'Logo Selector';
 test(
 	'Logo selector changes do not affect to every selector in the page',
 	{tag: '@LPD-39308'},
-	async ({page, site, taglibSamplePage}) => {
+	async ({page, site, samplePage}) => {
 
 		await test.step('Create a content site and the taglib sample widget', async () => {
-			await taglibSamplePage.setupTaglibSampleWidget({
+			await samplePage.setupSampleWidget({
 				site,
 			});
 		});
 
 		await test.step('Select Panel link', async () => {
-			await taglibSamplePage.selectLink(linkName);
+			await samplePage.selectLink(linkName);
 		});
 
 		await test.step('Open modal to change first logo selector and fire change event', async () => {
@@ -51,14 +51,7 @@ test(
             const secondInput = page
                 .locator('div')
                 .filter({ hasText: /^Second Logo$/ })
-                .locator('[id^="_com_liferay_sample_web_portlet_TaglibSamplePortlet_INSTANCE_"]');
-
-            const secondLogoSection = page.
-                locator('div')
-                .filter({hasText: /^Second Logo$/ });
-
-            const secondLogoInput = secondLogoSection
-                .locator('[id^="_com_liferay_sample_web_portlet_TaglibSamplePortlet_INSTANCE_"]');
+                .locator('[id^="_com_liferay_frontend_taglib_sample_web_portlet_SamplePortlet_INSTANCE_"]');
             
             await expect(secondInput).toHaveValue('Default');
 		});

--- a/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
@@ -24,8 +24,7 @@ const linkName = 'Logo Selector';
 test(
 	'Logo selector changes do not affect to every selector in the page',
 	{tag: '@LPD-39308'},
-	async ({page, site, samplePage}) => {
-
+	async ({page, samplePage, site}) => {
 		await test.step('Create a content site and the taglib sample widget', async () => {
 			await samplePage.setupSampleWidget({
 				site,
@@ -37,23 +36,29 @@ test(
 		});
 
 		await test.step('Open modal to change first logo selector and fire change event', async () => {
-            await page.getByLabel('Change First Logo').click();
+			await page.getByLabel('Change First Logo').click();
 
-            await page.evaluate(() => {
-                Liferay.fire('changeLogo', {tempImageFileName: 'New Logo Name'})
-            });
+			await page.evaluate(() => {
+				Liferay.fire('changeLogo', {
+					tempImageFileName: 'New Logo Name',
+				});
+			});
 
-            await page.frameLocator('iframe[title="Upload First Logo"]').getByRole('button', { name: 'Done' }).click();
-               
+			await page
+				.frameLocator('iframe[title="Upload First Logo"]')
+				.getByRole('button', {name: 'Done'})
+				.click();
 		});
 
 		await test.step('Check second logo selector has not been changed', async () => {
-            const secondInput = page
-                .locator('div')
-                .filter({ hasText: /^Second Logo$/ })
-                .locator('[id^="_com_liferay_frontend_taglib_sample_web_portlet_SamplePortlet_INSTANCE_"]');
-            
-            await expect(secondInput).toHaveValue('Default');
+			const secondInput = page
+				.locator('div')
+				.filter({hasText: /^Second Logo$/})
+				.locator(
+					'[id^="_com_liferay_frontend_taglib_sample_web_portlet_SamplePortlet_INSTANCE_"]'
+				);
+
+			await expect(secondInput).toHaveValue('Default');
 		});
 	}
 );


### PR DESCRIPTION
Hi guys,

The issue here is when we update logo selector we do it for every logo selector in the page. In this pull request I'm checking which one is being modified so we only update that one.

Once this pull request gets merged, the code in https://github.com/liferay-frontend/liferay-portal/pull/4587 might need to be rebased.

Thanks.

Regards.