### PR TITLE
LRCI-7362 Balance modules-compile axes by test class method count

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/CompileModulesBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/CompileModulesBatchTestClassGroup.java
@@ -8,12 +8,16 @@ package com.liferay.jenkins.results.parser.test.clazz.group;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
 import com.liferay.jenkins.results.parser.PortalTestClassJob;
+import com.liferay.jenkins.results.parser.test.clazz.TestClass;
+import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 
 import java.io.File;
 import java.io.IOException;
 
 import java.nio.file.PathMatcher;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.json.JSONObject;
@@ -34,6 +38,79 @@ public class CompileModulesBatchTestClassGroup
 		String batchName, PortalTestClassJob portalTestClassJob) {
 
 		super(batchName, portalTestClassJob);
+	}
+
+	@Override
+	protected void setAxisTestClassGroups() {
+		if (!containsTestClasses()) {
+			return;
+		}
+
+		int axisCount = getAxisCount();
+
+		if (axisCount == 0) {
+			return;
+		}
+
+		List<TestClass> testClasses = getTestClasses();
+
+		Collections.sort(
+			testClasses,
+			(testClass1, testClass2) -> {
+				List<TestClassMethod> testClassMethods1 =
+					testClass1.getTestClassMethods();
+				List<TestClassMethod> testClassMethods2 =
+					testClass2.getTestClassMethods();
+
+				int methodCount1 = testClassMethods1.size();
+				int methodCount2 = testClassMethods2.size();
+
+				if (methodCount1 != methodCount2) {
+					return Integer.compare(methodCount2, methodCount1);
+				}
+
+				return testClass1.compareTo(testClass2);
+			});
+
+		List<AxisTestClassGroup> newAxisTestClassGroups = new ArrayList<>(
+			axisCount);
+		int[] axisTestClassMethodCounts = new int[axisCount];
+
+		for (int i = 0; i < axisCount; i++) {
+			newAxisTestClassGroups.add(
+				TestClassGroupFactory.newAxisTestClassGroup(this));
+		}
+
+		for (TestClass testClass : testClasses) {
+			int minAxisIndex = 0;
+
+			for (int i = 1; i < axisCount; i++) {
+				if (axisTestClassMethodCounts[i] <
+						axisTestClassMethodCounts[minAxisIndex]) {
+
+					minAxisIndex = i;
+				}
+			}
+
+			AxisTestClassGroup axisTestClassGroup = newAxisTestClassGroups.get(
+				minAxisIndex);
+
+			axisTestClassGroup.addTestClass(testClass);
+
+			List<TestClassMethod> testClassMethods =
+				testClass.getTestClassMethods();
+
+			axisTestClassMethodCounts[minAxisIndex] += testClassMethods.size();
+		}
+
+		for (AxisTestClassGroup axisTestClassGroup : newAxisTestClassGroups) {
+			List<TestClass> axisTestClasses =
+				axisTestClassGroup.getTestClasses();
+
+			if (!axisTestClasses.isEmpty()) {
+				axisTestClassGroups.add(axisTestClassGroup);
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

- Override `setAxisTestClassGroups()` in `CompileModulesBatchTestClassGroup` to distribute test classes using LPT (Longest Processing Time-first) greedy bin-packing keyed on `TestClassMethod` count rather than `TestClass` count.
- Some modules hold many project sub-modules as `TestClassMethod`s on a single `TestClass`, so axis-balancing by test-class count left axis 0 with 34 minutes of work while peers finished in 6-20 minutes. Weighting by method count closes that gap.
- Subtask of LRCI-7299 (`modules-compile` parallelization). Pre-requisite for a future swap to `TestClassBalancedListSplitter` once per-project durations are accurate.

## Test plan

- [ ] CI `test-portal-acceptance-pullrequest(master)` green on this branch.
- [ ] `modules-compile` axis wall-clocks converge (compare axis times across the run; no single outlier axis dominating).