### PR TITLE
Fix level assignment in addCommerceDiscount

### DIFF
--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
@@ -335,13 +335,13 @@ public class CommerceDiscountLocalServiceImpl
 				commerceDiscount.setLevel1(level1);
 			}
 			else if (level.equals(CommerceDiscountConstants.LEVEL_L2)) {
-				commerceDiscount.setLevel2(level1);
+				commerceDiscount.setLevel2(level2);
 			}
 			else if (level.equals(CommerceDiscountConstants.LEVEL_L3)) {
-				commerceDiscount.setLevel3(level1);
+				commerceDiscount.setLevel3(level3);
 			}
 			else if (level.equals(CommerceDiscountConstants.LEVEL_L4)) {
-				commerceDiscount.setLevel4(level1);
+				commerceDiscount.setLevel4(level4);
 			}
 		}
 		else {


### PR DESCRIPTION
When adding a new L2-level discount using `_commerceDiscountService.addOrUpdateCommerceDiscount`, the Level 2 discount is not saved.

This behavior is caused by the following code in the `addCommerceDiscount` method of the `CommerceDiscountLocalServiceImpl` class:

```
		if (!level.isEmpty()) {
			if (level.equals(CommerceDiscountConstants.LEVEL_L1)) {
				commerceDiscount.setLevel1(level1);
			}
			else if (level.equals(CommerceDiscountConstants.LEVEL_L2)) {
				commerceDiscount.setLevel2(level1);
			}
			else if (level.equals(CommerceDiscountConstants.LEVEL_L3)) {
				commerceDiscount.setLevel3(level1);
			}
			else if (level.equals(CommerceDiscountConstants.LEVEL_L4)) {
				commerceDiscount.setLevel4(level1);
			}
		}
		else {
			commerceDiscount.setLevel1(level1);
			commerceDiscount.setLevel2(level2);
			commerceDiscount.setLevel3(level3);
			commerceDiscount.setLevel4(level4);
		}
```