### PR TITLE
LPD-88346 Add Duplicate action under a Copy submenu

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -3426,6 +3426,28 @@ public class DefaultObjectEntryManagerImpl
 					objectDefinition, serviceBuilderObjectEntry,
 					serviceBuilderParentObjectEntry)
 			).put(
+				"duplicate",
+				() -> {
+					if (!FeatureFlagManagerUtil.isEnabled(
+							serviceBuilderObjectEntry.getCompanyId(),
+							"LPD-17564")) {
+
+						return null;
+					}
+
+					return _addAction(
+						ActionKeys.UPDATE,
+						"postObjectEntryByObjectEntryFolderCopy",
+						serviceBuilderObjectEntry,
+						HashMapBuilder.put(
+							"objectEntryFolderId",
+							String.valueOf(
+								serviceBuilderObjectEntry.
+									getObjectEntryFolderId())
+						).build(),
+						dtoConverterContext.getUriInfo());
+				}
+			).put(
 				"expire",
 				() -> {
 					if (!FeatureFlagManagerUtil.isEnabled(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -16316,7 +16316,8 @@ public class ObjectEntryResourceTest {
 
 	private Map<String, Map<String, String>> _getExpectedActions(
 		String externalReferenceCode, ObjectDefinition objectDefinition,
-		String objectEntryId, boolean sharingEnabled) {
+		String objectEntryFolderId, String objectEntryId,
+		boolean sharingEnabled) {
 
 		String href = StringBundler.concat(
 			"http://localhost:8080/o", objectDefinition.getRESTContextPath(),
@@ -16359,6 +16360,21 @@ public class ObjectEntryResourceTest {
 			}
 		).put(
 			"delete", _getActionValue(href, "DELETE")
+		).put(
+			"duplicate",
+			() -> {
+				if (FeatureFlagManagerUtil.isEnabled(
+						_group.getCompanyId(), "LPD-17564")) {
+
+					return _getActionValue(
+						StringBundler.concat(
+							href, "/by-object-entry-folder-id/",
+							objectEntryFolderId, "/copy"),
+						"POST");
+				}
+
+				return null;
+			}
 		).put(
 			"expire",
 			() -> {
@@ -17462,8 +17478,9 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			_getExpectedActions(
 				jsonObject.getString("externalReferenceCode"),
-				_siteScopedObjectDefinition1, jsonObject.getString("id"),
-				sharingEnabled),
+				_siteScopedObjectDefinition1,
+				jsonObject.getString("objectEntryFolderId"),
+				jsonObject.getString("id"), sharingEnabled),
 			actionsJSONObject.toMap());
 	}
 

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -23982,6 +23982,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}.
 x-was-successfully-copied-to-x={0} was successfully copied to {1}.
 x-was-successfully-deleted={0} was successfully deleted.
+x-was-successfully-duplicated={} was successfully duplicated.
 x-was-successfully-expired={0} was successfully expired.
 x-was-successfully-moved-to-x={0} was successfully moved to {1}.
 x-was-successfully-published={0} was successfully published.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow=تم تعيين {0} بنجاح �
 x-was-successfully-assigned-to-x=تم تعيين {0} بنجاح إلى {1}.
 x-was-successfully-copied-to-x=تم نسخ {0} بنجاح إلى {1}.
 x-was-successfully-deleted=تم حذف {0} بنجاح.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired=انتهت صلاحية {0} بنجاح.
 x-was-successfully-moved-to-x=تم نقل {0} بنجاح إلى {1}.
 x-was-successfully-published=تم نشر {0} بنجاح.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} s'ha assignat correctament a
 x-was-successfully-assigned-to-x={0} s'ha assignat correctament a {1}.
 x-was-successfully-copied-to-x={0} s'ha copiat correctament a {1}.
 x-was-successfully-deleted={0} s'ha suprimit correctament.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ha vençut correctament.
 x-was-successfully-moved-to-x={0} s'ha mogut correctament a {1}.
 x-was-successfully-published={0} s'ha publicat correctament.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} wurde erfolgreich dem Standa
 x-was-successfully-assigned-to-x={0} wurde erfolgreich {1} zugewiesen.
 x-was-successfully-copied-to-x={0} wurde erfolgreich kopiert nach {1}.
 x-was-successfully-deleted={0} wurde erfolgreich gelöscht.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ist erfolgreich abgelaufen.
 x-was-successfully-moved-to-x={0} wurde erfolgreich verschoben nach {1}.
 x-was-successfully-published={0} wurde erfolgreich veröffentlicht.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} wurde erfolgreich dem Standa
 x-was-successfully-assigned-to-x={0} wurde erfolgreich {1} zugewiesen.
 x-was-successfully-copied-to-x={0} wurde erfolgreich kopiert nach {1}.
 x-was-successfully-deleted={0} wurde erfolgreich gelöscht.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ist erfolgreich abgelaufen.
 x-was-successfully-moved-to-x={0} wurde erfolgreich verschoben nach {1}.
 x-was-successfully-published={0} wurde erfolgreich veröffentlicht.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} wurde erfolgreich dem Standa
 x-was-successfully-assigned-to-x={0} wurde erfolgreich {1} zugewiesen.
 x-was-successfully-copied-to-x={0} wurde erfolgreich kopiert nach {1}.
 x-was-successfully-deleted={0} wurde erfolgreich gelöscht.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ist erfolgreich abgelaufen.
 x-was-successfully-moved-to-x={0} wurde erfolgreich verschoben nach {1}.
 x-was-successfully-published={0} wurde erfolgreich veröffentlicht.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -23982,6 +23982,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}.
 x-was-successfully-copied-to-x={0} was successfully copied to {1}.
 x-was-successfully-deleted={0} was successfully deleted.
+x-was-successfully-duplicated={} was successfully duplicated.
 x-was-successfully-expired={0} was successfully expired.
 x-was-successfully-moved-to-x={0} was successfully moved to {1}.
 x-was-successfully-published={0} was successfully published.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} se ha asignado correctamente
 x-was-successfully-assigned-to-x={0} se ha asignado correctamente a {1}.
 x-was-successfully-copied-to-x={0} se ha copiado correctamente en {1}.
 x-was-successfully-deleted={0} se ha eliminado correctamente.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ha vencido correctamente.
 x-was-successfully-moved-to-x={0} se ha movido correctamente a {1}.
 x-was-successfully-published={0} se ha publicado correctamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} se ha asignado correctamente
 x-was-successfully-assigned-to-x={0} se ha asignado correctamente a {1}.
 x-was-successfully-copied-to-x={0} se ha copiado correctamente en {1}.
 x-was-successfully-deleted={0} se ha eliminado correctamente.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ha vencido correctamente.
 x-was-successfully-moved-to-x={0} se ha movido correctamente a {1}.
 x-was-successfully-published={0} se ha publicado correctamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} se ha asignado correctamente
 x-was-successfully-assigned-to-x={0} se ha asignado correctamente a {1}.
 x-was-successfully-copied-to-x={0} se ha copiado correctamente en {1}.
 x-was-successfully-deleted={0} se ha eliminado correctamente.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ha vencido correctamente.
 x-was-successfully-moved-to-x={0} se ha movido correctamente a {1}.
 x-was-successfully-published={0} se ha publicado correctamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} se ha asignado correctamente
 x-was-successfully-assigned-to-x={0} se ha asignado correctamente a {1}.
 x-was-successfully-copied-to-x={0} se ha copiado correctamente en {1}.
 x-was-successfully-deleted={0} se ha eliminado correctamente.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ha vencido correctamente.
 x-was-successfully-moved-to-x={0} se ha movido correctamente a {1}.
 x-was-successfully-published={0} se ha publicado correctamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -23974,6 +23974,7 @@ x-was-successfully-assigned-to-default-workflow={0} määritettiin oletustyönku
 x-was-successfully-assigned-to-x={0} määritettiin kohteeseen {1}.
 x-was-successfully-copied-to-x={0} kopioitiin kohteeseen {1}.
 x-was-successfully-deleted={0} poistettiin.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} vanheni.
 x-was-successfully-moved-to-x={0} siirrettiin kohteeseen {1}.
 x-was-successfully-published={0} julkaistiin onnistuneesti.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} a été correctement affect�
 x-was-successfully-assigned-to-x={0} a bien été attribué à {1}.
 x-was-successfully-copied-to-x={0} a bien été copié dans {1}.
 x-was-successfully-deleted={0} a bien été supprimé.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} a bien été supprimé.
 x-was-successfully-moved-to-x={0} a bien été déplacé dans {1}.
 x-was-successfully-published={0} a été publié avec succès.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} a été correctement affect�
 x-was-successfully-assigned-to-x={0} a bien été attribué à {1}.
 x-was-successfully-copied-to-x={0} a bien été copié dans {1}.
 x-was-successfully-deleted={0} a bien été supprimé.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} a bien été supprimé.
 x-was-successfully-moved-to-x={0} a bien été déplacé dans {1}.
 x-was-successfully-published={0} a été publié avec succès.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} a été correctement affect�
 x-was-successfully-assigned-to-x={0} a bien été attribué à {1}.
 x-was-successfully-copied-to-x={0} a bien été copié dans {1}.
 x-was-successfully-deleted={0} a bien été supprimé.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} a bien été supprimé.
 x-was-successfully-moved-to-x={0} a bien été déplacé dans {1}.
 x-was-successfully-published={0} a été publié avec succès.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} foi publicado correctamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -23979,6 +23979,7 @@ x-was-successfully-assigned-to-default-workflow={0} sikeresen hozzárendelve az 
 x-was-successfully-assigned-to-x=A(z) {0} sikeresen hozzárendelve: {1}.
 x-was-successfully-copied-to-x=A(z) {0} sikeresen másolva ide: {1}.
 x-was-successfully-deleted={0} sikeresen törölve.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} sikeresen lejárt.
 x-was-successfully-moved-to-x=A(z) {0} sikeresen áthelyezve ide: {1}.
 x-was-successfully-published={0} sikeresen közzétéve.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -23977,6 +23977,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow="{0}" が正常にデフォル�
 x-was-successfully-assigned-to-x="{0}" が正常に "{1}" に割り当てられました。
 x-was-successfully-copied-to-x="{0}" が正常に "{1}" にコピーされました。
 x-was-successfully-deleted="{0}" が正常に削除されました。
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired="{0}" が正常に期限切れになりました。
 x-was-successfully-moved-to-x="{0}" が正常に "{1}" に移動されました。
 x-was-successfully-published={0}が正常に公開されました。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -23982,6 +23982,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -23975,6 +23975,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} ໄດ້ຖືກກຳນ�
 x-was-successfully-assigned-to-x={0} ໄດ້ຖືກກຳນົດໃຫ້ {1} ຢ່າງສຳເລັດຜົນ.
 x-was-successfully-copied-to-x=ສຳເນົາ {0} ໄປຫາ {1} ສຳເລັດແລ້ວ.
 x-was-successfully-deleted=ລຶບ {0} ສຳເລັດແລ້ວ.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} ໄດ້ໝົດອາຍຸຢ່າງສຳເລັດຜົນ.
 x-was-successfully-moved-to-x=ຍ້າຍ {0} ໄປຫາ {1} ສຳເລັດແລ້ວ.
 x-was-successfully-published=ເຜີຍແຜ່ {0} ສຳເລັດແລ້ວ.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -23979,6 +23979,7 @@ x-was-successfully-assigned-to-default-workflow={0} is toegewezen aan de standaa
 x-was-successfully-assigned-to-x={0} is toegewezen aan {1}.
 x-was-successfully-copied-to-x={0} is gekopieerd naar {1}.
 x-was-successfully-deleted={0} is verwijderd.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} is verlopen.
 x-was-successfully-moved-to-x={0} is verplaatst naar {1}.
 x-was-successfully-published={0} is gepubliceerd.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -23979,6 +23979,7 @@ x-was-successfully-assigned-to-default-workflow={0} is toegewezen aan de standaa
 x-was-successfully-assigned-to-x={0} is toegewezen aan {1}.
 x-was-successfully-copied-to-x={0} is gekopieerd naar {1}.
 x-was-successfully-deleted={0} is verwijderd.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} is verlopen.
 x-was-successfully-moved-to-x={0} is verplaatst naar {1}.
 x-was-successfully-published={0} is gepubliceerd.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} foi atribuído ao fluxo de t
 x-was-successfully-assigned-to-x={0} foi atribuído com sucesso a {1}.
 x-was-successfully-copied-to-x={0} foi copiado com sucesso para {1}.
 x-was-successfully-deleted={0} foi excluído com sucesso.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} foi expirado com sucesso.
 x-was-successfully-moved-to-x={0} foi movido com sucesso para {1}.
 x-was-successfully-published={0} foi publicado com sucesso.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} foi atribuído ao fluxo de t
 x-was-successfully-assigned-to-x={0} foi atribuído com sucesso a {1}.
 x-was-successfully-copied-to-x={0} foi copiado com sucesso para {1}.
 x-was-successfully-deleted={0} foi excluído com sucesso.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} foi expirado com sucesso.
 x-was-successfully-moved-to-x={0} foi movido com sucesso para {1}.
 x-was-successfully-published={0} foi publicado com sucesso.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} har tilldelats till standard
 x-was-successfully-assigned-to-x={0} har tilldelats till {1}.
 x-was-successfully-copied-to-x={0} har kopierats till {1}.
 x-was-successfully-deleted={0} har tagits bort.
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} har slutat gälla.
 x-was-successfully-moved-to-x={0} har flyttats till {1}.
 x-was-successfully-published={0} har publicerats.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -23976,6 +23976,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -23978,6 +23978,7 @@ x-was-successfully-assigned-to-default-workflow={0} 已被成功指定给默认�
 x-was-successfully-assigned-to-x={0} 已被成功指定给 {1}。
 x-was-successfully-copied-to-x={0} 已成功复制到 {1}。
 x-was-successfully-deleted="{0}"已被成功删除。
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} 已成功过期。
 x-was-successfully-moved-to-x={0} 已成功移动到 {1}。
 x-was-successfully-published={0} 已成功发布。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -23977,6 +23977,7 @@ x-was-successfully-assigned-to-default-workflow={0} was successfully assigned to
 x-was-successfully-assigned-to-x={0} was successfully assigned to {1}. (Automatic Copy)
 x-was-successfully-copied-to-x={0} was successfully copied to {1}. (Automatic Copy)
 x-was-successfully-deleted={0} was successfully deleted. (Automatic Copy)
+x-was-successfully-duplicated={} was successfully duplicated. (Automatic Copy)
 x-was-successfully-expired={0} was successfully expired. (Automatic Copy)
 x-was-successfully-moved-to-x={0} was successfully moved to {1}. (Automatic Copy)
 x-was-successfully-published={0} was successfully published. (Automatic Copy)

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -382,10 +382,7 @@ public class SectionDisplayContextHelper {
 				null, "move-folder", "move",
 				_language.get(httpServletRequest, "move"), null, "update",
 				null),
-			new FDSActionDropdownItem(
-				null, "copy", "copy",
-				_language.get(httpServletRequest, "copy-to"), null, "update",
-				null),
+			_getCopyFDSActionDropdownItem(httpServletRequest),
 			new FDSActionDropdownItem(
 				PortletURLBuilder.create(
 					_portal.getControlPanelPortletURL(
@@ -420,6 +417,46 @@ public class SectionDisplayContextHelper {
 				null, "trash", "delete",
 				_language.get(httpServletRequest, "delete"), null, "delete",
 				null));
+	}
+
+	private FDSActionDropdownItem _getCopyFDSActionDropdownItem(
+		HttpServletRequest httpServletRequest) {
+
+		return FDSActionDropdownItemBuilder.setFDSActionDropdownItems(
+			FDSActionDropdownItemList.of(
+				FDSActionDropdownItemBuilder.setHref(
+					StringPool.BLANK
+				).setIcon(
+					"copy"
+				).setLabel(
+					_language.get(httpServletRequest, "copy-to")
+				).setPermissionKey(
+					"update"
+				).build(
+					"copy"
+				),
+				FDSActionDropdownItemBuilder.setHref(
+					StringPool.BLANK
+				).setIcon(
+					"copy"
+				).setLabel(
+					_language.get(httpServletRequest, "duplicate")
+				).setPermissionKey(
+					"duplicate"
+				).build(
+					"duplicate"
+				))
+		).setIcon(
+			"copy"
+		).setLabel(
+			_language.get(httpServletRequest, "copy")
+		).setPermissionKey(
+			"update"
+		).setType(
+			"contextual"
+		).build(
+			"copy-menu"
+		);
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -52,6 +52,7 @@ import SimpleActionLinkRenderer from './cell_renderers/SimpleActionLinkRenderer'
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
 import TypeRenderer from './cell_renderers/TypeRenderer';
 import addOnClickToCreationMenuItems from './utils/addOnClickToCreationMenuItems';
+import {executeAsyncItemAction} from './utils/executeAsyncItemAction';
 import transformFDSBulkActions from './utils/transformFDSBulkActions';
 import transformViewsItemsProps from './utils/transformViewsItemProps';
 import GalleryView from './views/GalleryView';
@@ -411,6 +412,19 @@ export default function AssetsFDSPropsTransformer({
 					additionalProps.rootObjectEntryFolderExternalReferenceCode ||
 						additionalProps.parentObjectEntryFolderExternalReferenceCode
 				);
+			}
+			else if (action?.data?.id === 'duplicate') {
+				event?.preventDefault();
+
+				executeAsyncItemAction({
+					method: 'POST',
+					refreshData: loadData,
+					successMessage: sub(
+						Liferay.Language.get('x-was-successfully-duplicated'),
+						`<strong>"${Liferay.Util.escapeHTML(itemData.title)}"</strong>`
+					),
+					url: itemData.actions.duplicate.href,
+				});
 			}
 			else if (
 				action?.data?.id === 'default-permissions' ||

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/types/ItemDataType.d.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/types/ItemDataType.d.ts
@@ -8,6 +8,7 @@ interface ItemData {
 		copy: Action;
 		'copy-replace': Action;
 		delete: Action;
+		duplicate: Action;
 		expire: Action;
 		get: Action;
 		'get-by-scope': Action;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -146,6 +146,7 @@ test(
 			await assetsPage.execItemAction({
 				action: 'Copy To',
 				filter: file1Title,
+				parentAction: 'Copy',
 			});
 		});
 
@@ -166,6 +167,7 @@ test(
 			await assetsPage.execItemAction({
 				action: 'Copy To',
 				filter: file2Title,
+				parentAction: 'Copy',
 			});
 		});
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -183,6 +183,77 @@ test(
 );
 
 test(
+	'Duplicating content creates a draft copy in the same Space',
+	{tag: '@LPD-88346'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const fileTitle = `Content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		await test.step('Create a new Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a content for that Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: fileTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		await test.step('Duplicate content', async () => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Duplicate',
+				filter: fileTitle,
+				parentAction: 'Copy',
+			});
+
+			await expect(
+				page.getByRole('link', {
+					exact: true,
+					name: `${fileTitle} (Copy)`,
+				})
+			).toBeVisible();
+
+			await expect(
+				assetsPage.table.bodyRows
+					.filter({
+						has: page.getByRole('link', {
+							exact: true,
+							name: `${fileTitle} (Copy)`,
+						}),
+					})
+					.getByText('Draft')
+			).toBeVisible();
+		});
+
+		await test.step('Duplicate the original again and check the suffix increments', async () => {
+			await assetsPage.execItemAction({
+				action: 'Duplicate',
+				filter: fileTitle,
+				parentAction: 'Copy',
+			});
+
+			await expect(
+				page.getByRole('link', {
+					exact: true,
+					name: `${fileTitle} (Copy 1)`,
+				})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
 	'Can view Share modal for added content',
 	{tag: '@LPD-62554'},
 	async ({apiHelpers, assetsPage}) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
@@ -18,6 +18,7 @@ interface ExecItemActionArgs {
 		| 'Copy To'
 		| 'Delete'
 		| 'Download'
+		| 'Duplicate'
 		| 'Edit'
 		| 'Expire'
 		| 'Export for Translation'
@@ -27,6 +28,7 @@ interface ExecItemActionArgs {
 		| 'View'
 		| 'View History';
 	filter: string;
+	parentAction?: 'Copy';
 }
 
 interface BulkCopyOrMoveArgs {
@@ -192,10 +194,11 @@ export class AssetsPage {
 		await this.page.getByRole('heading', {name: 'Contents'}).waitFor();
 	}
 
-	async execItemAction({action, filter}: ExecItemActionArgs) {
+	async execItemAction({action, filter, parentAction}: ExecItemActionArgs) {
 		await this.dataSetFragmentPage.execItemAction({
 			action,
 			filter,
+			parentAction,
 		});
 	}
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/DataSetPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/DataSetPage.ts
@@ -67,10 +67,12 @@ export class DataSetPage {
 	async execItemAction({
 		action,
 		filter,
+		parentAction,
 		timeout,
 	}: {
 		action: string;
 		filter: string;
+		parentAction?: string;
 		timeout?: number;
 	}) {
 		const item = this.getRow(filter);
@@ -78,6 +80,20 @@ export class DataSetPage {
 		const button = item.getByRole('button', {
 			name: `${filter} Actions`,
 		});
+
+		if (parentAction) {
+			await button.click();
+
+			await this.page
+				.getByRole('menuitem', {exact: true, name: parentAction})
+				.hover();
+
+			await this.page
+				.getByRole('menuitem', {exact: true, name: action})
+				.click();
+
+			return;
+		}
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/duplicate.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/duplicate.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
+import getRandomString from '../../../utils/getRandomString';
+import {
+	performLoginViaApi,
+	performUserSwitch,
+	userData,
+} from '../../../utils/performLogin';
+import {SpaceSummaryPage} from '../main/pages/SpaceSummaryPage';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: false},
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+let cmsAdminUser;
+let setupData: Array<{id: number | string; type: string}>;
+let spaceAdminUser;
+let spaceContentReviewerUser;
+let spaceMemberUser;
+let spaceName: string;
+
+test.beforeAll(async ({browser}) => {
+	const page = await browser.newPage();
+
+	await performLoginViaApi({page, screenName: 'test'});
+
+	const apiHelpers = new DataApiHelpers(page);
+
+	spaceName = `Space ${getRandomString()}`;
+
+	const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name: spaceName,
+		settings: {},
+		type: 'Space',
+	});
+
+	apiHelpers.data.push({id: space.id, type: 'assetLibrary'});
+
+	cmsAdminUser = await addCMSAdministrator(apiHelpers);
+
+	apiHelpers.data.push({id: cmsAdminUser.id, type: 'userAccount'});
+
+	const spaceSummaryPage = new SpaceSummaryPage(page);
+
+	await spaceSummaryPage.goto(spaceName);
+
+	const addRoleUser = async (role?: string) => {
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		apiHelpers.data.push({id: user.id, type: 'userAccount'});
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await spaceSummaryPage.addUserOrUserGroup(user.name, 'users');
+
+		if (role) {
+			await spaceSummaryPage.addRoleToSpaceMember(role, user.name);
+		}
+
+		return user;
+	};
+
+	spaceAdminUser = await addRoleUser('Space Administrator');
+	spaceContentReviewerUser = await addRoleUser('Space Content Reviewer');
+	spaceMemberUser = await addRoleUser();
+
+	setupData = [...apiHelpers.data];
+
+	await page.close();
+});
+
+test.afterAll(async ({browser}) => {
+	const page = await browser.newPage();
+
+	await performLoginViaApi({page, screenName: 'test'});
+
+	const apiHelpers = new DataApiHelpers(page);
+
+	apiHelpers.setData(setupData);
+
+	await apiHelpers.clearData();
+
+	await page.close();
+});
+
+test(
+	'Duplicate visibility depends on user role',
+	{tag: '@LPD-88346'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const fileTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create a content for the Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: fileTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		const duplicateAndVerify = async (expectedSuffixedTitle: string) => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Duplicate',
+				filter: fileTitle,
+				parentAction: 'Copy',
+			});
+
+			await expect(
+				page.getByRole('link', {
+					exact: true,
+					name: expectedSuffixedTitle,
+				})
+			).toBeVisible();
+		};
+
+		const expectDuplicateHidden = async () => {
+			await assetsPage.gotoSpaceContents(spaceName);
+
+			await assetsPage.table.bodyRows
+				.filter({hasText: fileTitle})
+				.getByRole('button', {name: `${fileTitle} Actions`})
+				.click();
+
+			await expect(
+				page.getByRole('menuitem', {exact: true, name: 'Duplicate'})
+			).toBeHidden();
+		};
+
+		await test.step('CMS Administrator can duplicate the content', async () => {
+			await performUserSwitch(page, cmsAdminUser.alternateName);
+
+			await duplicateAndVerify(`${fileTitle} (Copy)`);
+		});
+
+		await test.step('Space Administrator can duplicate the content', async () => {
+			await performUserSwitch(page, spaceAdminUser.alternateName);
+
+			await duplicateAndVerify(`${fileTitle} (Copy 1)`);
+		});
+
+		await test.step('Space Content Reviewer can duplicate the content', async () => {
+			await performUserSwitch(
+				page,
+				spaceContentReviewerUser.alternateName
+			);
+
+			await duplicateAndVerify(`${fileTitle} (Copy 2)`);
+		});
+
+		await test.step('Space Member does not see Duplicate', async () => {
+			await performUserSwitch(page, spaceMemberUser.alternateName);
+
+			await expectDuplicateHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/folder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/folder.spec.ts
@@ -73,6 +73,7 @@ test(
 			await assetsPage.execItemAction({
 				action: 'Copy To',
 				filter: folder1Name,
+				parentAction: 'Copy',
 			});
 
 			await copyFolderModalPage.space(spaceName).click();
@@ -101,6 +102,7 @@ test(
 			await assetsPage.execItemAction({
 				action: 'Copy To',
 				filter: folder1Name,
+				parentAction: 'Copy',
 			});
 
 			await copyFolderModalPage.spaceInModal(spaceName).click();
@@ -127,6 +129,7 @@ test(
 			await assetsPage.execItemAction({
 				action: 'Copy To',
 				filter: folder1Name,
+				parentAction: 'Copy',
 			});
 
 			await copyFolderModalPage.spaceInModal(spaceName).click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88346

## What is being fixed

The legacy CMS shipped a "Make a Copy" action for in-place duplication of content, used heavily for recurring content (e.g., quarterly webinar articles). The new CMS only ships "Copy to" — a cross-folder flow that opens a destination picker — so same-folder duplication today requires a copy + a manual move-back. This restores in-place duplication under a clearly distinct **Duplicate** action.

## How it is being fixed

The Object framework already exposes the right primitive: `DefaultObjectEntryManagerImpl#copyObjectEntry` auto-suffixes the name via `_updateDuplicateObjectEntryName` and lands the new entry in draft state. Rather than introducing a new manager method, this PR emits a new `actions.duplicate` slot on the `ObjectEntry` DTO that points at the existing `postObjectEntryByObjectEntryFolderCopy` endpoint, with the source's `objectEntryFolderId` substituted server-side via the `_addAction` helper. The client just POSTs the href as-is — no client-side substitution needed.

On the UI, "Copy to" and "Duplicate" are nested under a new **Copy** parent in the kebab dropdown, matching the Figma design and the existing `_getPermissionsFDSActionDropdownItem` pattern. The Playwright helper `execItemAction` grew an optional `parentAction` arg so tests can navigate the nested submenu, and the existing Copy-to tests were updated to pass `parentAction: 'Copy'`.

Visibility gates on the same `ActionKeys.UPDATE` permission as Copy-to (matching the existing pattern). Role coverage was added in a dedicated permission test that exercises CMS Administrator, Space Administrator, and Space Content Reviewer (each duplicates the same entry, with `(Copy)`, `(Copy 1)`, `(Copy 2)` suffixes incrementing per `UniqueUtil`), and asserts that Space Member does not see the action.

Bulk-selection Duplicate and folder-level Duplicate are scoped out of this ticket and tracked as separate sub-tasks under LPD-87058.

## Steps to reproduce

1. Sign in as a CMS Administrator.
2. Open **Assets → Contents** for any space and create a Basic Web Content (e.g., title `webinar-q1`).
3. On the new row, open the kebab menu, hover **Copy**, and click **Duplicate**.
4. A new row `webinar-q1 (Copy)` appears in the same space, in **Draft** status.
5. Open the kebab on the original row again, hover **Copy**, click **Duplicate** again. The new row is named `webinar-q1 (Copy 1)`.
6. Repeat step 5; the next is `webinar-q1 (Copy 2)`.
7. Confirm "Copy to" still works as before — open the same submenu, click **Copy To**, and the destination-picker modal opens.
8. Sign in as a Space Member of that space; the kebab no longer surfaces the Duplicate (or the Copy submenu, since it has no children visible to that role).

## Test plan

\`\`\`
gradlew -p modules/apps/object/object-rest-impl testIntegration --tests "*ObjectEntryResourceTest.testGetObjectEntryActionsWithSharingEnabled"

cd modules/test/playwright && yarn test \\
    tests/site-cms-site-initializer/main/all.spec.ts \\
    tests/site-cms-site-initializer/permissions/duplicate.spec.ts \\
    tests/site-cms-site-initializer/permissions/folder.spec.ts \\
    --grep "Duplicating content creates a draft copy|Duplicate visibility depends on user role|Only content folders will be displayed when copying content|CMS Administrator can copy a folder"
\`\`\`

_AI-assisted with Claude Code._