### PR TITLE
LPD-87418 Accept Workload Identity Federation credentials in Google Cloud Translator

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
+++ b/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
@@ -469,6 +469,16 @@ definition {
 
 	@summary = "Default summary"
 	macro setGoogleCloudTranslationServiceKey() {
+		var wifCredentialsFile = "/root/.gcloud/translate.json";
+
+		var wifCredentialsFileExists = FileUtil.exists(${wifCredentialsFile});
+
+		if (${wifCredentialsFileExists} == "true") {
+			var attributes = FileUtil.read(${wifCredentialsFile});
+
+			return ${attributes};
+		}
+
 		var lineSeparater = "\n";
 		var value1 = PropsUtil.get("google.cloud.translation.service.key.type");
 		var value2 = PropsUtil.get("google.cloud.translation.service.key.project.id");

--- a/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
+++ b/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
@@ -5,7 +5,7 @@
 
 package com.liferay.translation.translator.google.cloud.internal.translator;
 
-import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.translate.Language;
 import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateOptions;
@@ -151,13 +151,12 @@ public class GoogleCloudTranslator extends BaseTranslator {
 		String serviceAccountPrivateKey =
 			googleCloudTranslatorConfiguration.serviceAccountPrivateKey();
 
-		ServiceAccountCredentials serviceAccountCredentials = null;
+		GoogleCredentials googleCredentials = null;
 
 		try (InputStream inputStream = new ByteArrayInputStream(
 				serviceAccountPrivateKey.getBytes())) {
 
-			serviceAccountCredentials = ServiceAccountCredentials.fromStream(
-				inputStream);
+			googleCredentials = GoogleCredentials.fromStream(inputStream);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
@@ -170,7 +169,7 @@ public class GoogleCloudTranslator extends BaseTranslator {
 		return defaultTranslateFactory.create(
 			TranslateOptions.newBuilder(
 			).setCredentials(
-				serviceAccountCredentials
+				googleCredentials
 			).build());
 	}
 


### PR DESCRIPTION
## Summary

- **`GoogleCloudTranslator.java`**: Swap `ServiceAccountCredentials.fromStream(...)` for the generic `GoogleCredentials.fromStream(...)`. The generic loader dispatches on the JSON's `type` field, so existing customers with a `service_account` JSON pasted into the "Service Account Private Key" system-settings field keep working, while customers using AWS/Azure/GCP Workload Identity Federation can now paste an `external_account` config and have it succeed.
- **`Translations.macro` `setGoogleCloudTranslationServiceKey()`**: Prefer reading `/root/.gcloud/translate.json` verbatim, falling back to the existing property-reconstruction path when the file is absent. Old CI Docker images (no WIF config on disk) continue taking the property path; new images (LRCI-7279) take the file path.

## JIRA

- [LPD-87418](https://liferay.atlassian.net/browse/LPD-87418) — Accept Workload Identity Federation credentials in Google Cloud Translator
- [LRCI-7279](https://liferay.atlassian.net/browse/LRCI-7279) — Replace service account keys with credential config files (CI-side rollout)

## Dependencies and ordering

Must merge before any LRCI-7279 follow-up that removes `private.property[google.cloud.translation.service.key.*]` from `liferay-jenkins-ee/commands/build-shared.properties`. Otherwise a new-image Jenkins slave would paste an `external_account` JSON into an unpatched Google Cloud Translator and translation tests would fail.

## Test plan

- [ ] Translation functional tests pass on pre-LRCI-7279 CI Docker images (file absent → property path → service-account JSON).
- [ ] Translation functional tests pass on post-LRCI-7279 CI Docker images (file present → file path → WIF JSON).
- [ ] Existing customer configurations with `service_account` JSON continue to work unchanged.

[LPD-87418]: https://liferay.atlassian.net/browse/LPD-87418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LRCI-7279]: https://liferay.atlassian.net/browse/LRCI-7279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ