### PR TITLE
LPD-46621 Use redirect as default value in case URL gets shortened as this is a common pattern

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntryHistoryDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntryHistoryDisplayContext.java
@@ -55,7 +55,8 @@ public class DLViewEntryHistoryDisplayContext {
 			return _backURL;
 		}
 
-		_backURL = ParamUtil.getString(_renderRequest, "backURL");
+		_backURL = ParamUtil.getString(
+			_httpServletRequest, "backURL", _getRedirect());
 
 		return _backURL;
 	}


### PR DESCRIPTION
What is this trying to solve?
[LPD-46621](https://liferay.atlassian.net/browse/LPD-46621)
Paginated Document Library listing produces such a long URL, that PortletURLImpl choses to cut off backURL param from it, making View History Page's back button to be uninteractable.

How am I fixing it?
We can fall back to the redirect param. As this is a common pattern, tests are not included.

How can you verify that it works?
Follow the steps described in [LPD-46621](https://liferay.atlassian.net/browse/LPD-46621)

Cheers,
Balázs