### PR TITLE
LPD-87992 Calendar OOTB accessibility fixes

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/calendar_a11y.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/calendar_a11y.js
@@ -7,9 +7,15 @@ AUI.add(
 	'liferay-calendar-a11y',
 	(A) => {
 		A.CalendarBase.ATTRS.tabIndex.value = 0;
+
+		A.SchedulerEvent.prototype.EVENT_NODE_TEMPLATE =
+			A.SchedulerEvent.prototype.EVENT_NODE_TEMPLATE.replace(
+				'<div aria-expanded="false"',
+				'<div role="button" aria-expanded="false"'
+			);
 	},
 	'',
 	{
-		requires: ['calendar'],
+		requires: ['aui-scheduler', 'calendar'],
 	}
 );

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/calendar_a11y.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/calendar_a11y.js
@@ -13,6 +13,39 @@ AUI.add(
 				'<div aria-expanded="false"',
 				'<div role="button" aria-expanded="false"'
 			);
+
+		const calendarBaseProto = A.CalendarBase.prototype;
+
+		const hideEmptyDayButtons = function () {
+			this.get('contentBox')
+				.all('button')
+				.each((button) => {
+					const text = button.get('text').replace(/ /g, '').trim();
+
+					if (text) {
+						button.removeAttribute('aria-hidden');
+					}
+					else {
+						button.setAttribute('aria-hidden', 'true');
+					}
+				});
+		};
+
+		const originalRenderUI = calendarBaseProto.renderUI;
+
+		calendarBaseProto.renderUI = function () {
+			originalRenderUI.apply(this, arguments);
+
+			hideEmptyDayButtons.call(this);
+		};
+
+		const originalAfterDateChange = calendarBaseProto._afterDateChange;
+
+		calendarBaseProto._afterDateChange = function () {
+			originalAfterDateChange.apply(this, arguments);
+
+			hideEmptyDayButtons.call(this);
+		};
 	},
 	'',
 	{

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
@@ -817,11 +817,36 @@ AUI.add(
 			EXTENDS: A.SchedulerDayView,
 
 			NAME: 'scheduler-day-view',
+
+			prototype: {
+				_uiSetDate() {
+					const instance = this;
+
+					SchedulerDayView.superclass._uiSetDate.apply(
+						this,
+						arguments
+					);
+
+					if (instance.headerView) {
+						instance.headerView.syncDaysHeaderUI();
+					}
+				},
+
+				renderUI() {
+					const instance = this;
+
+					SchedulerDayView.superclass.renderUI.apply(this, arguments);
+
+					if (instance.headerView) {
+						instance.headerView.syncDaysHeaderUI();
+					}
+				},
+			},
 		});
 
 		Liferay.SchedulerDayView = SchedulerDayView;
 
-		Liferay.SchedulerWeekView = A.Component.create({
+		const SchedulerWeekView = A.Component.create({
 			ATTRS: {
 				headerDateFormatter: {
 					validator: isFunction,
@@ -890,7 +915,37 @@ AUI.add(
 			EXTENDS: A.SchedulerWeekView,
 
 			NAME: 'scheduler-week-view',
+
+			prototype: {
+				_uiSetDate() {
+					const instance = this;
+
+					SchedulerWeekView.superclass._uiSetDate.apply(
+						this,
+						arguments
+					);
+
+					if (instance.headerView) {
+						instance.headerView.syncDaysHeaderUI();
+					}
+				},
+
+				renderUI() {
+					const instance = this;
+
+					SchedulerWeekView.superclass.renderUI.apply(
+						this,
+						arguments
+					);
+
+					if (instance.headerView) {
+						instance.headerView.syncDaysHeaderUI();
+					}
+				},
+			},
 		});
+
+		Liferay.SchedulerWeekView = SchedulerWeekView;
 
 		const SchedulerMonthView = A.Component.create({
 			ATTRS: {

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
@@ -841,6 +841,37 @@ AUI.add(
 						instance.headerView.syncDaysHeaderUI();
 					}
 				},
+
+				syncDaysHeaderUI() {
+					const instance = this;
+
+					SchedulerDayView.superclass.syncDaysHeaderUI.apply(
+						this,
+						arguments
+					);
+
+					const scheduler = instance.get('scheduler');
+					const locale = scheduler.get('locale');
+					const viewDate = scheduler.get('viewDate');
+
+					instance.colHeaderDaysNode
+						.all('a')
+						.each((anchor, index) => {
+							const columnDate = DateMath.add(
+								viewDate,
+								DateMath.DAY,
+								index
+							);
+
+							anchor.setAttribute(
+								'aria-label',
+								A.DataType.Date.format(columnDate, {
+									format: Liferay.Language.get('a-b-d-y'),
+									locale,
+								})
+							);
+						});
+				},
 			},
 		});
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler_event_recorder.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler_event_recorder.js
@@ -49,6 +49,13 @@ AUI.add(
 					value: STR_BLANK,
 				},
 
+				headerContent: {
+					value:
+						'<input aria-label="' +
+						Liferay.Language.get('title') +
+						'" class="scheduler-event-recorder-content form-control" name="content" value="{content}" />',
+				},
+
 				permissionsCalendarBookingURL: {
 					setter: String,
 					validator: isValue,


### PR DESCRIPTION
## Summary

Fixes the accessibility issues axe DevTools and WAVE flag in the OOTB Calendar (LPP-63881 / LPD-87992). Five separate commits, one per axe rule:

- **Empty `<th>` in week/day all-day strip header** — call `headerView.syncDaysHeaderUI()` after render and date change so the seven day-name `<th>` cells get populated.
- **`aria-expanded="false"` on bare `<div>`** — patch `A.SchedulerEvent.EVENT_NODE_TEMPLATE` to add `role="button"`, which legalises both `aria-expanded` and `aria-haspopup` on the event tile (it already behaves like a button).
- **Empty buttons in side mini-calendar** — extend `A.CalendarBase` so the placeholder `<button>&nbsp;</button>` cells (days outside the displayed month) get `aria-hidden="true"` after each render and date change.
- **Day-view header anchor with empty accessible name** — override `syncDaysHeaderUI` on `Liferay.SchedulerDayView` to set `aria-label` with the localized full date on every header `<a>`. Also resolves the dependent "Table header text should not be empty" finding on the same `<th>`.
- **Missing form label on event popover title input** — override the `headerContent` ATTR on `Liferay.SchedulerEventRecorder` to inject `aria-label="Title"`.

Color-contrast findings are intentionally out of scope.

## Test plan

- [ ] Open the calendar fragment on master, run axe DevTools, confirm the five fixed rules drop to zero (Total Issues should fall from 20 to 4 — color-contrast only).
- [ ] Run WAVE, confirm "Empty table header" and "Missing form label" both drop to zero.
- [ ] Switch through Day, Week, Month, Agenda views; navigate forward/back several times — no regressions in headers, mini-calendar, or event tiles.
- [ ] Open an event popover and an Add Event popover; the title input announces "Title" to a screen reader.
- [ ] Tab through the day-view header — each `<a>` announces e.g. "Wednesday, April 29, 2026".

Jira: https://liferay.atlassian.net/browse/LPD-87992