### PR TITLE
LPD-47428

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -947,8 +947,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 	private long _getExpandoTableId(long companyId) throws Exception {
 		if (_expandoTable == null) {
-			_expandoTable = _expandoTableLocalService.getTable(
-				companyId, UserGroup.class.getName(), "LDAP");
+			_expandoTable = _expandoTableLocalService.fetchTable(
+				companyId,
+				_classNameLocalService.getClassNameId(UserGroup.class), "LDAP");
 
 			if (_expandoTable == null) {
 				_expandoTable = _expandoTableLocalService.addTable(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -6,9 +6,13 @@
 package com.liferay.portal.security.ldap.internal.exportimport;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.model.ExpandoTable;
 import com.liferay.expando.kernel.model.ExpandoTableConstants;
 import com.liferay.expando.kernel.model.ExpandoValue;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.expando.util.ExpandoConverterUtil;
 import com.liferay.petra.string.StringBundler;
@@ -37,6 +41,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.exportimport.UserGroupImportTransactionThreadLocal;
 import com.liferay.portal.kernel.security.ldap.AttributesTransformer;
 import com.liferay.portal.kernel.security.ldap.LDAPSettings;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -55,6 +60,7 @@ import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PwdGenerator;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.exportimport.UserImporter;
 import com.liferay.portal.security.ldap.ContactConverterKeys;
@@ -914,6 +920,45 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			role.getRoleId(), new long[] {group.getGroupId()});
 	}
 
+	private long _getExpandoColumnId() throws Exception {
+		if (_expandoColumn == null) {
+			_expandoColumn = _expandoColumnLocalService.fetchColumn(
+				_expandoTable.getTableId(), "ldapServerId");
+
+			if (_expandoColumn == null) {
+				_expandoColumn = _expandoColumnLocalService.addColumn(
+					_expandoTable.getTableId(), "ldapServerId",
+					ExpandoColumnConstants.LONG);
+
+				UnicodeProperties unicodeProperties =
+					_expandoColumn.getTypeSettingsProperties();
+
+				unicodeProperties.setProperty(
+					ExpandoColumnConstants.INDEX_TYPE,
+					String.valueOf(ExpandoColumnConstants.INDEX_TYPE_KEYWORD));
+				unicodeProperties.setProperty(
+					ExpandoColumnConstants.PROPERTY_HIDDEN,
+					Boolean.TRUE.toString());
+			}
+		}
+
+		return _expandoColumn.getColumnId();
+	}
+
+	private long _getExpandoTableId(long companyId) throws Exception {
+		if (_expandoTable == null) {
+			_expandoTable = _expandoTableLocalService.getTable(
+				companyId, UserGroup.class.getName(), "LDAP");
+
+			if (_expandoTable == null) {
+				_expandoTable = _expandoTableLocalService.addTable(
+					companyId, UserGroup.class.getName(), "LDAP");
+			}
+		}
+
+		return _expandoTable.getTableId();
+	}
+
 	private LDAPImportContext _getLDAPImportContext(
 		long companyId, Properties contactExpandoMappings,
 		Properties contactMappings, Properties groupMappings,
@@ -1174,6 +1219,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			}
 		}
 
+		_expandoValueLocalService.addValue(
+			_classNameLocalService.getClassNameId(UserGroup.class),
+			_getExpandoTableId(ldapImportContext.getCompanyId()),
+			_getExpandoColumnId(), userGroupId,
+			String.valueOf(ldapImportContext.getLdapServerId()));
+
 		if (_log.isDebugEnabled()) {
 			_log.debug(
 				StringBundler.concat(
@@ -1298,7 +1349,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			}
 		}
 
-		_updateUserUserGroups(user.getUserId(), newUserGroupIds);
+		_updateUserUserGroups(
+			ldapImportContext.getLdapServerId(), user.getUserId(),
+			newUserGroupIds);
 	}
 
 	private User _importUser(
@@ -1971,7 +2024,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		return password;
 	}
 
-	private void _updateUserUserGroups(long userId, Set<Long> userGroupIds)
+	private void _updateUserUserGroups(
+			long ldapServerId, long userId, Set<Long> userGroupIds)
 		throws Exception {
 
 		List<Long> deleteUserGroupIds = new ArrayList<>();
@@ -1986,7 +2040,16 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 					userGroupIds.remove(userGroupId);
 				}
 				else {
-					deleteUserGroupIds.add(userGroupId);
+					ExpandoValue expandoValue =
+						_expandoValueLocalService.getValue(
+							_getExpandoTableId(userGroup.getCompanyId()),
+							_getExpandoColumnId(), userGroupId);
+
+					if ((expandoValue != null) &&
+						(expandoValue.getLong() == ldapServerId)) {
+
+						deleteUserGroupIds.add(userGroupId);
+					}
 				}
 			}
 		}
@@ -2034,9 +2097,21 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 	private BeanProperties _beanProperties;
 
 	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
 	private CompanyLocalService _companyLocalService;
 
 	private String _companySecurityAuthType;
+	private ExpandoColumn _expandoColumn;
+
+	@Reference
+	private ExpandoColumnLocalService _expandoColumnLocalService;
+
+	private ExpandoTable _expandoTable;
+
+	@Reference
+	private ExpandoTableLocalService _expandoTableLocalService;
 
 	@Reference
 	private ExpandoValueLocalService _expandoValueLocalService;

--- a/modules/test/playwright/fixtures/ldapConfigurationPagesTest.ts
+++ b/modules/test/playwright/fixtures/ldapConfigurationPagesTest.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import test from '@playwright/test';
+
+import {LdapConfigurationPage} from '../pages/portal-security-ldap/LdapConfigurationPage';
+import {LdapServerPage} from '../pages/portal-security-ldap/LdapServerPage';
+
+const ldapConfigurationPagesTest = test.extend<{
+	ldapConfigurationPage: LdapConfigurationPage;
+	ldapServerPage: LdapServerPage;
+}>({
+	ldapConfigurationPage: async ({page}, use) => {
+		await use(new LdapConfigurationPage(page));
+	},
+	ldapServerPage: async ({page}, use) => {
+		await use(new LdapServerPage(page));
+	},
+});
+
+export {ldapConfigurationPagesTest};

--- a/modules/test/playwright/helpers/LdapConfigurationHelper.ts
+++ b/modules/test/playwright/helpers/LdapConfigurationHelper.ts
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const DEFAULT_LDAP_CONFIGURATION_VALUES = {
+	autogenerateUserPasswordOnImport: false,
+	createRolePerGroupOnImport: false,
+	defaultUserPassword: 'test',
+	enableExport: false,
+	enableGroupCacheOnImport: true,
+	enableGroupExport: true,
+	enableImport: false,
+	enableImportOnStartup: false,
+	enableUserPasswordOnImport: true,
+	enabled: false,
+	importInterval: 10,
+	importMethod: 'User',
+	importUserSyncStrategy: 'Auth Type',
+	lockExpirationTime: 86400000,
+	method: 'Bind',
+	passwordEncryptionAlgorithm: 'None',
+	required: false,
+	userLdapPasswordPolicy: false,
+};
+
+export type TLdapConfiguration = {
+	autogenerateUserPasswordOnImport?: boolean;
+	createRolePerGroupOnImport?: boolean;
+	defaultUserPassword?: string;
+	enableExport?: boolean;
+	enableGroupCacheOnImport?: boolean;
+	enableGroupExport?: boolean;
+	enableImport?: boolean;
+	enableImportOnStartup?: boolean;
+	enableUserPasswordOnImport?: boolean;
+	enabled?: boolean;
+	importInterval?: number;
+	importMethod?: string | 'Group' | 'User';
+	importUserSyncStrategy?: string | 'Auth Type' | 'UUID';
+	lockExpirationTime?: number;
+	method?: string | 'Bind' | 'Password Compare';
+	passwordEncryptionAlgorithm?:
+		| string
+		| 'BCRYPT'
+		| 'MD2'
+		| 'MD5'
+		| 'None'
+		| 'SHA'
+		| 'SHA-256'
+		| 'SHA-384'
+		| 'SSHA'
+		| 'UFC-CRYPT';
+	required?: boolean;
+	userLdapPasswordPolicy?: boolean;
+};
+
+export type TLdapServer = {
+	authenticationSearchFilter?: string;
+	baseDn?: string;
+	baseProviderUrl?: string;
+	clockSkew?: number;
+	credentials?: string;
+	customContactMapping?: string;
+	customUserMapping?: string;
+	defaultValues?:
+		| 'Apache Directory Server'
+		| 'Fedora Directory Server'
+		| 'Microsoft Active Directory Server'
+		| 'Novell eDirectory'
+		| 'OpenLDAP'
+		| 'other Directory Server';
+	description?: string;
+	emailAddress?: string;
+	firstName?: string;
+	fullName?: string;
+	group?: string;
+	groupDefaultObjectClasses?: string;
+	groupName?: string;
+	groupsDn?: string;
+	ignoreUserSearchFilterForAuthentication?: boolean;
+	importSearchFilterGroup?: string;
+	importSearchFilterUser?: string;
+	jobTitle?: string;
+	lastName?: string;
+	middleName?: string;
+	password?: string;
+	portrait?: string;
+	principal?: string;
+	screenName?: string;
+	serverName: string;
+	status?: string;
+	user?: string;
+	userDefaultObjectClasses?: string;
+	userIgnoreAttributes?: string;
+	usersDn?: string;
+	uuid?: string;
+};

--- a/modules/test/playwright/pages/portal-security-ldap/LdapConfigurationPage.ts
+++ b/modules/test/playwright/pages/portal-security-ldap/LdapConfigurationPage.ts
@@ -1,0 +1,274 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {
+	DEFAULT_LDAP_CONFIGURATION_VALUES,
+	TLdapConfiguration,
+} from '../../helpers/LdapConfigurationHelper';
+import {waitForAlert} from '../../utils/waitForAlert';
+import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
+
+export class LdapConfigurationPage {
+	readonly addLdapServerButton: Locator;
+	readonly autogenerateUserPasswordOnImport: Locator;
+	readonly createRolePerGroupOnImport: Locator;
+	readonly defaultUserPassword: Locator;
+	readonly enableExport: Locator;
+	readonly enableGroupCacheOnImport: Locator;
+	readonly enableGroupExport: Locator;
+	readonly enableImport: Locator;
+	readonly enableImportOnStartup: Locator;
+	readonly enableUserPasswordOnImport: Locator;
+	readonly enabled: Locator;
+	readonly importInterval: Locator;
+	readonly importMethod: Locator;
+	readonly importUserSyncStrategy: Locator;
+	readonly instanceSettingsPage: InstanceSettingsPage;
+	readonly lockExpirationTime: Locator;
+	readonly method: Locator;
+	readonly page: Page;
+	readonly passwordEncryptionAlgorithm: Locator;
+	readonly required: Locator;
+	readonly resetDefaultValues: Locator;
+	readonly saveButton: Locator;
+	readonly useLdapPasswordPolicy: Locator;
+
+	constructor(page: Page) {
+		this.addLdapServerButton = page.getByRole('button', {name: 'Add'});
+		this.autogenerateUserPasswordOnImport = page.getByText(
+			'Autogenerate User Password on Import'
+		);
+		this.createRolePerGroupOnImport = page.getByText(
+			'Create Role per Group on Import'
+		);
+		this.defaultUserPassword = page.getByLabel('Default User Password');
+		this.enableExport = page.getByText('Enable Export');
+		this.enableGroupCacheOnImport = page.getByText(
+			'Enable Group Cache on Import'
+		);
+		this.enableGroupExport = page.getByText('Enable Group Export');
+		this.enableImport = page.getByText('Enable Import').first();
+		this.enableImportOnStartup = page.getByText('Enable Import on Startup');
+		this.enableUserPasswordOnImport = page.getByText(
+			'Enable User Password on Import'
+		);
+
+		this.enabled = page.getByText('Enabled', {exact: true});
+		this.importInterval = page.getByLabel('Import Interval');
+		this.importMethod = page.getByLabel('Import Method');
+		this.importUserSyncStrategy = page.getByLabel(
+			'Import User Sync Strategy'
+		);
+		this.instanceSettingsPage = new InstanceSettingsPage(page);
+		this.lockExpirationTime = page.getByLabel('Lock Expiration Time');
+		this.method = page.getByLabel('Method');
+		this.page = page;
+		this.passwordEncryptionAlgorithm = page.getByLabel(
+			'Password Encryption Algorithm'
+		);
+		this.required = page.getByText('Required');
+		this.resetDefaultValues = page.getByText('Reset Default Values');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.useLdapPasswordPolicy = page.getByText('Use LDAP Password Policy');
+	}
+
+	async addLdapServer(forceReload = true) {
+		await this.goToServersTab(forceReload);
+
+		await this.addLdapServerButton.click();
+	}
+
+	async goTo() {
+		await this.instanceSettingsPage.goToInstanceSetting(
+			'LDAP',
+			'General',
+			false
+		);
+
+		await this.enabled.waitFor();
+	}
+
+	async goToServersTab(forceReload = true) {
+		if (forceReload) {
+			await this.goTo();
+		}
+
+		await this.page.getByRole('menuitem', {name: 'Servers'}).click();
+
+		await this.addLdapServerButton.waitFor();
+	}
+
+	async resetLdapConfiguration() {
+		await this.goTo();
+
+		const defaultLdapConfiguration: TLdapConfiguration = {
+			...DEFAULT_LDAP_CONFIGURATION_VALUES,
+		};
+
+		await this.updateLDAPGeneralConfiguration(defaultLdapConfiguration);
+
+		await this.updateLDAPExportConfiguration(defaultLdapConfiguration);
+
+		await this.updateLDAPImportConfiguration(defaultLdapConfiguration);
+	}
+
+	async updateLDAPConfiguration(
+		ldapConfiguration: TLdapConfiguration,
+		forceReload = true
+	) {
+		if (forceReload) {
+			await this.goTo();
+		}
+
+		await this.updateLDAPGeneralConfiguration(ldapConfiguration);
+
+		await this.updateLDAPExportConfiguration(ldapConfiguration);
+
+		await this.updateLDAPImportConfiguration(ldapConfiguration);
+	}
+
+	async updateLDAPExportConfiguration(ldapConfiguration: TLdapConfiguration) {
+		await this.page.getByRole('menuitem', {name: 'Export'}).click();
+
+		await this.enableExport.waitFor();
+
+		if (ldapConfiguration.enableExport !== undefined) {
+			await this.enableExport.setChecked(ldapConfiguration.enableExport);
+		}
+
+		if (ldapConfiguration.enableGroupExport !== undefined) {
+			await this.enableGroupExport.setChecked(
+				ldapConfiguration.enableGroupExport
+			);
+		}
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async updateLDAPGeneralConfiguration(
+		ldapConfiguration: TLdapConfiguration
+	) {
+		if (await this.enabled.isHidden()) {
+			await this.page.getByRole('menuitem', {name: 'General'}).click();
+		}
+
+		await this.enabled.waitFor();
+
+		if (ldapConfiguration.enabled !== undefined) {
+			await this.enabled.setChecked(ldapConfiguration.enabled);
+		}
+
+		if (ldapConfiguration.method) {
+			await this.method.selectOption(ldapConfiguration.method);
+		}
+
+		if (ldapConfiguration.passwordEncryptionAlgorithm) {
+			await this.passwordEncryptionAlgorithm.selectOption(
+				ldapConfiguration.passwordEncryptionAlgorithm
+			);
+		}
+
+		if (ldapConfiguration.required !== undefined) {
+			await this.required.setChecked(ldapConfiguration.required);
+		}
+
+		if (ldapConfiguration.userLdapPasswordPolicy !== undefined) {
+			await this.useLdapPasswordPolicy.setChecked(
+				ldapConfiguration.userLdapPasswordPolicy
+			);
+		}
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async updateLDAPImportConfiguration(ldapConfiguration: TLdapConfiguration) {
+		await this.page.getByRole('menuitem', {name: 'Import'}).click();
+
+		await this.enableImport.waitFor();
+
+		if (ldapConfiguration.autogenerateUserPasswordOnImport !== undefined) {
+			await this.autogenerateUserPasswordOnImport.setChecked(
+				ldapConfiguration.autogenerateUserPasswordOnImport
+			);
+		}
+
+		if (ldapConfiguration.createRolePerGroupOnImport !== undefined) {
+			await this.createRolePerGroupOnImport.setChecked(
+				ldapConfiguration.createRolePerGroupOnImport
+			);
+		}
+
+		if (ldapConfiguration.defaultUserPassword) {
+			await this.defaultUserPassword.fill(
+				ldapConfiguration.defaultUserPassword
+			);
+		}
+
+		if (ldapConfiguration.enableGroupCacheOnImport !== undefined) {
+			await this.enableGroupCacheOnImport.setChecked(
+				ldapConfiguration.enableGroupCacheOnImport
+			);
+		}
+
+		if (ldapConfiguration.enableImport !== undefined) {
+			await this.enableImport.setChecked(ldapConfiguration.enableImport);
+		}
+
+		if (ldapConfiguration.enableImportOnStartup !== undefined) {
+			await this.enableImportOnStartup.setChecked(
+				ldapConfiguration.enableImportOnStartup
+			);
+		}
+
+		if (ldapConfiguration.enableUserPasswordOnImport !== undefined) {
+			await this.enableUserPasswordOnImport.setChecked(
+				ldapConfiguration.enableUserPasswordOnImport
+			);
+		}
+
+		if (ldapConfiguration.importInterval) {
+			await this.importInterval.fill(
+				ldapConfiguration.importInterval.toString()
+			);
+		}
+
+		if (ldapConfiguration.importMethod) {
+			await this.importMethod.selectOption(
+				ldapConfiguration.importMethod
+			);
+		}
+
+		if (ldapConfiguration.importUserSyncStrategy) {
+			await this.importUserSyncStrategy.selectOption(
+				ldapConfiguration.importUserSyncStrategy
+			);
+		}
+
+		if (ldapConfiguration.lockExpirationTime) {
+			await this.lockExpirationTime.fill(
+				ldapConfiguration.lockExpirationTime.toString()
+			);
+		}
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+}

--- a/modules/test/playwright/pages/portal-security-ldap/LdapServerPage.ts
+++ b/modules/test/playwright/pages/portal-security-ldap/LdapServerPage.ts
@@ -1,0 +1,322 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {TLdapServer} from '../../helpers/LdapConfigurationHelper';
+import {waitForAlert} from '../../utils/waitForAlert';
+import {LdapConfigurationPage} from './LdapConfigurationPage';
+
+export class LdapServerPage {
+	readonly authenticationSearchFilter: Locator;
+	readonly baseDn: Locator;
+	readonly baseProviderUrl: Locator;
+	readonly cancelButton: Locator;
+	readonly clockSkew: Locator;
+	readonly closeButton: Locator;
+	readonly credentials: Locator;
+	readonly customContactMapping: Locator;
+	readonly customUserMapping: Locator;
+	readonly description: Locator;
+	readonly emailAddress: Locator;
+	readonly firstName: Locator;
+	readonly fullName: Locator;
+	readonly group: Locator;
+	readonly groupDefaultObjectClasses: Locator;
+	readonly groupName: Locator;
+	readonly groupsDn: Locator;
+	readonly ignoreUserSearchFilterForAuthentication: Locator;
+	readonly importSearchFilterGroup: Locator;
+	readonly importSearchFilterUser: Locator;
+	readonly jobTitle: Locator;
+	readonly lastName: Locator;
+	readonly ldapConfigurationPage: LdapConfigurationPage;
+	readonly middleName: Locator;
+	readonly page: Page;
+	readonly password: Locator;
+	readonly portrait: Locator;
+	readonly principal: Locator;
+	readonly saveButton: Locator;
+	readonly screenName: Locator;
+	readonly serverName: Locator;
+	readonly status: Locator;
+	readonly testLdapConnection: Locator;
+	readonly testLdapGroups: Locator;
+	readonly testLdapUsers: Locator;
+	readonly user: Locator;
+	readonly userDefaultObjectClasses: Locator;
+	readonly userIgnoreAttributes: Locator;
+	readonly usersDn: Locator;
+	readonly uuid: Locator;
+
+	constructor(page: Page) {
+		this.authenticationSearchFilter = page.getByLabel(
+			'Authentication Search Filter'
+		);
+		this.baseDn = page.getByLabel('Base DN The LDAP Base');
+		this.baseProviderUrl = page.getByLabel('Base Provider URL The LDAP');
+		this.cancelButton = page.getByRole('button', {name: 'Cancel'});
+		this.clockSkew = page.getByLabel('Clock Skew The system time');
+		this.closeButton = page.getByLabel('close');
+		this.credentials = page.getByLabel('Credentials');
+		this.customContactMapping = page.getByLabel('Custom Contact Mapping');
+		this.customUserMapping = page.getByLabel('Custom User Mapping');
+		this.description = page.getByLabel('Description');
+		this.emailAddress = page.getByLabel('Email Address');
+		this.firstName = page.getByLabel('First Name', {exact: true});
+		this.fullName = page.getByLabel('Full Name');
+		this.group = page.getByLabel('Group', {exact: true});
+		this.groupDefaultObjectClasses = page.getByLabel(
+			'Group Default Object Classes'
+		);
+		this.groupName = page.getByLabel('Group Name');
+		this.groupsDn = page.getByLabel('Groups DN');
+		this.ignoreUserSearchFilterForAuthentication = page.getByLabel(
+			'Ignore User Search Filter'
+		);
+		this.importSearchFilterGroup = page
+			.getByText('Groups Import Search Filter')
+			.getByLabel('Import Search Filter');
+		this.importSearchFilterUser = page
+			.getByText('Users Authentication Search')
+			.getByLabel('Import Search Filter');
+		this.jobTitle = page.getByLabel('Job Title');
+		this.lastName = page.getByLabel('Last Name', {exact: true});
+		this.ldapConfigurationPage = new LdapConfigurationPage(page);
+		this.middleName = page.getByLabel('Middle Name');
+		this.page = page;
+		this.password = page.getByLabel('Password');
+		this.portrait = page.getByLabel('Portrait');
+		this.principal = page.getByLabel('Principal');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.screenName = page.getByLabel('Screen Name');
+		this.serverName = page.getByLabel('Server Name');
+		this.status = page.getByLabel('Status');
+		this.testLdapConnection = page.getByRole('button', {
+			name: 'Test LDAP Connection',
+		});
+		this.testLdapGroups = page.getByRole('button', {
+			name: 'Test LDAP Groups',
+		});
+		this.testLdapUsers = page.getByRole('button', {
+			name: 'Test LDAP Users',
+		});
+		this.user = page.getByLabel('User', {exact: true});
+		this.userDefaultObjectClasses = page.getByLabel(
+			'User Default Object Classes'
+		);
+		this.userIgnoreAttributes = page.getByLabel('User Ignore Attributes');
+		this.usersDn = page.getByLabel('Users DN');
+		this.uuid = page.getByLabel('UUID');
+	}
+
+	async addLdapServer(ldapServer: TLdapServer, forceReload = true) {
+		await this.ldapConfigurationPage.addLdapServer(forceReload);
+
+		await this.populateLdapServerValues(ldapServer);
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async deleteLdapServer(serverName: string, forceReload = true) {
+		if (forceReload) {
+			await this.ldapConfigurationPage.goToServersTab();
+		}
+
+		this.page.once('dialog', async (dialog) => {
+			dialog.accept();
+		});
+
+		await this.ldapConfigurationPage.page
+			.getByRole('row', {name: serverName})
+			.locator('div')
+			.getByTitle('Delete')
+			.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async deleteLdapServers(forceReload = true) {
+		if (forceReload) {
+			await this.ldapConfigurationPage.goToServersTab();
+		}
+
+		const ldapServerDeleteButton = await this.ldapConfigurationPage.page
+			.getByRole('link', {name: 'Delete'})
+			.first();
+
+		while (await ldapServerDeleteButton.isVisible()) {
+			this.page.once('dialog', async (dialog) => {
+				dialog.accept();
+			});
+
+			await ldapServerDeleteButton.click();
+
+			await waitForAlert(
+				this.page,
+				`Success:Your request completed successfully.`
+			);
+		}
+	}
+
+	async editLdapServer(
+		ldapServer: TLdapServer,
+		existingServerName = ldapServer.serverName,
+		forceReload = true
+	) {
+		await this.viewLdapServer(existingServerName, forceReload);
+
+		await this.populateLdapServerValues(ldapServer);
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async populateLdapServerValues(ldapServer: TLdapServer) {
+		await this.serverName.waitFor();
+
+		if (ldapServer.defaultValues) {
+			await this.page.getByLabel(ldapServer.defaultValues).click();
+		}
+		if (ldapServer.authenticationSearchFilter) {
+			await this.authenticationSearchFilter.fill(
+				ldapServer.authenticationSearchFilter
+			);
+		}
+		if (ldapServer.baseDn) {
+			await this.baseDn.fill(ldapServer.baseDn);
+		}
+		if (ldapServer.baseProviderUrl) {
+			await this.baseProviderUrl.fill(ldapServer.baseProviderUrl);
+		}
+		if (ldapServer.clockSkew) {
+			await this.clockSkew.fill(ldapServer.clockSkew.toString());
+		}
+		if (ldapServer.credentials) {
+			await this.credentials.fill(ldapServer.credentials);
+		}
+		if (ldapServer.customContactMapping) {
+			await this.customContactMapping.fill(
+				ldapServer.customContactMapping
+			);
+		}
+		if (ldapServer.customUserMapping) {
+			await this.customUserMapping.fill(ldapServer.customUserMapping);
+		}
+		if (ldapServer.description) {
+			await this.description.fill(ldapServer.description);
+		}
+		if (ldapServer.emailAddress) {
+			await this.emailAddress.fill(ldapServer.emailAddress);
+		}
+		if (ldapServer.firstName) {
+			await this.firstName.fill(ldapServer.firstName);
+		}
+		if (ldapServer.fullName) {
+			await this.fullName.fill(ldapServer.fullName);
+		}
+		if (ldapServer.group) {
+			await this.group.fill(ldapServer.group);
+		}
+		if (ldapServer.groupDefaultObjectClasses) {
+			await this.groupDefaultObjectClasses.fill(
+				ldapServer.groupDefaultObjectClasses
+			);
+		}
+		if (ldapServer.groupName) {
+			await this.groupName.fill(ldapServer.groupName);
+		}
+		if (ldapServer.groupsDn) {
+			await this.groupsDn.fill(ldapServer.groupsDn);
+		}
+		if (ldapServer.ignoreUserSearchFilterForAuthentication !== undefined) {
+			await this.ignoreUserSearchFilterForAuthentication.setChecked(
+				ldapServer.ignoreUserSearchFilterForAuthentication
+			);
+		}
+		if (ldapServer.importSearchFilterGroup) {
+			await this.importSearchFilterGroup.fill(
+				ldapServer.importSearchFilterGroup
+			);
+		}
+		if (ldapServer.importSearchFilterUser) {
+			await this.importSearchFilterUser.fill(
+				ldapServer.importSearchFilterUser
+			);
+		}
+		if (ldapServer.jobTitle) {
+			await this.jobTitle.fill(ldapServer.jobTitle);
+		}
+		if (ldapServer.lastName) {
+			await this.lastName.fill(ldapServer.lastName);
+		}
+		if (ldapServer.middleName) {
+			await this.middleName.fill(ldapServer.middleName);
+		}
+		if (ldapServer.password) {
+			await this.password.fill(ldapServer.password);
+		}
+		if (ldapServer.portrait) {
+			await this.portrait.fill(ldapServer.portrait);
+		}
+		if (ldapServer.principal) {
+			await this.principal.fill(ldapServer.principal);
+		}
+		if (ldapServer.screenName) {
+			await this.screenName.fill(ldapServer.screenName);
+		}
+
+		await this.serverName.fill(ldapServer.serverName);
+
+		if (ldapServer.status) {
+			await this.status.fill(ldapServer.status);
+		}
+		if (ldapServer.user) {
+			await this.user.fill(ldapServer.user);
+		}
+		if (ldapServer.userDefaultObjectClasses) {
+			await this.userDefaultObjectClasses.fill(
+				ldapServer.userDefaultObjectClasses
+			);
+		}
+		if (ldapServer.userIgnoreAttributes) {
+			await this.userIgnoreAttributes.fill(
+				ldapServer.userIgnoreAttributes
+			);
+		}
+		if (ldapServer.usersDn) {
+			await this.usersDn.fill(ldapServer.usersDn);
+		}
+		if (ldapServer.uuid) {
+			await this.uuid.fill(ldapServer.uuid);
+		}
+	}
+
+	async viewLdapServer(serverName: string, forceReload = true) {
+		if (forceReload) {
+			await this.ldapConfigurationPage.goToServersTab();
+		}
+
+		await this.ldapConfigurationPage.page
+			.getByRole('row', {name: serverName})
+			.locator('div')
+			.getByTitle('Edit')
+			.click();
+
+		await this.serverName.waitFor();
+	}
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -90,6 +90,7 @@ import {config as portalSearchAdminWebConfig} from './tests/portal-search-admin-
 import {config as portalSearchWebConfig} from './tests/portal-search-web/config';
 import {config as portalSecurityAuditWebConfig} from './tests/portal-security-audit-web/config';
 import {config as portalSecurityContentSecurityPolicyConfig} from './tests/portal-security-content-security-policy/config';
+import {config as portalSecurityLdapConfig} from './tests/portal-security-ldap/config';
 import {config as portalSecurityScriptManagementWebConfig} from './tests/portal-security-script-management-web/config';
 import {config as portalSecurityServiceAccessPolicyService} from './tests/portal-security-service-access-policy-service/config';
 import {config as portalToolsRestBuilderTestImpl} from './tests/portal-tools-rest-builder-test-impl/config';
@@ -224,6 +225,7 @@ export default defineConfig({
 		portalSearchWebConfig,
 		portalSecurityAuditWebConfig,
 		portalSecurityContentSecurityPolicyConfig,
+		portalSecurityLdapConfig,
 		portalSecurityScriptManagementWebConfig,
 		portalSecurityServiceAccessPolicyService,
 		portalToolsRestBuilderTestImpl,

--- a/modules/test/playwright/tests/portal-security-ldap/config.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/config.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-security-ldap',
+	testDir: 'tests/portal-security-ldap',
+	timeout: 120 * 1000,
+};

--- a/modules/test/playwright/tests/portal-security-ldap/env/addGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/addGroups.ldif
@@ -1,0 +1,12 @@
+cn: ldapgroup1
+dn: cn=ldapgroup1,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser1,dc=example,dc=com
+
+cn: ldapgroup2
+dn: cn=ldapgroup2,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser1,dc=example,dc=com
+uniqueMember: cn=ldapuser2,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/env/addUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/addUsers.ldif
@@ -1,0 +1,17 @@
+cn: ldapuser1
+dn: cn=ldapuser1,dc=example,dc=com
+givenName: first
+mail: ldapuser1@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last
+userPassword: test
+
+cn: ldapuser2
+dn: cn=ldapuser2,dc=example,dc=com
+givenName: first
+mail: ldapuser2@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last
+userPassword: test

--- a/modules/test/playwright/tests/portal-security-ldap/env/admin.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/admin.ldif
@@ -1,0 +1,3 @@
+cn: admin
+dn: cn=admin,dc=example,dc=com
+objectclass: organizationalRole

--- a/modules/test/playwright/tests/portal-security-ldap/env/exampleCompany.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/exampleCompany.ldif
@@ -1,0 +1,5 @@
+dc: example
+dn: dc=example,dc=com
+o: Example Company
+objectclass: dcObject
+objectclass: organization

--- a/modules/test/playwright/tests/portal-security-ldap/env/modifiedSlapd.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/modifiedSlapd.ldif
@@ -1,0 +1,118 @@
+#
+# Load dynamic backend modules: 
+#
+#cn: module
+#dn: cn=module,cn=config
+#objectClass: olcModuleList
+#olcModuleload: 	back_ldap.la
+#olcModuleload: 	back_mdb.la
+#olcModuleload: 	back_passwd.la
+#olcModuleload: 	back_shell.la
+#olcModulepath: 	/usr/local/libexec/openldap
+
+#
+# See slapd-config(5) for details on configuration options.
+# This file should NOT be world readable.
+#
+#olcReferral: 	ldap: //root.openldap.org
+#
+# Sample security restrictions
+#	Require integrity protection (prevent hijacking)
+#	Require 112-bit (3DES or better) encryption for updates
+#	Require 64-bit encryption for simple bind
+#olcSecurity: ssf=1 update_ssf=112 simple_bind=64
+cn: config
+#
+#
+# Define global ACLs to disable default read access.
+#
+dn: cn=config
+objectClass: olcGlobal
+olcArgsFile: /usr/local/var/run/slapd.args
+olcPidFile: /usr/local/var/run/slapd.pid
+#
+# Do not enable referrals until AFTER you have a working directory
+# service AND an understanding of referrals.
+
+# Frontend settings
+#
+#	Other DSEs: 
+#		Allow self write access
+#		Allow authenticated users read access
+#		Allow anonymous users to authenticate
+#
+#	Root DSE: allow anyone to read it
+#	Subschema (sub)entry DSE: allow anyone to read it
+# Sample global access control policy: 
+#olcAccess: to *
+#	by self write
+#	by users read
+#	by anonymous auth
+#
+# if no access controls are present, the default policy
+# allows anyone and everyone to read anything but restricts
+# updates to rootdn.  (e.g., "access to * by * read")
+#
+# rootdn can always read and write EVERYTHING!
+#
+#olcAccess: to dn.base="" by * read
+#olcAccess: to dn.base="cn=Subschema" by * read
+dn: olcDatabase=frontend,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcFrontendConfig
+olcDatabase: frontend
+#
+
+########################################################
+# Start new MDB database definition
+########################################################
+OlcDbMaxSize: 1073741824
+dn: olcDatabase=mdb,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcMdbConfig
+olcDatabase: mdb
+olcDbDirectory: /usr/local/var/openldap-data
+olcDbIndex: objectClass eq
+#######################################################
+# End new MDB database definition
+#######################################################
+olcRootDN: cn=admin,dc=example,dc=com
+olcRootPW: secret
+olcSuffix: dc=example,dc=com
+
+#######################################################################
+# LMDB database definitions
+#######################################################################
+#
+dn: olcDatabase=mdb,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcMdbConfig
+olcDatabase: mdb
+olcDbDirectory: 	/usr/local/var/openldap-data
+# Indices to maintain
+olcDbIndex: objectClass eq
+olcDbMaxSize: 1073741824
+olcRootDN: cn=Manager,dc=my-domain,dc=com
+# Cleartext passwords, especially for the rootdn, should
+# be avoided.  See slappasswd(8) and slapd-config(5) for details.
+# Use of strong authentication encouraged.
+olcRootPW: secret
+# The database directory MUST exist prior to running slapd AND
+# should only be accessible by the slapd and slap tools.
+# Mode 700 recommended.
+olcSuffix: dc=my-domain,dc=com
+
+cn: schema
+dn: cn=schema,cn=config
+objectClass: olcSchemaConfig
+
+dn: olcDatabase=monitor,cn=config
+objectClass: olcDatabaseConfig
+olcDatabase: monitor
+olcMonitoring: FALSE
+olcRootDN: cn=config
+
+include: file: ///usr/local/etc/openldap/schema/core.ldif
+include: file: ///usr/local/etc/openldap/schema/cosine.ldif
+include: file: ///usr/local/etc/openldap/schema/inetorgperson.ldif
+include: file: ///usr/local/etc/openldap/schema/nis.ldif

--- a/modules/test/playwright/tests/portal-security-ldap/env/modifiedSlapd.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/modifiedSlapd.ldif
@@ -112,7 +112,7 @@ olcDatabase: monitor
 olcMonitoring: FALSE
 olcRootDN: cn=config
 
-include: file: ///usr/local/etc/openldap/schema/core.ldif
-include: file: ///usr/local/etc/openldap/schema/cosine.ldif
-include: file: ///usr/local/etc/openldap/schema/inetorgperson.ldif
-include: file: ///usr/local/etc/openldap/schema/nis.ldif
+include: file:///usr/local/etc/openldap/schema/core.ldif
+include: file:///usr/local/etc/openldap/schema/cosine.ldif
+include: file:///usr/local/etc/openldap/schema/inetorgperson.ldif
+include: file:///usr/local/etc/openldap/schema/nis.ldif

--- a/modules/test/playwright/tests/portal-security-ldap/env/removeGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/removeGroups.ldif
@@ -1,0 +1,2 @@
+cn=ldapgroup1,dc=example,dc=com
+cn=ldapgroup2,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/env/removeGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/removeGroups.ldif
@@ -1,2 +1,2 @@
 cn=ldapgroup1,dc=example,dc=com
-cn=ldapgroup2,dc=example,dc=com
+cn=ldapgroup2,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/env/removeUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/removeUsers.ldif
@@ -1,0 +1,2 @@
+cn=ldapuser1,dc=example,dc=com
+cn=ldapuser2,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/env/removeUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/env/removeUsers.ldif
@@ -1,2 +1,2 @@
 cn=ldapuser1,dc=example,dc=com
-cn=ldapuser2,dc=example,dc=com
+cn=ldapuser2,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/env/set_up.sh
+++ b/modules/test/playwright/tests/portal-security-ldap/env/set_up.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
+
+source ${CURRENT_DIR_NAME}/../../../env/common.sh
+
+function ldap_set_up {
+	###########################################################################
+	# Start: steps can be removed with next CI release
+	###########################################################################
+
+	# Copy over entire correct file
+	local ciSlapdLdifLocation="/usr/local/etc/openldap/slapd.ldif"
+	local modifiedSlapdLdif="${CURRENT_DIR_NAME}/modifiedSlapd.ldif"
+
+	cp ${modifiedSlapdLdif} ${ciSlapdLdifLocation}
+
+	# Delete slapd.d dir if it exists
+	if [ -d /usr/local/etc/slapd.d ]
+	then
+		echo "deleting slapd.d"
+		rm -rf /usr/local/etc/slapd.d
+	else
+		echo "slapd.d does not exist"
+	fi
+
+	mkdir /usr/local/etc/slapd.d
+
+	# Check if slapd.d now exists
+	if [ -d /usr/local/etc/slapd.d ]
+	then
+		echo "slapd.d exists"
+	else
+		echo "slapd.d still does not exist"
+	fi
+
+	# Import configuration database
+
+	echo "Performing slapadd:"
+	/usr/local/sbin/slapadd -n 0 -F /usr/local/etc/slapd.d -l ${ciSlapdLdifLocation}
+
+	###########################################################################
+	# End: steps can be removed with next CI release
+	###########################################################################
+
+	# Start SLAPD
+	echo "Starting slapd:"
+	/usr/local/libexec/slapd -F /usr/local/etc/slapd.d
+
+	if [ $? -ne 0 ]; then
+		echo "Command failed with exit status $?"
+	else
+		echo "Command succeeded"
+	fi
+
+	# Add Example Company via ldif file
+	local exampleCompanyLdif="${CURRENT_DIR_NAME}/exampleCompany.ldif"
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -w "secret" -f ${exampleCompanyLdif}
+
+	if [ $? -ne 0 ]; then
+		echo "Command failed with exit status $?"
+	else
+		echo "Command succeeded"
+	fi
+
+	# Add admin via ldif file
+	local adminLdif="${CURRENT_DIR_NAME}/admin.ldif"
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -w "secret" -f ${adminLdif}
+
+	if [ $? -ne 0 ]; then
+		echo "Command failed with exit status $?"
+	else
+		echo "Command succeeded"
+	fi
+
+	# Add users via ldif file
+	local addUsersLdif="${CURRENT_DIR_NAME}/addUsers.ldif"
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -w "secret" -f ${addUsersLdif}
+
+	if [ $? -ne 0 ]; then
+		echo "Command failed with exit status $?"
+	else
+		echo "Command succeeded"
+	fi
+
+	# Add groups via ldif file
+	local addGroupsLdif="${CURRENT_DIR_NAME}/addGroups.ldif"
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -w "secret" -f ${addGroupsLdif}
+
+	if [ $? -ne 0 ]; then
+		echo "Command failed with exit status $?"
+	else
+		echo "Command succeeded"
+	fi
+}
+
+function main {
+	default_set_up
+
+	ldap_set_up
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/portal-security-ldap/env/tear_down.sh
+++ b/modules/test/playwright/tests/portal-security-ldap/env/tear_down.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
+
+source ${CURRENT_DIR_NAME}/../../../env/common.sh
+
+function main {
+	default_tear_down
+
+	ldap_tear_down
+}
+
+function ldap_tear_down {
+	# Remove Groups
+	local removeGroupsLdif="${CURRENT_DIR_NAME}/removeGroups.ldif"
+
+	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -w "secret" -f ${removeGroupsLdif}
+
+	# Remove Users
+	local removeUsersLdif="${CURRENT_DIR_NAME}/removeUsers.ldif"
+
+	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -w "secret" -f ${removeUsersLdif}
+
+	# Stop slapd service
+	kill -INT `cat /usr/local/var/run/slapd.pid`
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
@@ -1,0 +1,406 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {instanceSettingsPagesTest} from '../../fixtures/instanceSettingsPagesTest';
+import {ldapConfigurationPagesTest} from '../../fixtures/ldapConfigurationPagesTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
+import {userGroupsPageTest} from '../../fixtures/userGroupsPageTest';
+import {usersAndOrganizationsPagesTest} from '../../fixtures/usersAndOrganizationsPagesTest';
+import {
+	TLdapConfiguration,
+	TLdapServer,
+} from '../../helpers/LdapConfigurationHelper';
+import {SystemSettingsPage} from '../../pages/configuration-admin-web/SystemSettingsPage';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../utils/getRandomString';
+import performLogin from '../../utils/performLogin';
+import {waitForAlert} from '../../utils/waitForAlert';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	loginTest(),
+	instanceSettingsPagesTest,
+	ldapConfigurationPagesTest,
+	systemSettingsPageTest,
+	usersAndOrganizationsPagesTest,
+	userGroupsPageTest
+);
+
+const LDAP_GROUP_1 = 'ldapgroup1';
+const LDAP_GROUP_2 = 'ldapgroup2';
+const LDAP_USER_1 = 'ldapuser1';
+const LDAP_USER_2 = 'ldapuser2';
+
+test.afterAll(async ({browser}) => {
+	const page = await browser.newPage();
+
+	await performLogin(page, 'test');
+
+	const systemSettingsPage = new SystemSettingsPage(page);
+
+	await test.step('Reset System Settings LDAP configuration', async () => {
+		await resetLdapImportSystemSettings(systemSettingsPage);
+	});
+});
+
+test.afterEach(
+	async ({
+		apiHelpers,
+		ldapConfigurationPage,
+		ldapServerPage,
+		userGroupsPage,
+	}) => {
+		await test.step('Delete LDAP servers from portal', async () => {
+			await ldapServerPage.deleteLdapServers();
+		});
+
+		await test.step('Reset LDAP Instance Settings', async () => {
+			await ldapConfigurationPage.resetLdapConfiguration();
+		});
+
+		await test.step('Delete LDAP users from portal if present', async () => {
+			let user =
+				await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
+					`${LDAP_USER_1}@liferay.com`
+				);
+
+			await apiHelpers.headlessAdminUser.deleteUserAccount(
+				Number(user.id)
+			);
+
+			user =
+				await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
+					`${LDAP_USER_2}@liferay.com`
+				);
+
+			await apiHelpers.headlessAdminUser.deleteUserAccount(
+				Number(user.id)
+			);
+		});
+
+		await test.step('Delete LDAP groups from portal if present', async () => {
+			await userGroupsPage.goto();
+
+			const selectAllCheckbox = userGroupsPage.page.getByLabel(
+				'Select All Items on the Page'
+			);
+
+			await selectAllCheckbox.waitFor();
+
+			await userGroupsPage.page.waitForTimeout(1000);
+
+			if (await selectAllCheckbox.isEnabled()) {
+				await selectAllCheckbox.click();
+
+				userGroupsPage.page.once('dialog', async (dialog) => {
+					dialog.accept();
+				});
+
+				await userGroupsPage.page
+					.getByRole('button', {name: 'Delete'})
+					.click();
+
+				await waitForAlert(
+					userGroupsPage.page,
+					`Success:Your request completed successfully.`
+				);
+			}
+		});
+	}
+);
+
+test.beforeAll(async ({browser}) => {
+	const page = await browser.newPage();
+
+	await performLogin(page, 'test');
+
+	const systemSettingsPage = new SystemSettingsPage(page);
+
+	// The import interval at the System Settings level controls the scheduled
+	// job trigger.  Set it low so we can trigger imports during tests.
+
+	await test.step('Set LDAP Import Interval to 1 at System level', async () => {
+		await resetLdapImportSystemSettings(systemSettingsPage);
+
+		await systemSettingsPage.page.getByLabel('Import Interval').fill('1');
+
+		await systemSettingsPage.page
+			.getByRole('button', {name: 'Save'})
+			.click();
+
+		await waitForAlert(
+			systemSettingsPage.page,
+			`Success:Your request completed successfully.`
+		);
+	});
+});
+
+test('LPD-47428: Verify a single LDAP user can belong to multiple User Groups imported from LDAP', async ({
+	browser,
+	editUserPage,
+	ldapConfigurationPage,
+	ldapServerPage,
+	usersAndOrganizationsPage,
+}) => {
+	const ldapServer1: TLdapServer = {
+		defaultValues: 'OpenLDAP',
+		importSearchFilterGroup: `(&(objectClass=groupOfUniqueNames)(cn=${LDAP_GROUP_1}))`,
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName: getRandomString(),
+	};
+
+	const ldapServer2: TLdapServer = {
+		defaultValues: 'OpenLDAP',
+		importSearchFilterGroup: `(&(objectClass=groupOfUniqueNames)(cn=${LDAP_GROUP_2}))`,
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName: getRandomString(),
+	};
+
+	await test.step('Add the same LDAP server twice, but adjust the group import search filter so each entry adds a different group', async () => {
+		await test.step('Add first LDAP server', async () => {
+			await ldapServerPage.addLdapServer(ldapServer1);
+		});
+
+		await test.step('Verify first LDAP server it only imports the first group', async () => {
+			await ldapServerPage.viewLdapServer(ldapServer1.serverName, false);
+
+			await ldapServerPage.testLdapGroups.click();
+
+			await expect(
+				await ldapServerPage.page.getByRole('cell', {
+					name: LDAP_GROUP_1,
+				})
+			).toBeVisible();
+
+			await expect(
+				await ldapServerPage.page.getByRole('cell', {
+					name: LDAP_GROUP_2,
+				})
+			).not.toBeVisible();
+
+			await ldapServerPage.closeButton.click();
+
+			await ldapServerPage.cancelButton.click();
+		});
+
+		await test.step('Add second LDAP server', async () => {
+			await ldapServerPage.addLdapServer(ldapServer2, false);
+		});
+
+		await test.step('Verify second LDAP server it only imports the second group', async () => {
+			await ldapServerPage.viewLdapServer(ldapServer2.serverName, false);
+
+			await ldapServerPage.testLdapGroups.click();
+
+			await expect(
+				await ldapServerPage.page.getByRole('cell', {
+					name: LDAP_GROUP_2,
+				})
+			).toBeVisible();
+
+			await expect(
+				await ldapServerPage.page.getByRole('cell', {
+					name: LDAP_GROUP_1,
+				})
+			).not.toBeVisible();
+
+			await ldapServerPage.closeButton.click();
+
+			await ldapServerPage.cancelButton.click();
+		});
+	});
+
+	await test.step('Enable LDAP and wait for 1 minute, so import interval can be reached, triggering a bulk import', async () => {
+		const ldapConfiguration: TLdapConfiguration = {
+			enableImport: true,
+			enabled: true,
+			importInterval: 1,
+			importMethod: 'Group',
+		};
+
+		await ldapConfigurationPage.updateLDAPConfiguration(ldapConfiguration);
+
+		await ldapConfigurationPage.page.waitForTimeout(60 * 1000);
+	});
+
+	await test.step('View User Groups associated with the LDAP user, and verify they were correctly imported', async () => {
+		await usersAndOrganizationsPage.goToUsers(false);
+
+		await (
+			await usersAndOrganizationsPage.usersTableRowLink(LDAP_USER_1)
+		).click();
+
+		await editUserPage.membershipsLink.click();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_1,
+					true
+				)
+			).row
+		).toBeVisible();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_2,
+					true
+				)
+			).row
+		).toBeVisible();
+	});
+
+	await test.step('Attempt login with ldap user, but use incorrect password.  This reproduces the bug described in LPD-47428.', async () => {
+		const page = await browser.newPage();
+
+		await page.goto('/');
+
+		await page.getByRole('button', {name: 'Sign In'}).last().click();
+
+		await page
+			.getByLabel('Email Address')
+			.fill(`${LDAP_USER_1}@liferay.com`);
+		await page.getByLabel('Password').fill('badPassword');
+
+		await page.getByRole('button', {name: 'Sign In'}).last().click();
+
+		await waitForAlert(page, 'Error:Authentication failed', {
+			autoClose: false,
+			type: 'danger',
+		});
+	});
+
+	await test.step('Verify both User Groups are still associated with the LDAP user.', async () => {
+		await editUserPage.page.reload();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_1,
+					true
+				)
+			).row
+		).toBeVisible();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_2,
+					true
+				)
+			).row
+		).toBeVisible();
+	});
+});
+
+test('smoke: Add LDAP server, verify connection, users, and groups are mapped properly, edit LDAP server, then delete LDAP server', async ({
+	ldapConfigurationPage,
+	ldapServerPage,
+}) => {
+	const serverName = getRandomString();
+
+	const ldapServer: TLdapServer = {
+		defaultValues: 'OpenLDAP',
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName,
+	};
+
+	await test.step('Add LDAP Server', async () => {
+		await ldapServerPage.addLdapServer(ldapServer);
+	});
+
+	await test.step('Test LDAP Server connections', async () => {
+		await ldapServerPage.viewLdapServer(serverName, false);
+
+		await ldapServerPage.testLdapConnection.click();
+
+		await expect(
+			await ldapServerPage.page.getByText(
+				'Liferay has successfully connected to the LDAP server'
+			)
+		).toBeVisible();
+
+		await ldapServerPage.closeButton.click();
+
+		await ldapServerPage.testLdapUsers.click();
+
+		await expect(
+			await ldapServerPage.page.getByText(
+				'A subset of users has been displayed for you to review'
+			)
+		).toBeVisible();
+
+		await ldapServerPage.closeButton.click();
+
+		await ldapServerPage.testLdapGroups.click();
+
+		await expect(
+			await ldapServerPage.page.getByText(
+				'A subset of groups has been displayed for you to review'
+			)
+		).toBeVisible();
+
+		await ldapServerPage.closeButton.click();
+
+		await ldapServerPage.cancelButton.click();
+	});
+
+	await test.step('Edit LDAP Server by changing server name', async () => {
+		ldapServer.serverName = 'newServerName';
+
+		await ldapServerPage.editLdapServer(ldapServer, serverName, false);
+
+		await expect(
+			await ldapConfigurationPage.page.getByRole('row', {
+				name: 'newServerName',
+			})
+		).toBeVisible();
+	});
+
+	await test.step('Delete LDAP server', async () => {
+		await ldapServerPage.deleteLdapServer('newServerName', false);
+
+		await expect(
+			await ldapConfigurationPage.page.getByRole('row', {
+				name: 'newServerName',
+			})
+		).toBeHidden();
+	});
+});
+
+async function resetLdapImportSystemSettings(
+	systemSettingsPage: SystemSettingsPage
+) {
+	await systemSettingsPage.goToSystemSetting('LDAP', 'Import');
+
+	await systemSettingsPage.page.getByLabel('Import Interval').waitFor();
+
+	if (
+		await systemSettingsPage.page
+			.getByRole('button', {name: 'Actions'})
+			.isVisible()
+	) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: systemSettingsPage.page.getByRole('menuitem', {
+				name: 'Reset Default Values',
+			}),
+			trigger: systemSettingsPage.page.getByRole('button', {
+				name: 'Actions',
+			}),
+		});
+
+		await waitForAlert(systemSettingsPage.page);
+	}
+}

--- a/modules/test/playwright/tests/portal-security-ldap/test.properties
+++ b/modules/test/playwright/tests/portal-security-ldap/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=LDAP

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/LDIFWhitespaceCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/LDIFWhitespaceCheck.java
@@ -34,6 +34,6 @@ public class LDIFWhitespaceCheck extends WhitespaceCheck {
 	}
 
 	private static final Pattern _attributePattern = Pattern.compile(
-		"(?<=(\\A|\n)).+?:[^ ]");
+		"(?<=(\\A|\n)).+?(?<!file):[^ ]");
 
 }


### PR DESCRIPTION
Follow-up from https://github.com/liferay-appsec/liferay-portal/pull/2227

https://liferay.atlassian.net/browse/LPD-47428

To run the Playwright tests locally, here are the steps:
1. Follow steps 1-7 of this [OpenLDAP quickstart guide](https://www.openldap.org/doc/admin24/quickstart.html).  You may need to replace `su root -c` with `sudo` depending on your OS.
2. For step 8, just use the [modifiedSlapd.ldif file](https://github.com/liferay-appsec/liferay-portal/blob/b7411efa1fec434b01defc215ac352b4f5f38632/modules/test/playwright/tests/portal-security-ldap/env/modifiedSlapd.ldif) from this PR, completely replacing the file located at `/usr/local/etc/openldap/slapd.ldif`.  The command is `sudo mv /path/to/modifiedSlapd.ldif /usr/local/etc/openldap/slapd.ldif`
3. Make a `slapd.d` directory with the following command: `sudo mkdir /usr/local/etc/slapd.d`
4. Follow steps 9 and 10 of the quickstart guide.
5. Import Example Company, admin role, users, and groups (in that order) with the following command: `sudo ldapadd -cx -D "cn=admin,dc=example,dc=com" -w "secret" -f /path/to/file.ldif` where `file.ldif` is the corresponding ldif file (see [set_up.sh](https://github.com/liferay-appsec/liferay-portal/blob/e4680c858a1518d263a5fde0015fff4b7374ac50/modules/test/playwright/tests/portal-security-ldap/env/set_up.sh) for details).
6. run the following command to determine if users and groups were added: `sudo ldapsearch -x -b 'dc=example,dc=com' '(objectclass=*)'`

Now the playwright tests can be ran as-is.  Otherwise, if you have an existing LDAP configuration you would rather use, just follow the user and group structure found in the [addUsersAndGroups.ldif](https://github.com/liferay-appsec/liferay-portal/blob/b7411efa1fec434b01defc215ac352b4f5f38632/modules/test/playwright/tests/portal-security-ldap/env/addUsersAndGroups.ldif) file, so the test aligns with your local LDAP structure.