### PR TITLE
LRCI-7299 Parallelize modules-compile

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -8712,50 +8712,17 @@ information. Make sure to commit in all format-javadoc results.
 					</then>
 				</if>
 
-				<loadresource property="modules.compile.task.groups">
+				<loadresource property="modules.compile.tasks">
 					<filterchain>
 						<replacestring from="-test:assemble" to="-test:compileTestIntegrationJava" />
-
-						<tokenfilter>
-							<replaceregex flags="g" pattern="(\S+ ){${test.module.groups.size}}" replace="\0," />
-						</tokenfilter>
 					</filterchain>
 					<propertyresource name="modules.test.class.group" />
 				</loadresource>
 
-				<get-gradle-module-dir-task-names gradle.task.names="${modules.compile.task.groups}" />
-
-				<for delimiter="|" list="${gradle.module.dir.task.names}" param="gradle.module.dir.task.name" trim="true">
-					<sequential>
-						<local name="gradle.module.dir" />
-						<local name="gradle.task.name" />
-
-						<propertyregex
-							input="@{gradle.module.dir.task.name}"
-							override="true"
-							property="gradle.module.dir"
-							regexp="([^=]+)=([^=]+)"
-							replace="\1"
-						/>
-
-						<propertyregex
-							input="@{gradle.module.dir.task.name}"
-							override="true"
-							property="gradle.task.name"
-							regexp="([^=]+)=([^=]+)"
-							replace="\2"
-						/>
-
-						<execute-gradle-task gradle.task.module.dir="${gradle.module.dir}" gradle.task.name="${gradle.task.name}">
-							<action>
-								<gradle-execute dir="${gradle.module.dir}" task="${gradle.task.name}">
-									<arg value="--continue" />
-									<arg value="--parallel" />
-								</gradle-execute>
-							</action>
-						</execute-gradle-task>
-					</sequential>
-				</for>
+				<gradle-execute dir="modules" task="${modules.compile.tasks}">
+					<arg value="--continue" />
+					<arg value="--parallel" />
+				</gradle-execute>
 			</test-action>
 
 			<test-set-up>

--- a/modules/init-ci.gradle
+++ b/modules/init-ci.gradle
@@ -1,0 +1,142 @@
+import groovy.xml.XmlUtil
+
+import java.util.concurrent.ConcurrentHashMap
+
+final String TASK_NAME_ASSEMBLE = "assemble"
+final String TASK_NAME_COMPILE_TEST_INTEGRATION_JAVA = "compileTestIntegrationJava"
+
+ConcurrentHashMap<String, Long> compileTaskStartTimes = new ConcurrentHashMap<String, Long>()
+ConcurrentHashMap<String, String> projectPathToTargetTaskName = new ConcurrentHashMap<String, String>()
+Set<String> writtenProjectPaths = ConcurrentHashMap.newKeySet()
+
+File testResultsDir = null
+
+Closure isCompileTask = {
+	Task task ->
+
+	return (task.name == TASK_NAME_ASSEMBLE) || (task.name == TASK_NAME_COMPILE_TEST_INTEGRATION_JAVA)
+}
+
+Closure getClassName = {
+	String projectPath ->
+
+	return "modules" + projectPath.replace(":", ".")
+}
+
+Closure writeReport = {
+	String projectPath, Double duration, String failureMessage, String failureStacktrace ->
+
+	writtenProjectPaths.add projectPath
+
+	int failureCount = (failureMessage == null) ? 0 : 1
+
+	String className = getClassName(projectPath)
+	String timestamp = new Date().format("yyyy-MM-dd_kk:mm:ss")
+
+	String failureElement = ""
+
+	if (failureMessage != null) {
+		failureElement = "<failure message=\"${XmlUtil.escapeXml(failureMessage)}\">${XmlUtil.escapeXml(failureStacktrace ?: "")}</failure>"
+	}
+
+	String xml = """<?xml version="1.0" encoding="UTF-8"?>
+
+		<testsuite errors="${failureCount}" failures="${failureCount}" hostname="localhost" name="${className}" skipped="0" tests="1" time="${duration}" timestamp="${timestamp}">
+			<properties />
+			<testcase classname="${className}" name="assemble" time="${duration}">
+				${failureElement
+}
+			</testcase>
+			<system-out></system-out>
+			<system-err></system-err>
+		</testsuite>"""
+
+	File file = new File(testResultsDir, "TEST-${className}.xml")
+
+	file.text = xml
+}
+
+gradle.taskGraph.whenReady {
+	TaskExecutionGraph taskGraph ->
+
+	taskGraph.allTasks.each {
+		Task task ->
+
+		if (!isCompileTask(task)) {
+			return
+		}
+
+		if (testResultsDir == null) {
+			testResultsDir = new File(gradle.rootProject.rootDir, "test-results")
+
+			testResultsDir.mkdirs()
+		}
+
+		projectPathToTargetTaskName.put task.project.path, task.name
+	}
+}
+
+gradle.taskGraph.addTaskExecutionListener(
+	new TaskExecutionListener() {
+
+		void afterExecute(Task task, TaskState taskState) {
+			String projectPath = task.project.path
+
+			if (!projectPathToTargetTaskName.containsKey(projectPath)) {
+				return
+			}
+
+			Throwable failure = taskState.failure
+			boolean compileTask = isCompileTask(task)
+
+			if (!compileTask && (failure == null)) {
+				return
+			}
+
+			double duration = 0.0d
+
+			if (compileTask) {
+				long startTime = compileTaskStartTimes.remove(task.path)
+
+				duration = (System.currentTimeMillis() - startTime) / 1000.0d
+			}
+
+			if (failure == null) {
+				writeReport(projectPath, duration, null, null)
+			}
+			else {
+				StringWriter stringWriter = new StringWriter()
+
+				failure.printStackTrace(new PrintWriter(stringWriter))
+
+				writeReport(
+					projectPath,
+					duration,
+					"${task.path} failed. Please check the logs for details.",
+					stringWriter.toString())
+			}
+		}
+
+		void beforeExecute(Task task) {
+			if (isCompileTask(task)) {
+				compileTaskStartTimes.put task.path, System.currentTimeMillis()
+			}
+		}
+
+	})
+
+gradle.buildFinished {
+	projectPathToTargetTaskName.each {
+		String projectPath, String targetTaskName ->
+
+		if (writtenProjectPaths.contains(projectPath)) {
+			return
+		}
+
+		writeReport(
+			projectPath,
+			0.0d,
+			"${projectPath}:${targetTaskName} was not executed. Please check the logs for details.",
+			"")
+	}
+}

--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -115,3 +115,15 @@ if (Boolean.getBoolean("build.performance.logger.enabled")) {
 
 		})
 }
+
+if (System.getenv("JENKINS_HOME")) {
+	gradle.rootProject {
+		Project rootProject ->
+
+		File scriptFile = rootProject.file("init-ci.gradle")
+
+		if (scriptFile.exists()) {
+			apply from: scriptFile
+		}
+	}
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7299

**What is being fixed:** The `modules-compile` batch in `build-test-batch.xml` runs each module's assemble task in its own `gradle-execute` call through a for-loop wrapper. That makes the batch effectively single-threaded across the axis, and modules-compile currently takes many hours across 13 nodes.

**How it is being fixed:** The `modules-compile` target now collects the full task list and dispatches it in a single `gradle-execute` call with `--parallel --continue`. The per-module JUnit reports that the old Ant-side `execute-gradle-task` macrodef used to emit are now produced by a new CI-only Gradle listener, living in `modules/init-ci.gradle` and applied from `modules/init.gradle` when `JENKINS_HOME` is set. The listener writes `modules/test-results/TEST-<dotted-module-path>.xml` in a shape byte-compatible with the Ant macro it replaces: one `<testsuite>` / `<testcase>` per module with the task duration and a `<failure>` containing the raw stacktrace on failure. Projects whose target task is skipped (typically because a dependency like `compileJava` failed) are covered by a `buildFinished` write-on-miss fallback, preserving the per-module visibility the old flow had.