### PR TITLE
LPD-66338 Setting DefaultLanguageId in proxyObject

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -122,6 +123,10 @@ public class ObjectEntryItemDescriptor
 		}
 
 		try {
+			if (Validator.isNull(_objectEntry.getTitleValue())) {
+				return _objectEntry.getTitleValue(String.valueOf(locale), true);
+			}
+
 			return _objectEntry.getTitleValue();
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
@@ -155,6 +155,8 @@ public class ObjectEntryUtil {
 		serviceBuilderObjectEntry.setObjectEntryId(
 			GetterUtil.getLong(objectEntry.getId()));
 		serviceBuilderObjectEntry.setObjectDefinitionId(objectDefinitionId);
+		serviceBuilderObjectEntry.setDefaultLanguageId(
+			objectEntry.getDefaultLanguageId());
 
 		return new ProxyObjectEntry(serviceBuilderObjectEntry, objectEntry);
 	}


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-66338

Non-translated object entries show as null instead of showing title in default language.

# How am I fixing it?
Setting defaulLanguageId while creating a proxyObject
 
# How can you verify that it works?
Run the included automated tests.