### PR TITLE
LPD-55865 Approved filter causes folder pagination issues in Web Content view

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/comparator/FolderArticleTitleComparator.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/comparator/FolderArticleTitleComparator.java
@@ -13,9 +13,9 @@ import com.liferay.portal.kernel.util.OrderByComparator;
  */
 public class FolderArticleTitleComparator extends OrderByComparator<Object> {
 
-	public static final String ORDER_BY_ASC = "title ASC";
+	public static final String ORDER_BY_ASC = "modelFolder DESC, title ASC";
 
-	public static final String ORDER_BY_DESC = "title DESC";
+	public static final String ORDER_BY_DESC = "modelFolder DESC, title DESC";
 
 	public static final String[] ORDER_BY_FIELDS = {"title"};
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1453,6 +1453,12 @@ public class JournalDisplayContext {
 			_themeDisplay.getLocale(), _themeDisplay.getTimeZone());
 	}
 
+	private SearchResponse _fetchArticles(int start, int end) {
+		return JournalSearcherUtil.searchJournalArticles(
+			searchContext -> _populateSearchContext(
+				start, end, searchContext, false));
+	}
+
 	private SearchContainer<Object> _getArticleAndFolderSearchContainer()
 		throws PortalException {
 
@@ -1562,17 +1568,53 @@ public class JournalDisplayContext {
 		SearchContainer<Object> articleAndFolderSearchContainer =
 			_getArticleAndFolderSearchContainer();
 
-		SearchResponse searchResponse =
-			JournalSearcherUtil.searchJournalArticleAndFolders(
+		int start = articleAndFolderSearchContainer.getStart();
+		int end = articleAndFolderSearchContainer.getEnd();
+
+		int delta = end - start;
+
+		SearchResponse folderSearchResponse =
+			JournalSearcherUtil.searchJournalFolders(
 				searchContext -> _populateSearchContext(
-					articleAndFolderSearchContainer.getStart(),
-					articleAndFolderSearchContainer.getEnd(), searchContext,
-					false));
+					start, end, searchContext, false));
+
+		int totalArticleCount;
+		int totalFolderCount = folderSearchResponse.getTotalHits();
+		List<Document> documents = new ArrayList<>();
+
+		if (start < totalFolderCount) {
+			documents.addAll(
+				folderSearchResponse.getDocuments71(
+				).subList(
+					start, Math.min(end, totalFolderCount)
+				));
+
+			SearchResponse articleSearchResponse = _fetchArticles(
+				0, delta - documents.size());
+
+			totalArticleCount = articleSearchResponse.getTotalHits();
+
+			if (delta > documents.size()) {
+				documents.addAll(articleSearchResponse.getDocuments71());
+			}
+		}
+		else {
+			int articleStart = start - totalFolderCount;
+
+			int articleEnd = delta + articleStart;
+
+			SearchResponse articleSearchResponse = _fetchArticles(
+				articleStart, articleEnd);
+
+			documents.addAll(articleSearchResponse.getDocuments71());
+
+			totalArticleCount = articleSearchResponse.getTotalHits();
+		}
 
 		articleAndFolderSearchContainer.setResultsAndTotal(
 			() -> JournalSearcherUtil.transformJournalArticleAndFolders(
-				searchResponse.getDocuments71()),
-			searchResponse.getTotalHits());
+				documents),
+			totalFolderCount + totalArticleCount);
 
 		_articleSearchContainer = articleAndFolderSearchContainer;
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalSearcherUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalSearcherUtil.java
@@ -63,6 +63,24 @@ public class JournalSearcherUtil {
 			).build());
 	}
 
+	public static SearchResponse searchJournalFolders(
+		Consumer<SearchContext> searchContextConsumer) {
+
+		Searcher searcher = _searcherSnapshot.get();
+		SearchRequestBuilderFactory searchRequestBuilderFactory =
+			_searchRequestBuilderFactorySnapshot.get();
+
+		return searcher.search(
+			searchRequestBuilderFactory.builder(
+			).emptySearchEnabled(
+				true
+			).modelIndexerClasses(
+				JournalFolder.class
+			).withSearchContext(
+				searchContextConsumer
+			).build());
+	}
+
 	public static List<Object> transformJournalArticleAndFolders(
 		List<Document> documents) {
 

--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -379,3 +379,65 @@ test(
 		expect(/[[{]/.test(inputValue || '')).toBeFalsy();
 	}
 );
+
+test(
+	'Validate Folder Count After Creating Folders and Filtering by Approved',
+	{
+		tag: '@LPD-55865',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		for (let i = 1; i <= 6; i++) {
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site.id,
+				titleMap: {en_US: `Web Content ${i}`},
+			});
+		}
+
+		for (let i = 1; i <= 6; i++) {
+			await apiHelpers.jsonWebServicesJournal.addFolder({
+				groupId: site.id,
+				name: `Folder ${i}`,
+			});
+		}
+
+		for (let i = 7; i <= 12; i++) {
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site.id,
+				titleMap: {en_US: `Web Content ${i}`},
+			});
+		}
+
+		for (let i = 7; i <= 12; i++) {
+			await apiHelpers.jsonWebServicesJournal.addFolder({
+				groupId: site.id,
+				name: `Folder ${i}`,
+			});
+		}
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByLabel('Filter', {exact: true}).click();
+
+		await page.getByRole('menuitem', {name: 'Approved'}).click();
+
+		await page.getByLabel('Filter', {exact: true}).click();
+
+		await page.getByRole('menuitem', {name: 'Web Content'}).click();
+
+		await page.getByLabel('Order', {exact: true}).click();
+
+		await page.getByRole('menuitem', {name: 'Create Date'}).click();
+
+		await page.waitForSelector('dd[data-folder="true"]');
+
+		const folders = await page.locator('dd[data-folder="true"]');
+		const folderCount = await folders.count();
+
+		expect(folderCount).toBe(12);
+	}
+);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-55865
When filtering by Approved status, and both folders and web content articles are present, the folders are getting split across multiple pages. Instead of showing all folders first, they are mixed with articles in pagination, which affects the expected order.

### **How am I fixing it?**
To fix the issue, the implementation first fetches all the folders. Then, if there's still space left on the page, it fetches only as many web content articles as needed to fill that space. Finally, it combines the folders and articles into one list, always showing the folders first.

### **How can you verify that it works?**

1. Start a Liferay instance
2. Create Six folders and  Six Web Content articles.
3. Repeat the above process
4. Apply a filter using the Approved status.

**Expected Result:**
All 12 folders should appear at the top of the content list on the first page