### PR TITLE
LRCI-5291 Align aws-java-sdk versions and remove unused org.w3c:dom

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -20,7 +20,6 @@ dependencies {
 	api group: "org.apache.commons", name: "commons-compress", version: "1.26.0"
 	api group: "org.dom4j", name: "dom4j", version: "2.1.3"
 	api group: "org.json", name: "json", version: "20231013"
-	api group: "org.w3c", name: "dom", version: "2.3.0-jaxb-1.0.6"
 	testImplementation group: "org.mockito", name: "mockito-core", version: "4.5.1"
 	testImplementation group: "org.mockito", name: "mockito-inline", version: "4.5.1"
 }

--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -3,8 +3,8 @@ targetCompatibility = "1.8"
 
 dependencies {
 	api group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
-	api group: "com.amazonaws", name: "aws-java-sdk-ec2", version: "1.12.262"
-	api group: "com.amazonaws", name: "aws-java-sdk-rds", version: "1.12.262"
+	api group: "com.amazonaws", name: "aws-java-sdk-ec2", version: "1.12.719"
+	api group: "com.amazonaws", name: "aws-java-sdk-rds", version: "1.12.719"
 	api group: "com.atlassian.jira", name: "jira-rest-java-client-app", version: "5.2.4"
 	api group: "com.google.cloud", name: "google-cloud-storage", version: "1.113.16"
 	api group: "com.google.guava", name: "guava", version: "32.0.1-jre"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-5291

**What is being fixed:** Two mismatched dependency versions and one unused dependency in jenkins-results-parser/build.gradle were identified during a dependency audit.

**How it is being fixed:** The `aws-java-sdk-ec2` and `aws-java-sdk-rds` versions are aligned from 1.12.262 to 1.12.719 to match `aws-java-sdk-core`, which was already at 1.12.719. The `org.w3c:dom:2.3.0-jaxb-1.0.6` explicit dependency is removed because the W3C DOM API is bundled in Java SE and there are no `org.w3c` imports anywhere in the module source; `gradlew test jar` passes cleanly without it.