### PR TITLE
LPD-4641 Add alt text to images for cards in Clay Sample Web.

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
@@ -232,6 +232,7 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 	>
 		<clay:image-card
 			actionDropdownItems="<%= claySampleImageCard.getActionDropdownItems() %>"
+			imageAlt="<%= claySampleImageCard.getTitle() %>"
 			imageSrc="https://images.unsplash.com/photo-1525151212033-377d12acc381"
 			labels="<%= claySampleImageCard.getLabels() %>"
 			selectable="<%= true %>"
@@ -669,6 +670,7 @@ ClaySampleVerticalCard claySampleVerticalCard = new ClaySampleVerticalCard();
 	>
 
 		<%
+		claySampleVerticalCard.setImageAlt(claySampleVerticalCard.getTitle());
 		claySampleVerticalCard.setImageSrc("https://images.unsplash.com/photo-1554939437-ecc492c67b78");
 		claySampleVerticalCard.setSelectable(true);
 		claySampleVerticalCard.setStickerLabel("MAD");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-4641

I resolved the errors related to alt text, but I noticed there were an additional 7 critical errors for "Form elements must have labels". I was unsure where to fix this after attempting in several places, it seems like it might be an issue with the checkbox of the card. I did notice though, it looks like it is wrapped in a label already which is one of the suggested fixes, so I was not sure about this one. 

<img width="1220" height="936" alt="image" src="https://github.com/user-attachments/assets/42c73bbb-404f-4da7-8531-5f9a8c034342" />

@pat270 
