### PR TITLE
LPD-87534 Fixed overlapping items on first open of virtualized (tags) dropdown

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/__tests__/useCollection.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/__tests__/useCollection.tsx
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayPortal} from '@clayui/shared';
+import {cleanup, render, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, {useRef, useState} from 'react';
+
+import {Collection} from '../Collection';
+
+global.ResizeObserver = require('resize-observer-polyfill');
+
+function VirtualizedDropdown({items}: {items: Array<string>}) {
+	const parentRef = useRef<HTMLDivElement>(null);
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<>
+			<button onClick={() => setIsOpen(true)} type="button">
+				Open
+			</button>
+
+			{isOpen && (
+				<ClayPortal>
+					<div
+						ref={parentRef}
+						style={{height: 200, overflow: 'auto'}}
+					>
+						<Collection
+							as="ul"
+							items={items}
+							parentRef={parentRef}
+							virtualize
+						>
+							{(item: string) => (
+								<li key={item} role="option">
+									{item}
+								</li>
+							)}
+						</Collection>
+					</div>
+				</ClayPortal>
+			)}
+		</>
+	);
+}
+
+describe('useCollection', () => {
+	afterEach(cleanup);
+
+	it('observes virtualized items on first mount even when the host container is initially detached from the document (LPD-87534)', async () => {
+
+		// Without the deferred measurement in `useCollection`, item refs fire
+		// while the portal container is still detached from the document, so
+		// `_measureElement` exits early on `!node.isConnected`,
+		// `ResizeObserver.observe` is never called for the items, and the
+		// virtualizer stays at the `estimateSize` fallback — which is what
+		// causes long labels to overlap on first open.
+
+		const observeSpy = jest.spyOn(
+			(global as any).ResizeObserver.prototype,
+			'observe'
+		);
+
+		const items = ['one', 'two', 'three'];
+
+		const {getByText} = render(<VirtualizedDropdown items={items} />);
+
+		userEvent.click(getByText('Open'));
+
+		await waitFor(() => {
+			const observedItems = observeSpy.mock.calls
+				.map((call) => call[0] as HTMLElement)
+				.filter((node) => node?.dataset?.index !== undefined);
+
+			expect(observedItems).toHaveLength(items.length);
+		});
+
+		observeSpy.mockRestore();
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/useCollection.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/useCollection.tsx
@@ -53,23 +53,23 @@ export function useCollection<
 	P = unknown,
 	K = unknown,
 >({
-	children,
-	connectNested = true,
-	exclude,
-	filter,
-	filterKey,
-	forceDeepRootUpdate,
-	itemContainer: ItemContainer,
-	itemIdKey = 'id',
-	items,
-	notFound,
-	parentKey,
-	passthroughKey = true,
-	publicApi,
-	suppressTextValueWarning = true,
-	virtualizer,
-	visibleKeys,
-}: ICollectionProps<T, P> & Props<P, K>): CollectionState {
+	  children,
+	  connectNested = true,
+	  exclude,
+	  filter,
+	  filterKey,
+	  forceDeepRootUpdate,
+	  itemContainer: ItemContainer,
+	  itemIdKey = 'id',
+	  items,
+	  notFound,
+	  parentKey,
+	  passthroughKey = true,
+	  publicApi,
+	  suppressTextValueWarning = true,
+	  virtualizer,
+	  visibleKeys,
+  }: ICollectionProps<T, P> & Props<P, K>): CollectionState {
 	const {forceUpdate, layout: parentLayout} = useContext(CollectionContext);
 
 	const layoutRef = useRef<Map<React.Key, LayoutValue>>(new Map());
@@ -126,9 +126,9 @@ export function useCollection<
 					>
 						{props
 							? React.cloneElement(
-									child as React.ReactElement,
-									props
-								)
+								child as React.ReactElement,
+								props
+							)
 							: child}
 					</ItemContainer>
 				);
@@ -140,22 +140,22 @@ export function useCollection<
 				key,
 				...(passthroughKey || hasChildNeedPassthroughKey
 					? {
-							index,
-							keyValue: key,
+						index,
+						keyValue: key,
 
-							// We only pass the textValue to the component when the collection
-							// indicates that it will be used for accessibility issues.
+						// We only pass the textValue to the component when the collection
+						// indicates that it will be used for accessibility issues.
 
-							...(!suppressTextValueWarning
-								? {
-										textValue: getTextValue(
-											key,
-											child,
-											true
-										),
-									}
-								: {}),
-						}
+						...(!suppressTextValueWarning
+							? {
+								textValue: getTextValue(
+									key,
+									child,
+									true
+								),
+							}
+							: {}),
+					}
 					: {}),
 				...(props ? props : {}),
 			});
@@ -280,19 +280,19 @@ export function useCollection<
 						const publicItem =
 							exclude && typeof item === 'object'
 								? excludeProps(
-										item as Record<any, any>,
-										exclude
-									)
+									item as Record<any, any>,
+									exclude
+								)
 								: item;
 						const child = Array.isArray(publicApi)
 							? (children(
-									publicItem,
-									...publicApi
-								) as ChildElement)
+								publicItem,
+								...publicApi
+							) as ChildElement)
 							: (children(
-									publicItem,
-									virtual.index
-								) as ChildElement);
+								publicItem,
+								virtual.index
+							) as ChildElement);
 
 						const props = {
 							'data-index': virtual.index,
@@ -355,11 +355,11 @@ export function useCollection<
 					if (
 						visibleKeys &&
 						((Array.isArray(visibleKeys) &&
-							!!visibleKeys.length &&
-							!visibleKeys.includes(index)) ||
-							(visibleKeys instanceof Set &&
-								visibleKeys.size > 0 &&
-								!visibleKeys.has(key)))
+						  !!visibleKeys.length &&
+						  !visibleKeys.includes(index)) ||
+						 (visibleKeys instanceof Set &&
+						  visibleKeys.size > 0 &&
+						  !visibleKeys.has(key)))
 					) {
 						return null;
 					}
@@ -380,11 +380,11 @@ export function useCollection<
 					if (
 						visibleKeys &&
 						((Array.isArray(visibleKeys) &&
-							!!visibleKeys.length &&
-							!visibleKeys.includes(index)) ||
-							(visibleKeys instanceof Set &&
-								visibleKeys.size > 0 &&
-								!visibleKeys.has(key)))
+						  !!visibleKeys.length &&
+						  !visibleKeys.includes(index)) ||
+						 (visibleKeys instanceof Set &&
+						  visibleKeys.size > 0 &&
+						  !visibleKeys.has(key)))
 					) {
 						return null;
 					}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/useCollection.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/useCollection.tsx
@@ -266,6 +266,9 @@ export function useCollection<
 	);
 
 	const virtualizerItems = virtualizer?.getVirtualItems();
+	const virtualizerLayoutKey = virtualizerItems
+		?.map((v) => `${v.index}:${v.start}:${v.size}`)
+		.join('|');
 
 	const performCollectionRender = useCallback(
 		({children, items}: ICollectionProps<T, P>) => {
@@ -294,7 +297,16 @@ export function useCollection<
 						const props = {
 							'data-index': virtual.index,
 							'ref': (node: HTMLElement) => {
-								virtualizer.measureElement(node);
+								if (node && !node.isConnected) {
+									requestAnimationFrame(() => {
+										if (node.isConnected) {
+											virtualizer.measureElement(node);
+										}
+									});
+								}
+								else {
+									virtualizer.measureElement(node);
+								}
 
 								const ref = (child as ChildElement).ref;
 
@@ -385,6 +397,7 @@ export function useCollection<
 			performItemRender,
 			publicApi,
 			virtualizerItems?.length,
+			virtualizerLayoutKey,
 			visibleKeys,
 			itemIdKey,
 		]


### PR DESCRIPTION
# What is this trying to solve?

  Ticket: https://liferay.atlassian.net/browse/LPD-87534.

  When opening a virtualized Clay dropdown (e.g. the Tags field on a Web Content) for the first time, items with multi-line labels overlap because they render at the virtualizer's `estimateSize` (37 px) fallback positions instead of their real measured heights. Closing and reopening the dropdown renders it correctly,
   so the bug is only on the first open.

  # How am I fixing it?

  In `useCollection.tsx`, the ref callback called `virtualizer.measureElement` synchronously the moment the item mounted. On the first open the dropdown is rendered through a portal (`Overlay`) whose container is not yet appended to the document, so `node.isConnected` is `false` and `_measureElement` exits early — no
   `ResizeObserver` is registered and item sizes never update. The ref now defers the call to `requestAnimationFrame` when the node is disconnected, by which point the portal has been attached.

  Once measurements start arriving, the `rendered` `useMemo` still has to invalidate so the items re-render with their measured `translateY` values. The previous deps (`virtualizerItems?.length`, `virtualizerTotalSize`) miss the case where positions change but length and total stay the same. Replaced with a
  `virtualizerLayoutKey` derived from each virtual item's `index:start:size`, which flips whenever any item's position or size changes.

  # How can you verify that it works?
Run the included automated tests.