### PR TITLE
DG-X Add liferay-dotcom-forms-global-css client extension

### DIFF
--- a/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-forms-global-css/assets/forms.css
+++ b/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-forms-global-css/assets/forms.css
@@ -1,0 +1,2527 @@
+/* Compiled from custom.scss + marketo.scss + marketo-skeleton.scss (multistep is inlined via custom.scss) */
+.pd-multi-step-form {
+  overflow: hidden;
+  padding: 3px;
+}
+.pd-multi-step-form[data-step="0"] .pd-step-0 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-0 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="0"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="0"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="0"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="0"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="0"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="0"] .pd-progress .pd-circle[data-step="0"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="1"] .pd-step-1 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-1 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="1"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="1"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="1"] .pd-progress .pd-circle[data-step="1"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="1"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="1"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="1"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="2"] .pd-step-2 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-2 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="2"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="2"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="2"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="3"] .pd-step-3 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-3 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="3"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="3"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="2"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="3"] .pd-progress .pd-circle[data-step="2"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="3"] .pd-progress .pd-bar[data-step="2"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-step-4 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-4 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="4"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="4"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="2"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="2"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-bar[data-step="2"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="3"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="3"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="4"] .pd-progress .pd-circle[data-step="3"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="4"] .pd-progress .pd-bar[data-step="3"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-step-5 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-5 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="5"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="5"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="2"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="2"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-bar[data-step="2"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="3"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="3"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="3"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-bar[data-step="3"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="4"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="4"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="5"] .pd-progress .pd-circle[data-step="4"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="5"] .pd-progress .pd-bar[data-step="4"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-step-6 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-6 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="6"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="6"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="2"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="2"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-bar[data-step="2"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="3"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="3"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="3"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-bar[data-step="3"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="4"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="4"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="4"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-bar[data-step="4"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="5"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="5"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="6"] .pd-progress .pd-circle[data-step="5"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="6"] .pd-progress .pd-bar[data-step="5"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-step-7 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-7 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="7"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="7"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="7"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="2"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="2"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-bar[data-step="2"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="3"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="3"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="3"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-bar[data-step="3"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="4"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="4"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="4"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-bar[data-step="4"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="5"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="5"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="5"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-bar[data-step="5"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="6"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="6"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="7"] .pd-progress .pd-circle[data-step="6"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="7"] .pd-progress .pd-bar[data-step="6"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-step-8 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-8 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="8"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="8"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="8"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="8"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="8"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="8"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="2"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="2"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="2"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="3"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="3"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="3"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="3"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="4"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="4"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="4"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="4"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="5"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="5"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="5"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="5"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="6"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="6"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="6"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="6"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="7"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="7"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="7"]:focus, .pd-multi-step-form[data-step="8"] .pd-progress .pd-circle[data-step="7"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="8"] .pd-progress .pd-bar[data-step="7"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-step-9 {
+  display: block;
+  height: auto;
+  margin: 0;
+  opacity: 1;
+  position: relative;
+  transform: translateX(0);
+  transition-duration: 0.3s;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+.pd-multi-step-form .pd-step-9 {
+  display: none;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(5000px);
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="9"] {
+  background-color: transparent;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="9"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="9"]:hover {
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="9"] {
+  background-color: transparent;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="9"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="9"]:hover {
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="0"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="0"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="0"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="0"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="0"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="0"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="1"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="1"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="1"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="1"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="1"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="1"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="2"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="2"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="2"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="2"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="2"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="2"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="3"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="3"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="3"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="3"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="3"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="3"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="4"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="4"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="4"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="4"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="4"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="4"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="5"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="5"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="5"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="5"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="5"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="5"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="6"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="6"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="6"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="6"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="6"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="6"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="7"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="7"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="7"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="7"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="7"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="7"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="8"] {
+  background-color: #179e49;
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="8"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-circle[data-step="8"]:hover {
+  background-color: #14883f;
+  border-color: #14883f;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress.pd-button-action-secondary .pd-bar[data-step="8"] {
+  border-color: #179e49;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="8"] {
+  background-color: #0b5fff;
+  border-color: #0b5fff;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="8"]:focus, .pd-multi-step-form[data-step="9"] .pd-progress .pd-circle[data-step="8"]:hover {
+  background-color: #0053f1;
+  border-color: #0053f1;
+}
+.pd-multi-step-form[data-step="9"] .pd-progress .pd-bar[data-step="8"] {
+  border-color: #0b5fff;
+}
+.pd-multi-step-form .pd-continue-button {
+  background: #0b5fff;
+  border-color: transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  transition: background 0.3s, box-shadow 0.3s, transform 0.3s;
+  width: 100%;
+}
+.pd-multi-step-form .pd-continue-button:active {
+  background: #004ad7;
+}
+.pd-multi-step-form .pd-continue-button:focus, .pd-multi-step-form .pd-continue-button:hover {
+  background: #0053f1;
+}
+.pd-multi-step-form .pd-continue-button.bg-action-secondary {
+  background: #19ab4f;
+}
+.pd-multi-step-form .pd-continue-button.bg-action-secondary:active {
+  background: #127f3a;
+}
+.pd-multi-step-form .pd-continue-button.bg-action-secondary:focus, .pd-multi-step-form .pd-continue-button.bg-action-secondary:hover {
+  background: #169545;
+}
+.pd-multi-step-form .pd-continue-button.bg-white {
+  background: #fff;
+  color: #0b5fff;
+}
+.pd-multi-step-form .pd-continue-button.bg-white:active {
+  color: #004ad7;
+}
+.pd-multi-step-form .pd-continue-button.bg-white:focus, .pd-multi-step-form .pd-continue-button.bg-white:hover {
+  color: #0053f1;
+}
+.pd-multi-step-form .pd-progress {
+  align-items: center;
+  display: flex;
+  margin: 1rem 0;
+  width: 100%;
+}
+.pd-multi-step-form .pd-progress .pd-circle {
+  background-color: transparent;
+  border: 2px solid #a5abb3;
+  border-radius: 50%;
+  cursor: pointer;
+  display: inline-block;
+  height: 16px;
+  min-width: 16px;
+  transition: all 0.5s ease-out;
+  width: 16px;
+}
+.pd-multi-step-form .pd-progress .pd-bar {
+  border: 1px solid #a5abb3;
+  display: inline-block;
+  margin: 0 3px;
+  transition: all 0.5s ease-out;
+}
+
+.pd-richtext {
+  font-size: 0.875rem;
+  padding: 1rem 0;
+}
+
+.pd-submit .actions {
+  margin: 0;
+  padding: 1rem 0 0;
+}
+.pd-submit input[type=submit] {
+  background: #0b5fff;
+  border-color: transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  transition: background 0.3s, box-shadow 0.3s, transform 0.3s;
+  width: 100%;
+}
+.pd-submit input[type=submit]:active {
+  background: #004ad7;
+  box-shadow: 0 0 0.75em 0 rgba(76, 76, 76, 0.16), 0 0.375em 1em -0.5em rgba(76, 76, 76, 0.8);
+}
+.pd-submit input[type=submit]:focus, .pd-submit input[type=submit]:hover {
+  background: #0053f1;
+}
+.pd-submit input[type=submit].bg-action-secondary {
+  background: #19ab4f;
+}
+.pd-submit input[type=submit].bg-action-secondary:active {
+  background: #127f3a;
+}
+.pd-submit input[type=submit].bg-action-secondary:focus, .pd-submit input[type=submit].bg-action-secondary:hover {
+  background: #169545;
+}
+.pd-submit input[type=submit].bg-white {
+  background: #fff;
+  color: #0b5fff;
+}
+.pd-submit input[type=submit].bg-white:active {
+  color: #004ad7;
+}
+.pd-submit input[type=submit].bg-white:focus, .pd-submit input[type=submit].bg-white:hover {
+  color: #0053f1;
+}
+
+/* ---------- Form generator styles ---------- */
+body {
+  margin: 0;
+}
+
+#container.horizontal-form .pd-form-fields {
+  display: flex;
+  justify-content: center;
+}
+#container.horizontal-form .pd-form-fields .pd-form-field-container {
+  display: flex;
+  flex-direction: column;
+  margin: 0 0.5rem;
+}
+#container.horizontal-form .pd-form-fields .pd-submit {
+  height: 3rem;
+  margin: 0 0.5rem;
+  width: auto;
+}
+@media (max-width: 767px) {
+  #container.horizontal-form .pd-form-fields {
+    display: block;
+  }
+  #container.horizontal-form .pd-form-fields .pd-form-field-container {
+    margin: 0;
+  }
+  #container.horizontal-form .pd-form-fields .pd-submit {
+    margin: 0;
+    width: 100%;
+  }
+}
+
+#pardot-form {
+  color: #272833;
+  font: 400 16px/1.5 "Source Sans Pro", Tahoma, "Trebuchet MS", sans-serif;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 0 1.5rem;
+}
+#pardot-form.dark .pd-checkbox label,
+#pardot-form.dark .pd-radio label {
+  color: rgba(255, 255, 255, 0.8);
+}
+#pardot-form.dark .pd-date.error label, #pardot-form.dark .pd-date.filled label, #pardot-form.dark .pd-date.focused label,
+#pardot-form.dark .pd-select.error label,
+#pardot-form.dark .pd-select.filled label,
+#pardot-form.dark .pd-select.focused label,
+#pardot-form.dark .pd-text.error label,
+#pardot-form.dark .pd-text.filled label,
+#pardot-form.dark .pd-text.focused label,
+#pardot-form.dark .pd-textarea.error label,
+#pardot-form.dark .pd-textarea.filled label,
+#pardot-form.dark .pd-textarea.focused label {
+  background: linear-gradient(transparent 50%, #3f547a 50%);
+  color: #fff;
+}
+#pardot-form.dark .pd-date.error .animated-border::before,
+#pardot-form.dark .pd-date.error .animated-border::after, #pardot-form.dark .pd-date.filled .animated-border::before,
+#pardot-form.dark .pd-date.filled .animated-border::after, #pardot-form.dark .pd-date.focused .animated-border::before,
+#pardot-form.dark .pd-date.focused .animated-border::after,
+#pardot-form.dark .pd-select.error .animated-border::before,
+#pardot-form.dark .pd-select.error .animated-border::after,
+#pardot-form.dark .pd-select.filled .animated-border::before,
+#pardot-form.dark .pd-select.filled .animated-border::after,
+#pardot-form.dark .pd-select.focused .animated-border::before,
+#pardot-form.dark .pd-select.focused .animated-border::after,
+#pardot-form.dark .pd-text.error .animated-border::before,
+#pardot-form.dark .pd-text.error .animated-border::after,
+#pardot-form.dark .pd-text.filled .animated-border::before,
+#pardot-form.dark .pd-text.filled .animated-border::after,
+#pardot-form.dark .pd-text.focused .animated-border::before,
+#pardot-form.dark .pd-text.focused .animated-border::after,
+#pardot-form.dark .pd-textarea.error .animated-border::before,
+#pardot-form.dark .pd-textarea.error .animated-border::after,
+#pardot-form.dark .pd-textarea.filled .animated-border::before,
+#pardot-form.dark .pd-textarea.filled .animated-border::after,
+#pardot-form.dark .pd-textarea.focused .animated-border::before,
+#pardot-form.dark .pd-textarea.focused .animated-border::after {
+  height: calc(100% + 2px);
+  width: calc(100% + 2px);
+}
+#pardot-form.dark .pd-date.error label,
+#pardot-form.dark .pd-select.error label,
+#pardot-form.dark .pd-text.error label,
+#pardot-form.dark .pd-textarea.error label {
+  color: #fff;
+}
+#pardot-form.dark .pd-date.error input,
+#pardot-form.dark .pd-date.error select,
+#pardot-form.dark .pd-date.error textarea,
+#pardot-form.dark .pd-select.error input,
+#pardot-form.dark .pd-select.error select,
+#pardot-form.dark .pd-select.error textarea,
+#pardot-form.dark .pd-text.error input,
+#pardot-form.dark .pd-text.error select,
+#pardot-form.dark .pd-text.error textarea,
+#pardot-form.dark .pd-textarea.error input,
+#pardot-form.dark .pd-textarea.error select,
+#pardot-form.dark .pd-textarea.error textarea {
+  background: #3f547a;
+}
+#pardot-form.dark .pd-date.error .animated-border::before,
+#pardot-form.dark .pd-select.error .animated-border::before,
+#pardot-form.dark .pd-text.error .animated-border::before,
+#pardot-form.dark .pd-textarea.error .animated-border::before {
+  border-right-color: #da1414;
+  border-top-color: #da1414;
+  transition: width 0.05s ease-out, height 0.05s ease-out 0.05s;
+}
+#pardot-form.dark .pd-date.error .animated-border::after,
+#pardot-form.dark .pd-select.error .animated-border::after,
+#pardot-form.dark .pd-text.error .animated-border::after,
+#pardot-form.dark .pd-textarea.error .animated-border::after {
+  border-bottom-color: #da1414;
+  border-left-color: #da1414;
+  transition: border-color 0.001s ease-out 0.1s, width 0.05s ease-out 0.1s, height 0.05s ease-out 0.15s;
+}
+#pardot-form.dark .pd-date.filled label,
+#pardot-form.dark .pd-select.filled label,
+#pardot-form.dark .pd-text.filled label,
+#pardot-form.dark .pd-textarea.filled label {
+  color: #fff;
+}
+#pardot-form.dark .pd-date.filled .animated-border::before,
+#pardot-form.dark .pd-date.filled .animated-border::after,
+#pardot-form.dark .pd-select.filled .animated-border::before,
+#pardot-form.dark .pd-select.filled .animated-border::after,
+#pardot-form.dark .pd-text.filled .animated-border::before,
+#pardot-form.dark .pd-text.filled .animated-border::after,
+#pardot-form.dark .pd-textarea.filled .animated-border::before,
+#pardot-form.dark .pd-textarea.filled .animated-border::after {
+  border-color: transparent;
+}
+#pardot-form.dark .pd-date.focused label,
+#pardot-form.dark .pd-select.focused label,
+#pardot-form.dark .pd-text.focused label,
+#pardot-form.dark .pd-textarea.focused label {
+  color: #fff;
+}
+#pardot-form.dark .pd-date.focused .animated-border::before,
+#pardot-form.dark .pd-date.focused .animated-border::after,
+#pardot-form.dark .pd-select.focused .animated-border::before,
+#pardot-form.dark .pd-select.focused .animated-border::after,
+#pardot-form.dark .pd-text.focused .animated-border::before,
+#pardot-form.dark .pd-text.focused .animated-border::after,
+#pardot-form.dark .pd-textarea.focused .animated-border::before,
+#pardot-form.dark .pd-textarea.focused .animated-border::after {
+  border-color: #fff;
+}
+#pardot-form.dark .pd-date.focused .animated-border::before,
+#pardot-form.dark .pd-select.focused .animated-border::before,
+#pardot-form.dark .pd-text.focused .animated-border::before,
+#pardot-form.dark .pd-textarea.focused .animated-border::before {
+  border-right-color: #fff;
+  border-top-color: #fff;
+  transition: width 0.05s ease-out, height 0.05s ease-out 0.05s;
+}
+#pardot-form.dark .pd-date.focused .animated-border::after,
+#pardot-form.dark .pd-select.focused .animated-border::after,
+#pardot-form.dark .pd-text.focused .animated-border::after,
+#pardot-form.dark .pd-textarea.focused .animated-border::after {
+  border-bottom-color: #fff;
+  border-left-color: #fff;
+  transition: border-color 0.001s ease-out 0.1s, width 0.05s ease-out 0.1s, height 0.05s ease-out 0.15s;
+}
+#pardot-form.dark .pd-select::after {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='9' fill='none'%3E%3Cpath fill='%23FFF' d='M1.06 2.47L6.4 7.81a.9.9 0 0 0 1.28 0l5.34-5.34a.9.9 0 0 0-.64-1.54H1.7a.9.9 0 0 0-.64 1.54z'/%3E%3C/svg%3E");
+}
+#pardot-form.dark .pd-select select {
+  background: #3f547a;
+}
+#pardot-form.dark .pd-form-field.filled > label, #pardot-form.dark .pd-form-field.focused > label, #pardot-form.dark .pd-form-field.pd-error > label {
+  background: linear-gradient(transparent 50%, #3f547a 50%);
+  top: -13px;
+}
+#pardot-form.dark .pd-form-field.filled input,
+#pardot-form.dark .pd-form-field.filled select,
+#pardot-form.dark .pd-form-field.filled textarea, #pardot-form.dark .pd-form-field.focused input,
+#pardot-form.dark .pd-form-field.focused select,
+#pardot-form.dark .pd-form-field.focused textarea, #pardot-form.dark .pd-form-field.pd-error input,
+#pardot-form.dark .pd-form-field.pd-error select,
+#pardot-form.dark .pd-form-field.pd-error textarea {
+  background: #3f547a;
+}
+#pardot-form.dark .pd-form-field.filled .animated-border {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+#pardot-form.dark .pd-form-field > label {
+  color: rgba(255, 255, 255, 0.8);
+  opacity: 1;
+}
+#pardot-form.dark .pd-form-field input,
+#pardot-form.dark .pd-form-field select,
+#pardot-form.dark .pd-form-field textarea {
+  background: #3f547a;
+  color: #fff;
+}
+#pardot-form.dark .pd-form-field .pd-description,
+#pardot-form.dark .pd-form-field .pd-description a {
+  color: rgba(255, 255, 255, 0.8);
+}
+#pardot-form.left-align input[type=submit].pd-submit {
+  width: auto;
+}
+#pardot-form .pd-checkbox,
+#pardot-form .pd-radio {
+  display: flex;
+  flex-direction: column-reverse;
+  padding-bottom: 1rem;
+}
+#pardot-form .pd-checkbox input,
+#pardot-form .pd-radio input {
+  background-color: #fff;
+  border: 1px solid #dadee3;
+  border-radius: 2px;
+  cursor: pointer;
+  height: 1rem;
+  margin: 0;
+  position: relative;
+  top: 2px;
+  width: 1rem;
+}
+#pardot-form .pd-checkbox label,
+#pardot-form .pd-radio label {
+  color: #394452;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5;
+}
+#pardot-form .pd-checkbox label.inline,
+#pardot-form .pd-radio label.inline {
+  padding-left: 1.25rem;
+}
+#pardot-form .pd-checkbox span,
+#pardot-form .pd-radio span {
+  display: block;
+}
+#pardot-form .pd-checkbox .value span,
+#pardot-form .pd-radio .value span {
+  padding-bottom: 0.5rem;
+}
+#pardot-form .pd-date.error input,
+#pardot-form .pd-date.error select,
+#pardot-form .pd-date.error textarea, #pardot-form .pd-date.filled input,
+#pardot-form .pd-date.filled select,
+#pardot-form .pd-date.filled textarea, #pardot-form .pd-date.focused input,
+#pardot-form .pd-date.focused select,
+#pardot-form .pd-date.focused textarea,
+#pardot-form .pd-select.error input,
+#pardot-form .pd-select.error select,
+#pardot-form .pd-select.error textarea,
+#pardot-form .pd-select.filled input,
+#pardot-form .pd-select.filled select,
+#pardot-form .pd-select.filled textarea,
+#pardot-form .pd-select.focused input,
+#pardot-form .pd-select.focused select,
+#pardot-form .pd-select.focused textarea,
+#pardot-form .pd-text.error input,
+#pardot-form .pd-text.error select,
+#pardot-form .pd-text.error textarea,
+#pardot-form .pd-text.filled input,
+#pardot-form .pd-text.filled select,
+#pardot-form .pd-text.filled textarea,
+#pardot-form .pd-text.focused input,
+#pardot-form .pd-text.focused select,
+#pardot-form .pd-text.focused textarea,
+#pardot-form .pd-textarea.error input,
+#pardot-form .pd-textarea.error select,
+#pardot-form .pd-textarea.error textarea,
+#pardot-form .pd-textarea.filled input,
+#pardot-form .pd-textarea.filled select,
+#pardot-form .pd-textarea.filled textarea,
+#pardot-form .pd-textarea.focused input,
+#pardot-form .pd-textarea.focused select,
+#pardot-form .pd-textarea.focused textarea {
+  background: #fff;
+}
+#pardot-form .pd-date.error label, #pardot-form .pd-date.filled label, #pardot-form .pd-date.focused label,
+#pardot-form .pd-select.error label,
+#pardot-form .pd-select.filled label,
+#pardot-form .pd-select.focused label,
+#pardot-form .pd-text.error label,
+#pardot-form .pd-text.filled label,
+#pardot-form .pd-text.focused label,
+#pardot-form .pd-textarea.error label,
+#pardot-form .pd-textarea.filled label,
+#pardot-form .pd-textarea.focused label {
+  background: linear-gradient(transparent 50%, #fff 50%);
+  border-radius: 2px;
+  bottom: calc(100% - 6px);
+  color: #0b5fff;
+  font-size: 0.875rem;
+  left: 7px;
+  line-height: 1.375;
+  margin: 0 10px;
+  opacity: 1;
+  padding: 0 5px;
+  position: absolute;
+  transform: none;
+  transition: background 0.025s;
+  white-space: unset;
+  width: unset;
+  z-index: 2;
+}
+#pardot-form .pd-date.error .animated-border::before,
+#pardot-form .pd-date.error .animated-border::after, #pardot-form .pd-date.filled .animated-border::before,
+#pardot-form .pd-date.filled .animated-border::after, #pardot-form .pd-date.focused .animated-border::before,
+#pardot-form .pd-date.focused .animated-border::after,
+#pardot-form .pd-select.error .animated-border::before,
+#pardot-form .pd-select.error .animated-border::after,
+#pardot-form .pd-select.filled .animated-border::before,
+#pardot-form .pd-select.filled .animated-border::after,
+#pardot-form .pd-select.focused .animated-border::before,
+#pardot-form .pd-select.focused .animated-border::after,
+#pardot-form .pd-text.error .animated-border::before,
+#pardot-form .pd-text.error .animated-border::after,
+#pardot-form .pd-text.filled .animated-border::before,
+#pardot-form .pd-text.filled .animated-border::after,
+#pardot-form .pd-text.focused .animated-border::before,
+#pardot-form .pd-text.focused .animated-border::after,
+#pardot-form .pd-textarea.error .animated-border::before,
+#pardot-form .pd-textarea.error .animated-border::after,
+#pardot-form .pd-textarea.filled .animated-border::before,
+#pardot-form .pd-textarea.filled .animated-border::after,
+#pardot-form .pd-textarea.focused .animated-border::before,
+#pardot-form .pd-textarea.focused .animated-border::after {
+  height: calc(100% + 2px);
+  width: calc(100% + 2px);
+}
+#pardot-form .pd-date.error .animated-border::before, #pardot-form .pd-date.filled .animated-border::before, #pardot-form .pd-date.focused .animated-border::before,
+#pardot-form .pd-select.error .animated-border::before,
+#pardot-form .pd-select.filled .animated-border::before,
+#pardot-form .pd-select.focused .animated-border::before,
+#pardot-form .pd-text.error .animated-border::before,
+#pardot-form .pd-text.filled .animated-border::before,
+#pardot-form .pd-text.focused .animated-border::before,
+#pardot-form .pd-textarea.error .animated-border::before,
+#pardot-form .pd-textarea.filled .animated-border::before,
+#pardot-form .pd-textarea.focused .animated-border::before {
+  border-right-color: #0b5fff;
+  border-top-color: #0b5fff;
+  transition: width 0.05s ease-out, height 0.05s ease-out 0.05s;
+}
+#pardot-form .pd-date.error .animated-border::after, #pardot-form .pd-date.filled .animated-border::after, #pardot-form .pd-date.focused .animated-border::after,
+#pardot-form .pd-select.error .animated-border::after,
+#pardot-form .pd-select.filled .animated-border::after,
+#pardot-form .pd-select.focused .animated-border::after,
+#pardot-form .pd-text.error .animated-border::after,
+#pardot-form .pd-text.filled .animated-border::after,
+#pardot-form .pd-text.focused .animated-border::after,
+#pardot-form .pd-textarea.error .animated-border::after,
+#pardot-form .pd-textarea.filled .animated-border::after,
+#pardot-form .pd-textarea.focused .animated-border::after {
+  border-bottom-color: #0b5fff;
+  border-left-color: #0b5fff;
+  transition: border-color 0.001s ease-out 0.1s, width 0.05s ease-out 0.1s, height 0.05s ease-out 0.15s;
+}
+#pardot-form .pd-date.error label,
+#pardot-form .pd-select.error label,
+#pardot-form .pd-text.error label,
+#pardot-form .pd-textarea.error label {
+  color: #da1414;
+}
+#pardot-form .pd-date.error .animated-border::before,
+#pardot-form .pd-date.error .animated-border::after,
+#pardot-form .pd-select.error .animated-border::before,
+#pardot-form .pd-select.error .animated-border::after,
+#pardot-form .pd-text.error .animated-border::before,
+#pardot-form .pd-text.error .animated-border::after,
+#pardot-form .pd-textarea.error .animated-border::before,
+#pardot-form .pd-textarea.error .animated-border::after {
+  border-color: #da1414;
+}
+#pardot-form .pd-date.filled label,
+#pardot-form .pd-select.filled label,
+#pardot-form .pd-text.filled label,
+#pardot-form .pd-textarea.filled label {
+  color: #858c94;
+}
+#pardot-form .pd-date.filled .animated-border::before,
+#pardot-form .pd-date.filled .animated-border::after,
+#pardot-form .pd-select.filled .animated-border::before,
+#pardot-form .pd-select.filled .animated-border::after,
+#pardot-form .pd-text.filled .animated-border::before,
+#pardot-form .pd-text.filled .animated-border::after,
+#pardot-form .pd-textarea.filled .animated-border::before,
+#pardot-form .pd-textarea.filled .animated-border::after {
+  border-color: transparent;
+}
+#pardot-form .pd-date.focused label,
+#pardot-form .pd-select.focused label,
+#pardot-form .pd-text.focused label,
+#pardot-form .pd-textarea.focused label {
+  color: #0b5fff;
+}
+#pardot-form .pd-date.focused .animated-border::before,
+#pardot-form .pd-date.focused .animated-border::after,
+#pardot-form .pd-select.focused .animated-border::before,
+#pardot-form .pd-select.focused .animated-border::after,
+#pardot-form .pd-text.focused .animated-border::before,
+#pardot-form .pd-text.focused .animated-border::after,
+#pardot-form .pd-textarea.focused .animated-border::before,
+#pardot-form .pd-textarea.focused .animated-border::after {
+  border-color: #0b5fff;
+}
+#pardot-form .pd-date label,
+#pardot-form .pd-select label,
+#pardot-form .pd-text label,
+#pardot-form .pd-textarea label {
+  bottom: 50%;
+  font-size: 0.875rem;
+  font-weight: 600;
+  left: 0;
+  line-height: 1.5;
+  opacity: 0.7;
+  overflow: hidden;
+  padding-left: 1rem;
+  position: absolute;
+  text-overflow: ellipsis;
+  transform: translateY(50%);
+  white-space: nowrap;
+  width: 250px;
+}
+#pardot-form .pd-date input,
+#pardot-form .pd-date select,
+#pardot-form .pd-date textarea,
+#pardot-form .pd-select input,
+#pardot-form .pd-select select,
+#pardot-form .pd-select textarea,
+#pardot-form .pd-text input,
+#pardot-form .pd-text select,
+#pardot-form .pd-text textarea,
+#pardot-form .pd-textarea input,
+#pardot-form .pd-textarea select,
+#pardot-form .pd-textarea textarea {
+  background: #ebeef2;
+  border: 0;
+  border-radius: 6px;
+  box-shadow: none;
+  box-sizing: border-box;
+  color: inherit;
+  font-family: "Source Sans Pro";
+  font-weight: 600;
+  height: 45px;
+  outline: 0;
+  padding: 0.5rem 1rem;
+  width: 100%;
+}
+#pardot-form .pd-select.country select {
+  background: none;
+}
+#pardot-form .pd-select.country .animated-border {
+  box-shadow: inset 0 0 0 1px #e8e8e7;
+}
+#pardot-form .pd-textarea textarea {
+  display: flex;
+  font: 600 16px/1.5 "Source Sans Pro", Tahoma, "Trebuchet MS", sans-serif;
+}
+#pardot-form .pd-errors {
+  background-color: #feefef;
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: #da1414;
+  display: block;
+  margin-bottom: 13px;
+  padding-left: 24px;
+}
+#pardot-form .pd-error {
+  align-items: center;
+  -webkit-animation: slidein 0.2s;
+  animation: slidein 0.2s;
+  background-color: #feefef;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  box-sizing: border-box;
+  color: #da1414;
+  display: flex;
+  margin-bottom: 1rem;
+  margin-top: 2px;
+  padding: 0.5rem 1rem;
+  width: 100%;
+}
+@keyframes slidein {
+  from {
+    transform: translate(-2px, -30px);
+  }
+  to {
+    transform: translate(-2px, 0px);
+  }
+}
+#pardot-form .pd-error:before {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M2.05078 11.9492C3.37402 13.2726 5.12988 14 7 14C8.87012 14 10.6289 13.2726 11.9492 11.9492C13.2725 10.6258 14 8.8703 14 7C14 5.1297 13.2725 3.37146 11.9492 2.05078C10.6289 0.727356 8.87012 0 7 0C5.12988 0 3.37109 0.727356 2.05078 2.05078C0.727539 3.37146 0 5.1297 0 7C0 8.8703 0.727539 10.6285 2.05078 11.9492ZM6.125 3.5C6.125 3.01599 6.51562 2.625 7 2.625C7.48438 2.625 7.875 3.01599 7.875 3.5V7.875C7.875 8.35901 7.48438 8.75 7 8.75C6.51562 8.75 6.125 8.35901 6.125 7.875V3.5ZM7.875 10.5C7.875 10.016 7.48438 9.625 7 9.625C6.51562 9.625 6.125 10.016 6.125 10.5C6.125 10.984 6.51562 11.375 7 11.375C7.48438 11.375 7.875 10.984 7.875 10.5Z' fill='%23DA1414'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 14px 14px;
+  content: "";
+  display: inline-block;
+  height: 14px;
+  padding-right: 0.5rem;
+  pointer-events: none;
+  width: 14px;
+}
+#pardot-form .pd-form-field {
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  position: relative;
+}
+#pardot-form .pd-form-field.filled .animated-border {
+  box-shadow: inset 0 0 0 1px #e8e8e7;
+}
+#pardot-form .pd-form-field.error {
+  margin-bottom: 0;
+}
+#pardot-form .pd-form-field.error.filled + div + .pd-error, #pardot-form .pd-form-field.error.focused + div + .pd-error {
+  position: relative;
+  transform: translate(-1px, -2px);
+  width: calc(100% + 2px);
+  z-index: -1;
+}
+#pardot-form .pd-form-field.hidden .animated-border {
+  box-shadow: none;
+}
+#pardot-form .pd-form-field.pd-checkbox, #pardot-form .pd-form-field.pd-radio {
+  margin-bottom: 0.5rem;
+}
+#pardot-form .pd-form-field.pd-checkbox.dependentFieldSlave .value span, #pardot-form .pd-form-field.pd-radio.dependentFieldSlave .value span {
+  display: flex;
+  padding-bottom: 0;
+}
+#pardot-form .pd-form-field.pd-checkbox.dependentFieldSlave .value span input, #pardot-form .pd-form-field.pd-radio.dependentFieldSlave .value span input {
+  top: 5px;
+  width: 3rem;
+}
+#pardot-form .pd-form-field.pd-checkbox .animated-border, #pardot-form .pd-form-field.pd-radio .animated-border {
+  box-shadow: none;
+}
+#pardot-form .pd-form-field .animated-border {
+  background: inherit;
+  border: 0;
+  border-radius: 7px;
+  bottom: -1px;
+  box-sizing: border-box;
+  display: block;
+  left: -1px;
+  outline: none;
+  padding: 10px;
+  position: absolute;
+  right: -1px;
+  top: -1px;
+  transition: color 0.25s;
+  z-index: -1;
+}
+#pardot-form .pd-form-field .animated-border::before, #pardot-form .pd-form-field .animated-border::after {
+  border: 2px solid transparent;
+  border-radius: 6px;
+  box-sizing: inherit;
+  content: "";
+  height: 0;
+  position: absolute;
+  width: 0;
+}
+#pardot-form .pd-form-field .animated-border::before {
+  left: -1px;
+  top: -1px;
+}
+#pardot-form .pd-form-field .animated-border::after {
+  bottom: -1px;
+  right: -1px;
+}
+#pardot-form .pd-form-field .pd-description,
+#pardot-form .pd-form-field .pd-description a {
+  color: #647480;
+  font-size: 0.75rem;
+  line-height: 1.666;
+  order: -1;
+}
+#pardot-form .pd-select label {
+  pointer-events: none;
+}
+#pardot-form .pd-select::after {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='9' fill='none'%3E%3Cpath fill='%236D7580' d='M1.06 2.47L6.4 7.81a.9.9 0 0 0 1.28 0l5.34-5.34a.9.9 0 0 0-.64-1.54H1.7a.9.9 0 0 0-.64 1.54z'/%3E%3C/svg%3E");
+  pointer-events: none;
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+#pardot-form .pd-select select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+}
+#pardot-form .pd-select select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+#pardot-form .pd-select select::-ms-expand {
+  display: none;
+}
+#pardot-form .pd-textarea label {
+  padding-top: 0.5rem;
+  top: 0;
+  transform: none;
+}
+#pardot-form .pd-textarea textarea {
+  font-size: 0.875rem;
+  height: auto;
+}
+#pardot-form .pd-submit {
+  background: #0b5fff;
+  border-color: transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: #fff;
+  cursor: pointer;
+  font-family: "Source Sans Pro";
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5;
+  padding: 0.75rem 1rem;
+  transition: background 0.3s, box-shadow 0.3s, transform 0.3s;
+  width: 100%;
+}
+#pardot-form .pd-submit:active {
+  background: #004ad7;
+  box-shadow: 0 0 0.75em 0 rgba(76, 76, 76, 0.16), 0 0.375em 1em -0.5em rgba(76, 76, 76, 0.8);
+}
+#pardot-form .pd-submit:focus, #pardot-form .pd-submit:hover {
+  background: #0053f1;
+}
+#pardot-form .pd-submit.bg-action-secondary {
+  background: #19ab4f;
+}
+#pardot-form .pd-submit.bg-action-secondary:active {
+  background: #127f3a;
+}
+#pardot-form .pd-submit.bg-action-secondary:focus, #pardot-form .pd-submit.bg-action-secondary:hover {
+  background: #169545;
+}
+#pardot-form .pd-submit.bg-white {
+  background: #fff;
+  color: #0b5fff;
+}
+#pardot-form .pd-submit.bg-white:active {
+  color: #004ad7;
+}
+#pardot-form .pd-submit.bg-white:focus, #pardot-form .pd-submit.bg-white:hover {
+  color: #0053f1;
+}
+#pardot-form .pd-submit input {
+  cursor: pointer;
+}
+
+#ui-datepicker-div {
+  background: #ebeef2;
+  color: #272833;
+  display: none;
+  font: 400 16px/1.5 "Source Sans Pro", Tahoma, "Trebuchet MS", sans-serif;
+  padding: 0.5rem 1rem;
+}
+#ui-datepicker-div .ui-datepicker-prev {
+  margin-right: 0.5rem;
+}
+
+#email-preferences-container {
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  margin: 15vh auto 0;
+  max-width: 391px;
+  width: 100%;
+}
+#email-preferences-container p {
+  color: #545d69;
+  font-size: 1.125rem;
+  height: 56px;
+  line-height: 1.75;
+  margin: 0;
+  padding-bottom: 1.5rem;
+  position: static;
+}
+#email-preferences-container svg {
+  align-self: center;
+  height: 72px;
+  width: 227.97px;
+}
+#email-preferences-container .form {
+  align-self: center;
+  background: #fff;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+}
+#email-preferences-container .pd-checkbox {
+  padding-bottom: 0.5rem;
+}
+#email-preferences-container .pd-checkbox input {
+  cursor: pointer;
+}
+#email-preferences-container .pd-checkbox input[type=checkbox] {
+  display: none;
+}
+#email-preferences-container .pd-checkbox input:checked ~ label::after {
+  cursor: pointer;
+  display: block;
+}
+#email-preferences-container .pd-checkbox input:checked ~ label::before {
+  background: #0b5fff;
+  cursor: pointer;
+}
+#email-preferences-container .pd-checkbox label {
+  color: #394452;
+  font-weight: 600;
+  margin-left: 0.5rem;
+}
+#email-preferences-container .pd-checkbox label::before {
+  border: 1px solid #dadee3;
+  border-radius: 2px;
+  content: "";
+  cursor: pointer;
+  height: 1rem;
+  left: 0;
+  position: absolute;
+  top: 4px;
+  width: 1rem;
+}
+#email-preferences-container .pd-checkbox label::after {
+  border-bottom: 1px solid #fff;
+  border-left-color: #fff;
+  border-right: 1px solid #fff;
+  border-top-color: #fff;
+  border-top-style: solid;
+  border-top-width: 0;
+  content: "";
+  display: none;
+  height: 12px;
+  left: 6px;
+  position: absolute;
+  top: 5px;
+  transform: rotate(37deg);
+  width: 5px;
+}
+#email-preferences-container .pd-checkbox .pd-description {
+  color: #545d69;
+  font-size: 0.9rem;
+  line-height: 1.25;
+  margin-top: -0.8rem;
+}
+#email-preferences-container #pardot-form > div.pd-form-field.\%\%form-field-class-type\%\%.required.\%\%form-field-dependency-css\%\% {
+  margin-bottom: 0;
+}
+#email-preferences-container .pd-email input {
+  background-color: #ebeef2;
+  border: none;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px #e8e8e7;
+  box-sizing: border-box;
+  color: #94989e;
+  font-weight: 600;
+  height: 3rem;
+  outline: none;
+  padding-left: 1rem;
+  width: 100%;
+}
+#email-preferences-container .pd-field-label {
+  color: #94989e;
+  cursor: pointer;
+  left: 6px;
+  opacity: 0.7;
+  position: absolute;
+  top: -13px;
+  transform: scale(0.8);
+}
+#email-preferences-container .pd-form-field.no-label {
+  order: 2;
+  padding-top: 10px;
+  text-align: center;
+}
+#email-preferences-container .pd-form-field.no-label a {
+  color: #545d69;
+}
+#email-preferences-container .pd-submit {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+html:not(#__):not(#___) .cadmin .user-control-group {
+  flex-grow: 0 !important;
+}
+
+html:not(#__):not(#___) .cadmin .tools-control-group {
+  flex: 1;
+}#formsection .form-container,
+.bg-whiteColor .mktoForm {
+  background-color: #fff;
+}
+
+#LblMarketing_Subscription_Opt_In__c ~ .mktoCheckboxList {
+  float: left;
+}
+
+.mktoForm #LblMarketing_Subscription_Opt_In__c.mktoLabel {
+  color: #394452;
+  float: right;
+  left: 0;
+  margin-bottom: 1rem;
+}
+
+.mktoForm {
+  color: #09101d;
+  padding-bottom: 1.5rem;
+}
+.mktoForm a {
+  color: #0b5fff;
+}
+.mktoForm a:hover {
+  color: #0053f0;
+}
+.mktoForm input[type=date],
+.mktoForm input[type=email],
+.mktoForm input[type=tel],
+.mktoForm input[type=text],
+.mktoForm input[type=url],
+.mktoForm select,
+.mktoForm textarea {
+  background: #fff;
+  border: 0;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px #ebeef2;
+  font-family: "Source Sans Pro";
+  font-weight: 600;
+  height: 45px;
+  outline: 0;
+  padding: 0.5rem 1rem;
+  width: 100%;
+}
+.mktoForm textarea {
+  height: auto;
+}
+.mktoForm select.mktoField {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #ffffff;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='9' fill='none'%3E%3Cpath fill='%236D7580' d='M1.06 2.47L6.4 7.81a.9.9 0 0 0 1.28 0l5.34-5.34a.9.9 0 0 0-.64-1.54H1.7a.9.9 0 0 0-.64 1.54z'/%3E%3C/svg%3E");
+  background-position: 97% 50%;
+  background-repeat: no-repeat;
+  background-size: 14px;
+}
+.mktoForm .g-recaptcha > iframe {
+  display: none;
+}
+.mktoForm .grecaptcha-badge {
+  border-radius: 2px;
+  bottom: 14px;
+  box-shadow: gray 0px 0px 5px;
+  display: block;
+  height: 60px;
+  overflow: hidden;
+  position: fixed;
+  right: -186px;
+  transition: right 0.3s ease 0s;
+  width: 256px;
+}
+.mktoForm .mktoButtonRow {
+  margin-top: 1.5rem;
+}
+.mktoForm .mktoButton {
+  background-color: #0b5fff;
+  background-image: none;
+  border: 1px solid transparent;
+  border-color: transparent;
+  border-radius: 4px;
+  color: #fff;
+  font-family: "Source Sans Pro";
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 24px;
+  padding: 0.75rem 1rem;
+  width: 100%;
+}
+.mktoForm .mktoButton.bg-action-default {
+  background-color: #0b5fff;
+}
+.mktoForm .mktoButton.bg-white {
+  color: #0b5fff;
+}
+.mktoForm .mktoCaptchaDisclaimer {
+  display: none;
+}
+.mktoForm .mktoCheckboxList,
+.mktoForm .mktoRadioList {
+  margin-top: 0.5rem;
+}
+.mktoForm .mktoCheckboxList input,
+.mktoForm .mktoRadioList input {
+  border-radius: 2px;
+  cursor: pointer;
+  float: left;
+  height: 1rem;
+  margin-right: 8px;
+  margin-top: 5px;
+}
+.mktoForm .mktoCheckboxList label,
+.mktoForm .mktoRadioList label {
+  color: #394452;
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 24px;
+  padding: 0.125rem 0;
+}
+.mktoForm .mktoClear,
+.mktoForm .mktoOffset {
+  display: none;
+}
+.mktoForm .mktoLabel {
+  background: linear-gradient(180deg, transparent 50%, #fff 50%);
+  color: #858c94;
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  left: 16px;
+  padding: 0 2px;
+  position: relative;
+  top: 9px;
+}
+.mktoForm .mktoLabel .mktoAsterix {
+  float: right;
+}
+.mktoForm .mktoError {
+  align-items: center;
+  -webkit-animation: slidein 0.2s;
+  animation: slidein 0.2s;
+  background-color: #feefef;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  box-sizing: border-box;
+  color: #da1414;
+  display: flex;
+  padding: 0.5rem 1rem;
+  width: 100%;
+}
+.mktoForm .mktoFieldWrap.focused .mktoField, .mktoForm .mktoFieldWrap.focused.error .mktoField {
+  border: 2px solid #004ad7;
+}
+.mktoForm .mktoFieldWrap.focused .mktoLabel, .mktoForm .mktoFieldWrap.focused.error .mktoLabel {
+  color: #004ad7;
+}
+.mktoForm .mktoFieldWrap.error .mktoField {
+  border: 2px solid #da1414;
+}
+.mktoForm .mktoFieldWrap.error .mktoLabel {
+  color: #da1414;
+}
+.mktoForm .mktoFieldWrap.checkbox-field, .mktoForm .mktoFieldWrap.radio-field {
+  padding-top: 1rem;
+}
+.mktoForm .mktoFieldWrap.checkbox-field .mktoLabel, .mktoForm .mktoFieldWrap.radio-field .mktoLabel {
+  background: transparent;
+  color: #394452;
+  font-size: 1rem;
+  line-height: 24px;
+  padding: 0;
+  position: static;
+}
+.mktoForm .mktoFieldWrap.checkbox-field.single-checkbox {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: start;
+}
+.mktoForm .mktoFieldWrap.checkbox-field.single-checkbox .mktoCheckboxList {
+  padding-bottom: 0.5rem;
+}
+.mktoForm .mktoFieldWrap:not(:has(> .mktoField[aria-required=true])) > .mktoLabel > .mktoAsterix {
+  display: none !important;
+}
+.mktoForm .mktoFormCol {
+  width: 100%;
+}
+.mktoForm .mktoFormRow {
+  display: flex;
+  gap: 1rem;
+}
+.mktoForm.marketo-dark .mktoFieldWrap.focused .mktoField, .mktoForm.marketo-dark .mktoFieldWrap.focused.error .mktoField {
+  border-color: #fff;
+}
+.mktoForm.marketo-dark .mktoFieldWrap.focused .mktoLabel, .mktoForm.marketo-dark .mktoFieldWrap.focused.error .mktoLabel {
+  color: #fff;
+}
+.mktoForm.marketo-dark .mktoFieldWrap.filled input[type=date],
+.mktoForm.marketo-dark .mktoFieldWrap.filled input[type=email],
+.mktoForm.marketo-dark .mktoFieldWrap.filled input[type=tel],
+.mktoForm.marketo-dark .mktoFieldWrap.filled input[type=text],
+.mktoForm.marketo-dark .mktoFieldWrap.filled input[type=url],
+.mktoForm.marketo-dark .mktoFieldWrap.filled select,
+.mktoForm.marketo-dark .mktoFieldWrap.filled textarea {
+  border: 1px solid rgba(255, 255, 255, 0.6);
+}
+.mktoForm.marketo-dark .mktoLabel {
+  background: linear-gradient(180deg, transparent 50%, #3f547a 50%);
+  color: #fff;
+}
+.mktoForm.marketo-dark select.mktoField {
+  background-color: #3f547a;
+}
+.mktoForm.marketo-dark input[type=date],
+.mktoForm.marketo-dark input[type=email],
+.mktoForm.marketo-dark input[type=tel],
+.mktoForm.marketo-dark input[type=text],
+.mktoForm.marketo-dark input[type=url],
+.mktoForm.marketo-dark select,
+.mktoForm.marketo-dark textarea {
+  background: #3f547a;
+  box-shadow: inset 0 0 0 1px transparent;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+[id^=fragment] .mktoForm .mktoLabel {
+  top: 14px;
+}/* ---------- Skeleton loader ---------- */
+.marketo-skeleton-wrapper {
+  height: 250px;
+  margin-top: 1.5rem;
+  max-height: 200px;
+  position: relative;
+  transition: max-height 0.3s;
+  will-change: max-height;
+}
+.marketo-skeleton-wrapper.hide-skeleton {
+  height: auto;
+  margin-top: 0;
+  max-height: 1500px;
+}
+.marketo-skeleton-wrapper.hide-skeleton .marketo-form-skeleton {
+  opacity: 0;
+  visibility: hidden;
+}
+.marketo-skeleton-wrapper.hide-skeleton .marketo-form-wrapper {
+  opacity: 1;
+  visibility: visible;
+}
+.marketo-skeleton-wrapper.hide-skeleton .marketo-form-legal-text {
+  color: #647480;
+  font-size: 0.75rem;
+  line-height: 1.666;
+  opacity: 1;
+  padding-top: 16px;
+  visibility: visible;
+}
+.marketo-skeleton-wrapper.hide-skeleton .marketo-form-legal-text a {
+  color: #647480;
+  text-decoration: underline;
+}
+.marketo-skeleton-wrapper.hide-skeleton .marketo-form-legal-text a:hover {
+  color: #0053f0;
+}
+.marketo-skeleton-wrapper .marketo-form-skeleton {
+  left: 0;
+  opacity: 1;
+  position: absolute;
+  top: 0;
+  transition: opacity 0.3s, visibility 0.3s;
+  visibility: visible;
+  width: 100%;
+}
+.marketo-skeleton-wrapper .marketo-form-skeleton .skeleton-input {
+  animation: loading-content 0.8s ease infinite alternate;
+  background: #e8e8e7;
+  border-radius: 4px;
+  height: 46px;
+  margin-bottom: 2rem;
+  width: 100%;
+}
+.marketo-skeleton-wrapper .marketo-form-skeleton .skeleton-input:last-child {
+  animation-delay: 0.2s;
+}
+.marketo-skeleton-wrapper .marketo-form-skeleton .skeleton-input:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.marketo-skeleton-wrapper .marketo-form-wrapper,
+.marketo-skeleton-wrapper .marketo-form-legal-text {
+  opacity: 0;
+  transition: opacity 0.3s ease-out 0.3s, visibility 0.3s ease-out 0.3s;
+  visibility: hidden;
+}
+
+@keyframes loading-content {
+  0% {
+    opacity: 0.4;
+  }
+  95% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0.9;
+  }
+}

--- a/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-forms-global-css/assets/js/marketo.js
+++ b/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-forms-global-css/assets/js/marketo.js
@@ -1,0 +1,435 @@
+// eslint-disable-next-line no-unused-vars
+
+function loadMarketoForm(
+	formEl,
+	formId,
+	submitButtonText,
+	submitButtonColor,
+	redirectUrl,
+	assetInfo,
+	utmInfo
+) {
+	var mktoFormConfig = {
+		munchkinId: '212-DQY-814',
+		podId: '//pages.liferay.com'
+	};
+
+	loadMarketoFormsJs(mktoFormConfig, function() {
+		formEl.id = 'mktoForm_' + formId;
+
+		MktoForms2.loadForm(
+			mktoFormConfig.podId,
+			mktoFormConfig.munchkinId,
+			formId,
+			function(form) {
+				formEl.id = '';
+
+				// eslint-disable-next-line es5/no-es6-methods
+				var buttonElem = form.getFormElem().find('button.mktoButton');
+
+				if (buttonElem) {
+					buttonElem.html(submitButtonText);
+
+					if (submitButtonColor) {
+						buttonElem.addClass('bg-' + submitButtonColor);
+					}
+				}
+
+				var skeletonWrapperEl = formEl.querySelector(
+					'.marketo-skeleton-wrapper'
+				);
+
+				if (skeletonWrapperEl) {
+					skeletonWrapperEl.classList.toggle('hide-skeleton');
+				}
+
+				namespaceFormElements(form);
+				removeFormStyles(form);
+				initializeFocusedFilledClasses();
+
+				if (assetInfo && assetInfo.title && assetInfo.asset_url) {
+					form.setValues({
+						Recent_Asset_Name__c: assetInfo.title,
+						Recent_Asset_URL__c: assetInfo.asset_url
+					});
+				}
+
+				if (utmInfo) {
+					form.setValues({
+						Last_CID__c: utmInfo.utm_cid,
+						Last_Campaign__c: utmInfo.utm_campaign,
+						Last_Content__c: utmInfo.utm_content,
+						Last_Medium__c: utmInfo.utm_medium,
+						Last_Source__c: utmInfo.utm_source,
+						Last_Term__c: utmInfo.utm_term
+					});
+				}
+
+				var formInitEvent = new CustomEvent('marketoFormInit', {
+					detail: form
+				});
+				document.dispatchEvent(formInitEvent);
+
+				sendFormViewAnalytics(formId, assetInfo);
+
+				var formElement = form.getFormElem()[0];
+
+				formElement.addEventListener('submit', function(event) {
+					window.SixSenseEvent = event;
+					// eslint-disable-next-line no-console
+					console.info('6sense: Form submit initiated.');
+				});
+
+				formElement
+					.getElementsByTagName('button')[0]
+					.setAttribute('name', 'mktoButton_' + form.getId());
+
+				formElement.setAttribute('name', 'mktoForm_' + form.getId());
+
+				form.onSuccess(function() {
+					// eslint-disable-next-line no-undef
+					if (window._6si) {
+						// eslint-disable-next-line no-undef
+						window._6si.send(window.SixSenseEvent);
+
+						// eslint-disable-next-line no-console
+						console.info('6sense: Form submit completed.');
+					} else {
+						console.warn(
+							'6sense: Event object not found. Form fill not logged.'
+						);
+					}
+
+					sendFormSubmitAnalytics(formId, assetInfo);
+					location.href = redirectUrl;
+
+					return false;
+				});
+			}
+		);
+
+		MktoForms2.onFormRender(function(form) {
+			namespaceFormElements(form);
+			removeFormStyles(form);
+		});
+
+		MktoForms2.whenReady(function(form) {
+			form.onValidate(function(nativeValid) {
+				if (!nativeValid) {
+					return;
+				}
+
+				var formEl = form.getFormElem()[0],
+					currentValues = form.getValues(),
+					buttonEl = formEl.querySelector('.mktoButtonWrap');
+
+				var bannedEmailFieldNames = [
+					'Email',
+					'Email_Address_2__c'
+				].filter(function(fieldName) {
+					return isEmailBanned(currentValues[fieldName]);
+				});
+
+				buttonEl.removeAttribute('data-error-message');
+
+				var allEmailsValid = bannedEmailFieldNames.length == 0;
+
+				if (!allEmailsValid) {
+					form.showErrorMessage(
+						Liferay.Language.get('email-validate-message'),
+						MktoForms2.$(
+							formEl.querySelector(
+								"[name='" + bannedEmailFieldNames[0] + "']"
+							)
+						)
+					);
+				}
+
+				form.submittable(allEmailsValid);
+			});
+
+			function isEmailBanned(emailAddress) {
+				return [
+					/@gmail\./,
+					/@yahoo\./,
+					/@hotmail\./,
+					/@live\./,
+					/@aol\./,
+					/@outlook\./,
+					/@mailinator\./,
+					/@info\./,
+					/@xgh6\./,
+					/@business\./,
+					/@bsuiness\./,
+					/@gnnmail\./,
+					/@gma\./,
+					/@1122\./,
+					/@hot\./,
+					/@h05d\./,
+					/@work\./,
+					/@mailin\./,
+					/@mail\./,
+					/@mainator\./,
+					/@service\./,
+					/@domai\./,
+					/@domain\./,
+					/@armyspy\./,
+					/@maiator\./,
+					/@company\./,
+					/@temporary\./
+				].some(function(pattern) {
+					return new RegExp(
+						pattern.source + '[a-z0-9-.]+$',
+						'i'
+					).test(emailAddress);
+				});
+			}
+		});
+	});
+}
+
+var loadMarketoFormsJs = (function() {
+	var loading = false;
+
+	return function(mktoFormConfig, callback) {
+		if (!loading) {
+			loading = true;
+
+			if (typeof MktoForms2 !== 'undefined') {
+				callback();
+
+				return;
+			}
+
+			var mktoForms2BaseStyleSpan = document.createElement('span');
+			mktoForms2BaseStyleSpan.id = 'mktoForms2BaseStyle';
+			mktoForms2BaseStyleSpan.setAttribute('class', 'd-none');
+
+			document.head.appendChild(mktoForms2BaseStyleSpan);
+
+			var mktoForms2ThemeStyleSpan = document.createElement('span');
+			mktoForms2ThemeStyleSpan.id = 'mktoForms2ThemeStyle';
+			mktoForms2ThemeStyleSpan.setAttribute('class', 'd-none');
+
+			document.head.appendChild(mktoForms2ThemeStyleSpan);
+
+			var mktoStyleLoadedDiv = document.createElement('div');
+			mktoStyleLoadedDiv.id = 'mktoStyleLoaded';
+
+			// Prevent marketo from loading its own styles by adding the test styles it creates
+
+			document.head.appendChild(mktoStyleLoadedDiv);
+
+			var mktoStyle = document.createElement('style');
+			mktoStyle.appendChild(
+				document.createTextNode(
+					'#mktoStyleLoaded { display: none; background-color: #123456; border-top-color: #123456; color: #123456;}'
+				)
+			);
+			document.head.appendChild(mktoStyle);
+
+			var script = document.createElement('script');
+
+			if (script) {
+				script.setAttribute(
+					'src',
+					mktoFormConfig.podId + '/js/forms2/js/forms2.min.js'
+				);
+				document.head.appendChild(script);
+			}
+		}
+
+		waitForMarketoAPI(callback);
+	};
+})();
+
+function waitForMarketoAPI(callback) {
+	var timeout = 10;
+
+	var poll = function() {
+		setTimeout(function() {
+			timeout--;
+			if (typeof MktoForms2 !== 'undefined') {
+				callback();
+			} else if (timeout > 0) {
+				poll();
+			}
+		}, 100);
+	};
+
+	poll();
+}
+
+function namespaceFormElements(form) {
+	var formEl = form.getFormElem()[0];
+
+	var randomNamespace = '_' + new Date().getTime() + Math.random();
+
+	formEl.querySelectorAll('label[for]').forEach(function(labelEl) {
+		var forEl = labelEl.control;
+
+		var fieldWrapper = labelEl.parentNode;
+
+		var radioListEl = fieldWrapper.querySelector(
+			'#' + labelEl.id + ' ~ .mktoRadioList'
+		);
+		var checkboxListEl = fieldWrapper.querySelector(
+			'#' + labelEl.id + ' ~ .mktoCheckboxList'
+		);
+
+		if (forEl) {
+			labelEl.htmlFor = forEl.id = forEl.id + randomNamespace;
+		}
+
+		if (
+			checkboxListEl &&
+			!fieldWrapper.classList.contains('checkbox-field')
+		) {
+			fieldWrapper.classList.add('checkbox-field');
+
+			var checkboxListInputs = checkboxListEl.querySelectorAll('input');
+
+			if (
+				!fieldWrapper.classList.contains('single-checkbox') &&
+				checkboxListInputs.length === 1
+			) {
+				fieldWrapper.classList.add('single-checkbox');
+			}
+		} else if (
+			radioListEl &&
+			!fieldWrapper.classList.contains('radio-field')
+		) {
+			fieldWrapper.classList.add('radio-field');
+		}
+	});
+}
+
+function removeFormStyles(form) {
+	var formEl = form.getFormElem()[0];
+
+	var arrayify = getSelection.call.bind([].slice);
+
+	var styledEls = arrayify(formEl.querySelectorAll('[style]')).concat(formEl);
+
+	styledEls.forEach(function(el) {
+		el.removeAttribute('style');
+	});
+
+	formEl.querySelectorAll('style').forEach(function(el) {
+		el.remove();
+	});
+}
+
+// eslint-disable-next-line no-unused-vars
+function removeMarketoStylesheets(form) {
+	var formEl = form.getFormElem()[0];
+
+	var arrayify = getSelection.call.bind([].slice);
+
+	var styleSheets = arrayify(document.styleSheets);
+
+	styleSheets.forEach(function(stylesheet) {
+		if (
+			// eslint-disable-next-line no-undef
+			[mktoForms2BaseStyle, mktoForms2ThemeStyle].indexOf(
+				stylesheet.ownerNode
+			) != -1 ||
+			formEl.contains(stylesheet.ownerNode)
+		) {
+			stylesheet.disabled = true;
+		}
+	});
+}
+
+function initializeFocusedFilledClasses() {
+	var formFields = document.querySelectorAll(
+		'.mktoFormRow input, .mktoFormRow textarea, .mktoFormRow select'
+	);
+
+	var j = formFields.length;
+	while (j--) {
+		var formField = formFields.item(j);
+
+		toggleFilledClass(null, formField);
+		formField.addEventListener('change', checkErrorClass, true);
+		formField.addEventListener('focus', checkErrorClass, true);
+		formField.addEventListener('keydown', checkErrorClass, true);
+		formField.addEventListener('change', toggleFilledClass, true);
+		formField.addEventListener('focus', toggleFocusedClass, true);
+		formField.addEventListener(
+			'blur',
+			function(event, target) {
+				checkErrorClass(event, target);
+
+				toggleFocusedClass(event, target);
+			},
+			true
+		);
+	}
+}
+
+function toggleFilledClass(event, target) {
+	target = target ? target : event.target;
+
+	var wrapper = target.parentNode;
+
+	if (target.value) {
+		wrapper.classList.add('filled');
+	} else {
+		wrapper.classList.remove('filled');
+	}
+}
+
+function toggleFocusedClass(event) {
+	event.target.parentNode.classList.toggle('focused');
+}
+
+function checkErrorClass(event, target) {
+	target = target ? target : event.target;
+
+	if (target.classList.contains('mktoInvalid')) {
+		target.parentNode.classList.add('error');
+	} else {
+		target.parentNode.classList.remove('error');
+	}
+}
+
+function sendFormViewAnalytics(formId, assetInfo) {
+	if (window.Analytics) {
+		Analytics.send('formViewed', 'Form', {
+			formId: formId,
+			title: document.title
+		});
+
+		if (assetInfo) {
+			Analytics.send('documentPreviewed', 'Document', {
+				fileEntryId: assetInfo.fileEntryId,
+				fileEntryUUID: assetInfo.fileEntryUUID,
+				groupId: assetInfo.groupId,
+				title: assetInfo.title,
+				version: assetInfo.version
+			});
+		}
+	}
+}
+
+function sendFormSubmitAnalytics(formId, assetInfo) {
+	if (window.Analytics) {
+		Analytics.send('formSubmitted', 'Form', {
+			formId: formId
+		});
+
+		if (assetInfo) {
+			Analytics.send('documentDownloaded', 'Document', {
+				fileEntryId: assetInfo.fileEntryId,
+				groupId: assetInfo.groupId,
+				title: assetInfo.title,
+				version: assetInfo.version
+			});
+		}
+	}
+}
+
+if (typeof module !== 'undefined') {
+	module.exports = loadMarketoForm;
+}

--- a/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-forms-global-css/client-extension.yaml
+++ b/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-forms-global-css/client-extension.yaml
@@ -1,0 +1,7 @@
+assemble:
+    -   from: assets
+        into: static
+liferay-dotcom-forms-global-css:
+    name: Liferay Dotcom Forms Global CSS
+    type: globalCSS
+    url: forms.css


### PR DESCRIPTION
Migrates the forms-theme-contributor module (Bundle-SymbolicName com.liferay.osb.www.forms.theme.contributor) from
lfris-www/liferay/modules/extensions/forms-theme-contributor into the liferay-dotcom-workspace as a globalCSS client extension.

Assets shipped:
- forms.css: concatenation of compiled custom.css (which inlines multistep), marketo.css, and marketo-skeleton.css, produced by the original Liferay Sass + autoprefixer pipeline (with bourbon mixins resolved from themes/www-theme/node_modules/bourbon at build time).
- js/marketo.js: unchanged from the source module.

Paired with DG-X removal of the source module in lfris-www (branch DG-X-remove-forms-theme-contributor).