### PR TITLE
LPD-50051 - The CX is cleared from the configuration after deploy

### DIFF
--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -32,7 +33,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -112,6 +113,8 @@ public class CETConfigurationFactoryTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+
+		_user = UserTestUtil.getAdminUser(_virtualInstanceCompanyId);
 	}
 
 	@Test
@@ -132,14 +135,14 @@ public class CETConfigurationFactoryTest {
 
 		ClientExtensionEntryRel clientExtensionEntryRel =
 			_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				_user.getUserId(), _group.getGroupId(),
 				_portal.getClassNameId(LayoutSet.class),
 				publicLayoutSet.getLayoutSetId(), externalReferenceCode,
 				ClientExtensionEntryConstants.TYPE_THEME_CSS, StringPool.BLANK,
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		clientExtensionEntryRel =
-			_clientExtensionEntryRelLocalService.getClientExtensionEntryRel(
+			_clientExtensionEntryRelLocalService.fetchClientExtensionEntryRel(
 				clientExtensionEntryRel.getClientExtensionEntryRelId());
 
 		Assert.assertNotNull(clientExtensionEntryRel);
@@ -148,7 +151,7 @@ public class CETConfigurationFactoryTest {
 			pid, themeCSSCETConfigurationProperties);
 
 		clientExtensionEntryRel =
-			_clientExtensionEntryRelLocalService.getClientExtensionEntryRel(
+			_clientExtensionEntryRelLocalService.fetchClientExtensionEntryRel(
 				clientExtensionEntryRel.getClientExtensionEntryRelId());
 
 		Assert.assertNotNull(clientExtensionEntryRel);
@@ -285,7 +288,7 @@ public class CETConfigurationFactoryTest {
 			Collections.singletonList(
 				"scope=" + (controlPanelScoped ? "controlPanel" : ""))
 		).put(
-			"userId", TestPropsValues.getUserId()
+			"userId", _user.getUserId()
 		).put(
 			"webContextPath", "/" + name
 		).build();
@@ -393,6 +396,7 @@ public class CETConfigurationFactoryTest {
 	private static final List<AutoCloseable> _autoCloseables =
 		new ArrayList<>();
 	private static Group _group;
+	private static User _user;
 	private static long _virtualInstanceCompanyId;
 
 	@Inject

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
@@ -24,11 +24,14 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -51,6 +54,7 @@ import javax.portlet.Portlet;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -105,6 +109,51 @@ public class CETConfigurationFactoryTest {
 		}
 	}
 
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAddAndUpdateThemeCSSClientExtensionEntry()
+		throws Exception {
+
+		Dictionary<String, Object> themeCSSCETConfigurationProperties =
+			_getThemeCSSCETConfigurationProperties(
+				_virtualInstanceCompanyId, false);
+
+		String pid = ConfigurationTestUtil.createFactoryConfiguration(
+			_PID, themeCSSCETConfigurationProperties);
+
+		String externalReferenceCode =
+			"LXC:" + pid1.substring(pid1.indexOf(StringPool.TILDE) + 1);
+
+		LayoutSet publicLayoutSet = _group.getPublicLayoutSet();
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_portal.getClassNameId(LayoutSet.class),
+				publicLayoutSet.getLayoutSetId(), externalReferenceCode,
+				ClientExtensionEntryConstants.TYPE_THEME_CSS, StringPool.BLANK,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		clientExtensionEntryRel =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRel(
+				clientExtensionEntryRel.getClientExtensionEntryRelId());
+
+		Assert.assertNotNull(clientExtensionEntryRel);
+
+		ConfigurationTestUtil.saveConfiguration(
+			pid, themeCSSCETConfigurationProperties);
+
+		clientExtensionEntryRel =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRel(
+				clientExtensionEntryRel.getClientExtensionEntryRelId());
+
+		Assert.assertNotNull(clientExtensionEntryRel);
+	}
+
 	@Test
 	public void testAddCET() throws Exception {
 		FeatureFlagTestHelper featureFlagTestHelper =
@@ -133,7 +182,8 @@ public class CETConfigurationFactoryTest {
 		Layout layout = _getControlPanelLayout(_virtualInstanceCompanyId);
 		String pid1 = ConfigurationTestUtil.createFactoryConfiguration(
 			_PID,
-			_getThemeCSSCETConfigurationProperties(_virtualInstanceCompanyId));
+			_getThemeCSSCETConfigurationProperties(
+				_virtualInstanceCompanyId, true));
 		String pid2 = null;
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -154,7 +204,7 @@ public class CETConfigurationFactoryTest {
 			pid2 = ConfigurationTestUtil.createFactoryConfiguration(
 				_PID,
 				_getThemeCSSCETConfigurationProperties(
-					_virtualInstanceCompanyId));
+					_virtualInstanceCompanyId, true));
 
 			clientExtensionEntryRels =
 				_clientExtensionEntryRelLocalService.
@@ -211,7 +261,7 @@ public class CETConfigurationFactoryTest {
 	}
 
 	private Dictionary<String, Object> _getThemeCSSCETConfigurationProperties(
-			long companyId)
+			long companyId, boolean controlPanelScoped)
 		throws Exception {
 
 		String name = RandomTestUtil.randomString();
@@ -231,7 +281,9 @@ public class CETConfigurationFactoryTest {
 		).put(
 			"type", ClientExtensionEntryConstants.TYPE_THEME_CSS
 		).put(
-			"typeSettings", Collections.singletonList("scope=controlPanel")
+			"typeSettings",
+			Collections.singletonList(
+				"scope=" + (controlPanelScoped ? "controlPanel" : ""))
 		).put(
 			"userId", TestPropsValues.getUserId()
 		).put(
@@ -340,6 +392,7 @@ public class CETConfigurationFactoryTest {
 
 	private static final List<AutoCloseable> _autoCloseables =
 		new ArrayList<>();
+	private static Group _group;
 	private static long _virtualInstanceCompanyId;
 
 	@Inject

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -222,6 +222,21 @@ public class CETConfigurationFactory {
 							CETConfiguration.class, properties),
 						companyId, externalReferenceCode);
 
+					if (!Objects.equals(
+							_cet.getType(),
+							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+
+						return;
+					}
+
+					ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
+
+					if (!Objects.equals(
+							themeCSSCET.getScope(), "controlPanel")) {
+
+						return;
+					}
+
 					if (_log.isInfoEnabled()) {
 						_log.info(
 							StringBundler.concat(
@@ -242,13 +257,7 @@ public class CETConfigurationFactory {
 								" and company ", companyId));
 					}
 
-					if (Objects.equals(
-							_cet.getType(),
-							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
-
-						_addControlPanelThemeCSSClientExtensionEntryRel(
-							companyId);
-					}
+					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
 				}
 				catch (Exception exception) {
 					_log.error(

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -138,18 +138,7 @@ public class CETConfigurationFactory {
 
 					_cetManager.deleteCET(_cet);
 
-					if (!Objects.equals(
-							_cet.getType(),
-							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
-
-						return;
-					}
-
-					ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
-
-					if (!Objects.equals(
-							themeCSSCET.getScope(), "controlPanel")) {
-
+					if (!_isControlPanelScopedThemeCSSCET()) {
 						return;
 					}
 
@@ -222,18 +211,7 @@ public class CETConfigurationFactory {
 							CETConfiguration.class, properties),
 						companyId, externalReferenceCode);
 
-					if (!Objects.equals(
-							_cet.getType(),
-							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
-
-						return;
-					}
-
-					ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
-
-					if (!Objects.equals(
-							themeCSSCET.getScope(), "controlPanel")) {
-
+					if (!_isControlPanelScopedThemeCSSCET()) {
 						return;
 					}
 
@@ -334,6 +312,18 @@ public class CETConfigurationFactory {
 	private String _getExternalReferenceCode(Map<String, Object> properties) {
 		return "LXC:" +
 			ConfigurationFactoryUtil.getExternalReferenceCode(properties);
+	}
+
+	private boolean _isControlPanelScopedThemeCSSCET() {
+		if (!Objects.equals(
+				_cet.getType(), ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+
+			return false;
+		}
+
+		ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
+
+		return Objects.equals(themeCSSCET.getScope(), "controlPanel");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -96,10 +96,7 @@ public class CETConfigurationFactory {
 								" and company ", companyId));
 					}
 
-					if (Objects.equals(
-							_cet.getType(),
-							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
-
+					if (_isControlPanelScopedThemeCSSCET()) {
 						_addControlPanelThemeCSSClientExtensionEntryRel(
 							companyId);
 					}
@@ -253,10 +250,6 @@ public class CETConfigurationFactory {
 		throws PortalException {
 
 		ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
-
-		if (!Objects.equals(themeCSSCET.getScope(), "controlPanel")) {
-			return;
-		}
 
 		ClientExtensionEntryRel clientExtensionEntryRel =
 			_clientExtensionEntryRelLocalService.

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -88,14 +88,6 @@ public class CETConfigurationFactory {
 							CETConfiguration.class, properties),
 						companyId, externalReferenceCode);
 
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Adding client extension entry relations for ",
-								"client extension ", externalReferenceCode,
-								" and company ", companyId));
-					}
-
 					if (_isControlPanelScopedThemeCSSCET()) {
 						_addControlPanelThemeCSSClientExtensionEntryRel(
 							companyId);
@@ -224,14 +216,6 @@ public class CETConfigurationFactory {
 						deleteClientExtensionEntryRels(
 							companyId, _cet.getExternalReferenceCode());
 
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Adding client extension entry relations for ",
-								"client extension ", externalReferenceCode,
-								" and company ", companyId));
-					}
-
 					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
 				}
 				catch (Exception exception) {
@@ -250,6 +234,14 @@ public class CETConfigurationFactory {
 		throws PortalException {
 
 		ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Adding client extension entry relations for client ",
+					"extension ", themeCSSCET.getExternalReferenceCode(),
+					" and company ", companyId));
+		}
 
 		ClientExtensionEntryRel clientExtensionEntryRel =
 			_clientExtensionEntryRelLocalService.

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -119,11 +119,9 @@ public class CETConfigurationFactory {
 				try {
 					_deleteCET(companyId);
 
-					if (!_isControlPanelScopedThemeCSSCET()) {
-						return;
+					if (_isControlPanelScopedThemeCSSCET()) {
+						_deleteClientExtensionEntryRels(companyId);
 					}
-
-					_deleteClientExtensionEntryRels(companyId);
 				}
 				catch (Exception exception) {
 					_log.error(
@@ -174,13 +172,12 @@ public class CETConfigurationFactory {
 							CETConfiguration.class, properties),
 						companyId, externalReferenceCode);
 
-					if (!_isControlPanelScopedThemeCSSCET()) {
-						return;
+					if (_isControlPanelScopedThemeCSSCET()) {
+						_deleteClientExtensionEntryRels(companyId);
+
+						_addControlPanelThemeCSSClientExtensionEntryRel(
+							companyId);
 					}
-
-					_deleteClientExtensionEntryRels(companyId);
-
-					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
 				}
 				catch (Exception exception) {
 					_log.error(

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -117,31 +117,13 @@ public class CETConfigurationFactory {
 			_companyLocalService, _properties,
 			companyId -> {
 				try {
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Deleting CET for client extension ",
-								externalReferenceCode, " and company ",
-								companyId));
-					}
-
-					_cetManager.deleteCET(_cet);
+					_deleteCET(companyId);
 
 					if (!_isControlPanelScopedThemeCSSCET()) {
 						return;
 					}
 
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Deleting client extension entry relations ",
-								"for client extension ", externalReferenceCode,
-								" and company ", companyId));
-					}
-
-					_clientExtensionEntryRelLocalService.
-						deleteClientExtensionEntryRels(
-							companyId, _cet.getExternalReferenceCode());
+					_deleteClientExtensionEntryRels(companyId);
 				}
 				catch (Exception exception) {
 					_log.error(
@@ -177,15 +159,7 @@ public class CETConfigurationFactory {
 			_companyLocalService, properties,
 			companyId -> {
 				try {
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Deleting CET for client extension ",
-								externalReferenceCode, " and company ",
-								companyId));
-					}
-
-					_cetManager.deleteCET(_cet);
+					_deleteCET(companyId);
 
 					if (_log.isInfoEnabled()) {
 						_log.info(
@@ -204,17 +178,7 @@ public class CETConfigurationFactory {
 						return;
 					}
 
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Deleting client extension entry relations ",
-								"for client extension ", externalReferenceCode,
-								" and company ", companyId));
-					}
-
-					_clientExtensionEntryRelLocalService.
-						deleteClientExtensionEntryRels(
-							companyId, _cet.getExternalReferenceCode());
+					_deleteClientExtensionEntryRels(companyId);
 
 					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
 				}
@@ -275,6 +239,31 @@ public class CETConfigurationFactory {
 				"Only one theme CSS client extension can be applied at a " +
 					"time. To avoid conflicts, none of them will be applied.");
 		}
+	}
+
+	private void _deleteCET(Long companyId) {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Deleting CET for client extension ",
+					_cet.getExternalReferenceCode(), " and company ",
+					companyId));
+		}
+
+		_cetManager.deleteCET(_cet);
+	}
+
+	private void _deleteClientExtensionEntryRels(long companyId) {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Deleting client extension entry relations for client ",
+					"extension ", _cet.getExternalReferenceCode(),
+					" and company ", companyId));
+		}
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			companyId, _cet.getExternalReferenceCode());
 	}
 
 	private Layout _getControlPanelLayout(long companyId)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-50051

## Problem 

The themeCSS CX is being removed from the client extension entry relation table when it's redeployed. 

## Solution

We only want to remove themeCSS CX from the client extension entry relation table when they are "control panel" scoped. So we need to always check that before removing it. I created a private method to help with this check and also extracted a number of other instances of duplicated code to simplify it. 