### PR TITLE
LPD-86151 Remove authArguments from MCP server and use the user token

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
@@ -11,8 +11,6 @@ import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -36,7 +34,8 @@ import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 
-import java.util.Base64;
+import java.io.Serializable;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -70,7 +69,7 @@ public class MCPToolProviderUtil {
 		long companyId, DTOConverterRegistry dtoConverterRegistry, long groupId,
 		Locale locale, List<String> mcpServerExternalReferenceCodes,
 		ObjectEntryManager objectEntryManager, String sseEventSinkKey,
-		long userId) {
+		long userId, Map<String, Serializable> workflowContext) {
 
 		if (ListUtil.isEmpty(mcpServerExternalReferenceCodes)) {
 			return null;
@@ -82,7 +81,8 @@ public class MCPToolProviderUtil {
 				mcpServerExternalReferenceCodes, objectEntryManager, userId),
 			objectEntry -> {
 				McpTransport mcpTransport = _createMcpTransport(
-					objectEntry.getProperties());
+					objectEntry.getProperties(),
+					GetterUtil.getString(workflowContext.get("userToken")));
 
 				return new DefaultMcpClient.Builder(
 				).transport(
@@ -101,23 +101,12 @@ public class MCPToolProviderUtil {
 		).build();
 	}
 
-	private static Map<String, String> _createCustomHeaders(
-		String authArguments) {
-
-		if (authArguments.isBlank()) {
-			return Map.of();
-		}
-
-		return Map.of("Authorization", _parseBasicAuthorization(authArguments));
-	}
-
 	private static McpTransport _createMcpTransport(
-		Map<String, Object> properties) {
+		Map<String, Object> properties, String userToken) {
 
 		return new StreamableHttpMcpTransport.Builder(
 		).customHeaders(
-			_createCustomHeaders(
-				GetterUtil.getString(properties.get("authArguments")))
+			Map.of("Liferay-AI-Hub-Cell-On-Behalf-Of", userToken)
 		).url(
 			GetterUtil.getString(properties.get("url"))
 		).build();
@@ -173,26 +162,6 @@ public class MCPToolProviderUtil {
 				null, null, null);
 
 			return (List<ObjectEntry>)page.getItems();
-		}
-		catch (Exception exception) {
-			throw new RuntimeException(exception);
-		}
-	}
-
-	private static String _parseBasicAuthorization(String authArguments) {
-		try {
-			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-				authArguments);
-
-			Base64.Encoder encoder = Base64.getEncoder();
-
-			String credentials =
-				jsonObject.getString("userName") + ":" +
-					jsonObject.getString("password");
-
-			return "Basic " +
-				new String(
-					encoder.encode(credentials.getBytes("UTF-8")), "UTF-8");
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -219,7 +219,7 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 					ToolsUtil.getMCPServerExternalReferenceCodes(
 						_jsonFactory, kaleoNodeSettingValues),
 					_objectEntryManager, sseEventSinkKey,
-					serviceContext.getUserId())
+					serviceContext.getUserId(), workflowContext)
 			).userMessage(
 				userMessage
 			).vertexAiGeminiStreamingChatModel(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -187,7 +187,7 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 					ToolsUtil.getMCPServerExternalReferenceCodes(
 						_jsonFactory, kaleoNodeSettingValues),
 					_objectEntryManager, sseEventSinkKey,
-					serviceContext.getUserId())
+					serviceContext.getUserId(), workflowContext)
 			).userMessage(
 				userMessage
 			).vertexAiGeminiStreamingChatModel(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -57,7 +57,6 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -212,13 +211,6 @@ public class AgentInstanceResourceTest
 			_mcpServerObjectDefinition.getObjectDefinitionId(), 0,
 			LocaleUtil.toLanguageId(LocaleUtil.getDefault()),
 			HashMapBuilder.<String, Serializable>put(
-				"authArguments",
-				JSONUtil.put(
-					"password", PropsValues.DEFAULT_ADMIN_PASSWORD
-				).put(
-					"userName", "test@liferay.com"
-				).toString()
-			).put(
 				"externalReferenceCode", "L_LIFERAY_AI_HUB_MCP_SERVER"
 			).put(
 				"r_accountToAIHubMCPServers_accountEntryId",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/mcp-server-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/mcp-server-object-definition.json
@@ -18,34 +18,6 @@
 	"name": "AIHubMCPServer",
 	"objectFields": [
 		{
-			"DBType": "Clob",
-			"businessType": "LongText",
-			"defaultValue": "null",
-			"externalReferenceCode": "AUTHENTICATION_ARGUMENTS",
-			"indexed": true,
-			"indexedAsKeyword": false,
-			"indexedLanguageId": "en_US",
-			"label": {
-				"en_US": "Authentication Arguments"
-			},
-			"listTypeDefinitionId": 0,
-			"localized": false,
-			"name": "authArguments",
-			"objectFieldSettings": [
-				{
-					"name": "showCounter",
-					"value": false
-				}
-			],
-			"readOnly": "false",
-			"readOnlyConditionExpression": "",
-			"required": false,
-			"state": false,
-			"system": true,
-			"type": "Clob",
-			"unique": false
-		},
-		{
 			"DBType": "String",
 			"businessType": "Text",
 			"defaultValue": "null",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86151

## What is being fixed

The MCP server object stored Basic Auth credentials in an `authArguments` field on each entry, which leaked credentials into Object data. `MCPToolProviderUtil` then base64-encoded those credentials into an `Authorization: Basic` header on every MCP request.

## How it is being fixed

The `authArguments` field is removed from the MCP server object definition, and `MCPToolProviderUtil` now forwards the AI Hub Cell user token (read from the workflow context) as the `Liferay-AI-Hub-Cell-On-Behalf-Of` header — the same JWT scheme already used by `LiferayWebSearchEngine` and the AI Hub Cell auth verifier. `AIDecisionNodeExecutor` and `LLMNodeExecutor` pass the workflow context through to `MCPToolProviderUtil.create`.

## Why are there no tests?

The existing `AgentInstanceResourceTest` exercises the MCP server flow; the test was adapted to drop `authArguments` and continues to cover the on-behalf-of path.