### PR TITLE
fix: iframe widget uses AutosizeIframe plugin for automatic resize

### DIFF
--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -163,6 +163,7 @@
 				}
 			}
 			catch (e) {
+				console.error('Error parsing iframe URL for autosizing:', e);
 			}
 		}
 

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -143,23 +143,44 @@
 			);
 		}
 
+		let autosizeApplied = false;
+
 		if (<%= iFramePortletInstanceConfiguration.resizeAutomatically() %>) {
-			iframe.height = document.body.scrollHeight;
+			const portalURL = '<%= HtmlUtil.escapeJS(themeDisplay.getPortalURL()) %>';
+			const iframeSrc = '<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeSrc()) %>';
+
+			try {
+				const iframeURL = new URL(iframeSrc, portalURL);
+
+				if (iframeURL.origin === portalURL) {
+					const iframeNode = A.one('#<portlet:namespace />iframe');
+
+					if (iframeNode) {
+						iframeNode.plug(A.Plugin.AutosizeIframe);
+
+						autosizeApplied = true;
+					}
+				}
+			}
+			catch (e) {
+			}
 		}
 
 		iframe.addEventListener('load', () => {
-			let height = iframe.getAttribute('height');
+			if (!autosizeApplied) {
+				let height = iframe.getAttribute('height');
 
-			if (height == null) {
-				height =
-					'<%= HtmlUtil.escapeJS(iFramePortletInstanceConfiguration.heightNormal()) %>';
-
-				if (themeDisplay.isStateMaximized()) {
+				if (height == null) {
 					height =
-						'<%= HtmlUtil.escapeJS(iFramePortletInstanceConfiguration.heightMaximized()) %>';
-				}
+						'<%= HtmlUtil.escapeJS(iFramePortletInstanceConfiguration.heightNormal()) %>';
 
-				iframe.height = height;
+					if (themeDisplay.isStateMaximized()) {
+						height =
+							'<%= HtmlUtil.escapeJS(iFramePortletInstanceConfiguration.heightMaximized()) %>';
+					}
+
+					iframe.height = height;
+				}
 			}
 		});
 	}


### PR DESCRIPTION
When "Resize Automatically" is enabled, the IFrame widget loads aui-autosize-iframe but never plugs A.Plugin.AutosizeIframe. Instead it sets iframe.height = document.body.scrollHeight, which measures the parent page, not the iframe content.

This change:

- Plugs A.Plugin.AutosizeIframe on same-origin iframes when resizeAutomatically is true
- Applies manual height (heightNormal/heightMaximized) only as fallback when autosize is not applied (cross-origin or resizeAutomatically disabled)
- Omits the height attribute from the iframe tag when resizeAutomatically is enabled so the plugin can control it.