### PR TITLE
LPD-63066 Improve shortcut hint in regular uses of CKEditor 4 as well

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor4/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor4/main.scss
@@ -335,3 +335,23 @@
 		padding: 0.5em;
 	}
 }
+
+.keyboard-message.popover {
+	left: inherit;
+	padding: 0.25rem 0.5rem;
+	right: 4px;
+	top: 4px;
+	transition: padding ease-out 200ms;
+
+	&:not(:hover) {
+		padding: 0;
+
+		.c-kbd-sm:not(.c-kbd) {
+			display: none;
+		}
+
+		.c-kbd-light {
+			font-size: 65%;
+		}
+	}
+}


### PR DESCRIPTION
Hi,

This is the second part of [this pull request](https://github.com/liferay-frontend/liferay-portal/pull/5039). That one was fixing the case when using Codemirror in Fragments and DDM Templates, but not for regular uses of CKEditor, such as Web Content. This commit is just doing that.

Thanks.

Regards.