### PR TITLE
Fix Japanese translation in Share Form Modal

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/components/share-form/Email.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/components/share-form/Email.es.js
@@ -67,7 +67,7 @@ const Email = ({
 	return (
 		<div className="share-form-modal-item-email">
 			<ClayForm.Group>
-				<label>{Liferay.Language.get('to')}</label>
+				<label>{Liferay.Language.get('to[email]')}</label>
 
 				<ClayInput.Group small stacked>
 					<ClayInput.GroupItem>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -20550,6 +20550,7 @@ title-only=タイトルのみ
 title[person]=タイトル
 titles=タイトル
 to=終了
+to[email]=宛先
 to-add,-click-members-on-the-left=追加するには、左のメンバーをクリックしてください。
 to-add,-click-members-on-the-top-list=追加するには、トップリストのメンバーをクリックしてください。
 to-add-a-fixed-tax-rate-you-must-add-a-tax-category=固定税率を追加するには、税カテゴリを追加する必要があります。


### PR DESCRIPTION
Context: 
- Received [customer ticket](https://liferay-support.zendesk.com/agent/tickets/136696) about Japanese translation being wrong for the OOTB Form Sharing feature. 

Expected behavior:
- The "To" should be "宛先" for emails
Actual behavior: 
- The "To" is "終了"

Changes:
- Added a more contextual key to `Language_ja.properties`
- Use the added key for the `share-form-modal` 