### PR TITLE
LPD-52199 Duplicated values in index IX_E81EADC5 during upgrade

### DIFF
--- a/modules/apps/portal/portal-upgrade-test-util/src/main/java/com/liferay/portal/upgrade/test/util/BaseExternalReferenceCodeUpgradeProcessTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test-util/src/main/java/com/liferay/portal/upgrade/test/util/BaseExternalReferenceCodeUpgradeProcessTestCase.java
@@ -88,12 +88,12 @@ public abstract class BaseExternalReferenceCodeUpgradeProcessTestCase {
 	@Test
 	public void testUpgradeProcess() throws Exception {
 		for (String tableName : getTableNames()) {
-			ExternalReferenceCodeModel[] externalReferenceCodeModels =
-				addExternalReferenceCodeModels(tableName);
-
 			List<IndexMetadata> indexMetadatas = _dropIndexes(tableName);
 
 			try {
+				ExternalReferenceCodeModel[] externalReferenceCodeModels =
+					addExternalReferenceCodeModels(tableName);
+
 				_prepareDatabaseForUpgradeProcess(
 					externalReferenceCodeModels,
 					_hasColumn(tableName, "groupId"), tableName);

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutExternalReferenceCodeUpgradeProcessTest.java
@@ -11,7 +11,9 @@ import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.version.Version;
@@ -34,14 +36,35 @@ public class LayoutExternalReferenceCodeUpgradeProcessTest
 			String tableName)
 		throws PortalException {
 
+		serviceContext = ServiceContextTestUtil.getServiceContext(
+			group.getGroupId());
+
+		serviceContext.setUuid(_UUID);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
 		Layout layout = _layoutLocalService.addLayout(
-			null, TestPropsValues.getUserId(), group.getGroupId(), true,
+			"", TestPropsValues.getUserId(), group.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			LayoutConstants.TYPE_CONTENT, false, false, null, serviceContext);
+
+		serviceContext = ServiceContextTestUtil.getServiceContext(
+			group.getGroupId());
+
+		serviceContext.setUuid(_UUID);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		Layout privateLayout = _layoutLocalService.addLayout(
+			"", TestPropsValues.getUserId(), group.getGroupId(), true,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
 			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
 			LayoutConstants.TYPE_CONTENT, false, false, null, serviceContext);
 
 		return new ExternalReferenceCodeModel[] {
-			layout, layout.fetchDraftLayout()
+			layout, layout.fetchDraftLayout(), privateLayout,
+			privateLayout.fetchDraftLayout()
 		};
 	}
 
@@ -53,6 +76,14 @@ public class LayoutExternalReferenceCodeUpgradeProcessTest
 		Layout layout = (Layout)externalReferenceCodeModel;
 
 		return _layoutLocalService.fetchLayout(layout.getPlid());
+	}
+
+	@Override
+	protected String getExternalReferenceCode(
+		ExternalReferenceCodeModel externalReferenceCodeModel,
+		String tableName) {
+
+		return externalReferenceCodeModel.getExternalReferenceCode();
 	}
 
 	@Override
@@ -74,6 +105,8 @@ public class LayoutExternalReferenceCodeUpgradeProcessTest
 	protected Version getVersion() {
 		return null;
 	}
+
+	private static final String _UUID = "uuid";
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutExternalReferenceCodeUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutExternalReferenceCodeUpgradeProcess.java
@@ -5,17 +5,63 @@
 
 package com.liferay.portal.upgrade.v7_4_x;
 
-import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.model.impl.LayoutModelImpl;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 /**
  * @author Rubén Pulido
  */
-public class LayoutExternalReferenceCodeUpgradeProcess
-	extends BaseExternalReferenceCodeUpgradeProcess {
+public class LayoutExternalReferenceCodeUpgradeProcess extends UpgradeProcess {
 
 	@Override
-	protected String[][] getTableAndPrimaryKeyColumnNames() {
-		return new String[][] {{"Layout", "plid"}};
+	protected void doUpgrade() throws Exception {
+		if (!hasColumn(LayoutModelImpl.TABLE_NAME, "externalReferenceCode")) {
+			alterTableAddColumn(
+				LayoutModelImpl.TABLE_NAME, "externalReferenceCode",
+				"VARCHAR(75)");
+		}
+
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			StringBundler selectSB = new StringBundler(4);
+
+			selectSB.append("select plid from ");
+			selectSB.append(LayoutModelImpl.TABLE_NAME);
+			selectSB.append(" where externalReferenceCode is null or ");
+			selectSB.append("externalReferenceCode = ''");
+
+			StringBundler updateSB = new StringBundler(3);
+
+			updateSB.append("update ");
+			updateSB.append(LayoutModelImpl.TABLE_NAME);
+			updateSB.append(" set externalReferenceCode = ? where plid = ?");
+
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(selectSB.toString());
+				ResultSet resultSet = preparedStatement1.executeQuery();
+				PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection, updateSB.toString())) {
+
+				while (resultSet.next()) {
+					long plid = resultSet.getLong(1);
+
+					preparedStatement2.setString(1, PortalUUIDUtil.generate());
+
+					preparedStatement2.setLong(2, plid);
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
I'm trying to fix https://liferay.atlassian.net/browse/LPD-52199

The export/import framework maintains the same uuid value when importing data. This means that there can be duplicated uuids for the same group (see reproduction steps in the LPD). When populating the uuid column for the layout table, we were copying the values of the uuids so we generating duplicated ERCs under the same scope group which breaks IX_E81EADC5 constraint. This pull changes this and I generate a new uuid to populate the ERC instead of copying the current uuid value.