### PR TITLE
LPD-82497 add collection option included to asset publisher configuration

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/css/main.scss
@@ -35,3 +35,9 @@
 		margin-top: -55px;
 	}
 }
+
+	.hide-control-menu {
+		.control-menu {
+			display: none;
+		}
+	}

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -21,6 +21,7 @@ import com.liferay.asset.kernel.service.AssetEntryServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
+import com.liferay.asset.list.constants.AssetListPortletKeys;
 import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntrySegmentsEntryRelLocalService;
 import com.liferay.asset.publisher.action.AssetEntryAction;
@@ -89,6 +90,7 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -111,6 +113,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsParamUtil;
 import com.liferay.portal.kernel.util.StringComparator;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -460,6 +463,13 @@ public class AssetPublisherDisplayContext {
 				RequestBackedPortletURLFactoryUtil.create(_portletRequest),
 				getSelectAssetListEventName(),
 				infoCollectionProviderItemSelectorCriterion));
+	}
+
+	public String getAddCollectionAssetListURL() {
+		return String.valueOf(PortalUtil.getControlPanelPortletURL(
+			_httpServletRequest, _themeDisplay.getScopeGroup(),
+			AssetListPortletKeys.ASSET_LIST, 0, 0,
+			PortletRequest.ACTION_PHASE));
 	}
 
 	public String getAssetTagName() {
@@ -1413,6 +1423,8 @@ public class AssetPublisherDisplayContext {
 			}
 		).put(
 			"url", getAssetListSelectorURL()
+		).put(
+			"addCollectionUrl", getAddCollectionAssetListURL()
 		).build();
 	}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/SelectCollection.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/SelectCollection.js
@@ -17,6 +17,7 @@ export default function SelectCollection({
 	selectEventName,
 	title: initialTitle,
 	url,
+	addCollectionUrl
 }) {
 	const onChangeCollectionButtonClick = () => {
 		openSelectionModal({
@@ -59,6 +60,14 @@ export default function SelectCollection({
 			title: defaultTitle,
 		});
 	};
+
+	const onAddCollectionButtonClick = () => {
+		openSelectionModal({
+			iframeBodyCssClass: 'hide-control-menu',
+			title: Liferay.Language.get('add-collection'),
+			url: addCollectionUrl.toString()
+		});
+	}
 
 	const [values, setValues] = useState({
 		assetListEntryId: initialAssetListEntryId,
@@ -103,7 +112,7 @@ export default function SelectCollection({
 						className="c-mr-2 flex-shrink-0"
 						displayType="secondary"
 						onClick={onChangeCollectionButtonClick}
-						symbol={values.clearButtonEnabled ? 'change' : 'plus'}
+						symbol={values.clearButtonEnabled ? 'change' : 'select'}
 						title={
 							values.clearButtonEnabled
 								? Liferay.Language.get('change-collection')
@@ -116,13 +125,23 @@ export default function SelectCollection({
 							aria-label={Liferay.Language.get(
 								'clear-collection'
 							)}
-							className="flex-shrink-0"
+							className="c-mr-2 flex-shrink-0"
 							displayType="secondary"
 							onClick={onClearCollectionButtonClick}
 							symbol="times-circle"
 							title={Liferay.Language.get('clear-collection')}
 						/>
 					) : null}
+
+					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('add-collection')}
+						className="flex-shrink-0"
+						displayType="primary"
+						onClick={onAddCollectionButtonClick}
+						symbol="plus"
+						title={Liferay.Language.get('add-collection')}
+					/>
+
 				</div>
 			</ClayForm.Group>
 		</>


### PR DESCRIPTION
### What is this trying to solve

Technical spike (https://liferay.atlassian.net/browse/LPD-82497)
Check if its feasible to open the Creation flow in a new tab and how to deal with the coming back from the creation page to the Asset Publisher collection selector. 

Check also if its possible to show the Creation flow within the same modal, without navigating to other page/tab

### How did I achieve it
I added a button (plus icon) to open the collection management inside of Asset Publisher configuration. 

### Screen record

https://github.com/user-attachments/assets/0218026c-1cb0-4953-a587-1a8c160cac61

