### PR TITLE
fix: improve IllegalArgumentException message for column length check

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/OrderByComparatorFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/OrderByComparatorFactoryUtil.java
@@ -25,7 +25,7 @@ public class OrderByComparatorFactoryUtil {
 
 		if ((columns.length == 0) || ((columns.length % 2) != 0)) {
 			throw new IllegalArgumentException(
-				"Columns length is not an even number");
+				"Columns length is zero or not an even number");
 		}
 
 		return new DefaultOrderByComparator<>(tableName, columns);


### PR DESCRIPTION
Clarified that the columns array must have a non-zero even length. The previous message was ambiguous and could be misinterpreted.