### PR TITLE
LPD-55663 fix audit export additional information column

### DIFF
--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -90,15 +90,11 @@ public class ExportAuditEventsMVCResourceCommand
 	}
 
 	private String _getAuditEventCSV(AuditEvent auditEvent) {
-		return StringBundler.concat(
-			StringPool.QUOTE,
-			StringUtil.merge(
-				TransformUtil.transform(
-					_functions.values(),
-					function -> function.apply(auditEvent)),
-				StringBundler.concat(
-					StringPool.QUOTE, StringPool.COMMA, StringPool.QUOTE)),
-			StringPool.QUOTE, StringPool.NEW_LINE);
+		List<String> fields = TransformUtil.transform(
+			_functions.values(),
+			function -> CSVUtil.encode(function.apply(auditEvent)));
+
+		return StringUtil.merge(fields) + StringPool.NEW_LINE;
 	}
 
 	private List<AuditEvent> _getAuditEvents(


### PR DESCRIPTION
When a user exports the audit log as a csv file, the "additional information" column is formatted wrong. It is expected that additional information will be displayed within one column, but it spreads into multiple columns. I believe that it is because the comma character is not escaped properly.
 
Reproduction steps:
- login as an admin user
- export the existing audit log
- Issue - additional information is separated into multiple columns based on the comma character