### PR TITLE
LPD-88837 Add PageSpeed scanner with sitemap-based URL discovery

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/bnd.bnd
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay SEO Studio PageSpeed
+Bundle-SymbolicName: com.liferay.seo.studio.pagespeed
+Bundle-Version: 1.0.0
+-dsannotations-options: inherit

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/build.gradle
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testImplementation project(":core:petra:petra-function")
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/LiferayHeadlessClient.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/LiferayHeadlessClient.java
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+
+import java.net.HttpURLConnection;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Kiana Suetani
+ */
+public class LiferayHeadlessClient {
+
+	public LiferayHeadlessClient(String authToken, String portalURL) {
+		_authToken = authToken;
+		_portalURL = portalURL;
+	}
+
+	public List<String> getPageURLs(int maxPages) throws Exception {
+		if (maxPages <= 0) {
+			return new ArrayList<>();
+		}
+
+		String protocol = "https://";
+
+		if (_portalURL.startsWith("http://")) {
+			protocol = "http://";
+		}
+
+		LinkedHashSet<String> urlSet = new LinkedHashSet<>();
+
+		for (String virtualHost : _getVirtualHosts()) {
+			_addSitemapURLs(
+				maxPages, protocol + virtualHost + "/sitemap.xml", urlSet);
+
+			if (urlSet.size() >= maxPages) {
+				break;
+			}
+		}
+
+		List<String> urls = new ArrayList<>(urlSet);
+
+		if (urls.size() > maxPages) {
+			return urls.subList(0, maxPages);
+		}
+
+		return urls;
+	}
+
+	private void _addSitemapURLs(
+			int maxPages, String sitemapURL, LinkedHashSet<String> urlSet)
+		throws Exception {
+
+		String sitemapXML = _makeRequest(sitemapURL);
+
+		if (Validator.isNotNull(sitemapXML)) {
+			urlSet.addAll(_parseSitemapURLs(0, maxPages, sitemapXML));
+		}
+	}
+
+	private List<String> _getChildSitemapURLs(Element rootElement) {
+		List<String> childSitemapURLs = new ArrayList<>();
+
+		for (Element sitemapElement : rootElement.elements("sitemap")) {
+			Element locElement = sitemapElement.element("loc");
+
+			if (locElement != null) {
+				childSitemapURLs.add(locElement.getText());
+			}
+		}
+
+		return childSitemapURLs;
+	}
+
+	private List<String> _getVirtualHosts() throws Exception {
+		String responseJSON = _makeRequest(
+			_portalURL + "/o/headless-portal-instances/v1.0/portal-instances");
+
+		if (Validator.isNull(responseJSON)) {
+			return new ArrayList<>();
+		}
+
+		JSONObject responseJSONObject = JSONFactoryUtil.createJSONObject(
+			responseJSON);
+
+		JSONArray itemsJSONArray = responseJSONObject.getJSONArray("items");
+
+		if ((itemsJSONArray == null) || (itemsJSONArray.length() == 0)) {
+			return new ArrayList<>();
+		}
+
+		List<String> virtualHosts = new ArrayList<>();
+
+		for (int i = 0; i < itemsJSONArray.length(); i++) {
+			String virtualHost = itemsJSONArray.getJSONObject(
+				i
+			).getString(
+				"virtualHost"
+			);
+
+			if (Validator.isNotNull(virtualHost)) {
+				virtualHosts.add(virtualHost);
+			}
+		}
+
+		return virtualHosts;
+	}
+
+	private String _makeRequest(String url) {
+		try {
+			Http.Options options = new Http.Options();
+
+			if (Validator.isNotNull(_authToken)) {
+				options.addHeader("Authorization", "Bearer " + _authToken);
+			}
+
+			options.setLocation(url);
+
+			options.setTimeout(30000);
+
+			String response = HttpUtil.URLtoString(options);
+
+			Http.Response httpResponse = options.getResponse();
+
+			if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Response code ", httpResponse.getResponseCode(),
+							" for ", url));
+				}
+
+				return null;
+			}
+
+			return response;
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to make request to " + url, exception);
+			}
+
+			return null;
+		}
+	}
+
+	private List<String> _parseSitemapURLs(int depth, int maxPages, String xml)
+		throws Exception {
+
+		if (depth > _MAX_SITEMAP_DEPTH) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Maximum sitemap recursion depth exceeded");
+			}
+
+			return new ArrayList<>();
+		}
+
+		Document document = SAXReaderUtil.read(xml);
+
+		Element rootElement = document.getRootElement();
+
+		List<String> urls = new ArrayList<>();
+
+		if (Objects.equals(rootElement.getName(), "sitemapindex")) {
+			for (String childSitemapURL : _getChildSitemapURLs(rootElement)) {
+				String childSitemapXML = _makeRequest(childSitemapURL);
+
+				if (Validator.isNotNull(childSitemapXML)) {
+					urls.addAll(
+						_parseSitemapURLs(
+							depth + 1, maxPages, childSitemapXML));
+				}
+
+				if (urls.size() >= maxPages) {
+					break;
+				}
+			}
+		}
+		else {
+			for (Element urlElement : rootElement.elements("url")) {
+				Element locElement = urlElement.element("loc");
+
+				if (locElement == null) {
+					continue;
+				}
+
+				String url = locElement.getText();
+
+				if (Validator.isNotNull(url)) {
+					urls.add(url);
+
+					if (urls.size() >= maxPages) {
+						break;
+					}
+				}
+			}
+		}
+
+		return urls;
+	}
+
+	private static final int _MAX_SITEMAP_DEPTH = 3;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiferayHeadlessClient.class);
+
+	private final String _authToken;
+	private final String _portalURL;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScanResult.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScanResult.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScanResult {
+
+	public static final String STATUS_COMPLETED = "completed";
+
+	public static final String STATUS_FAILED = "failed";
+
+	public static final String STATUS_RUNNING = "running";
+
+	public PageSpeedScanResult(
+		PageSpeedScores averageScores, String errorMessage, int pagesErrored,
+		int pagesScanned, int pagesTotal, String status) {
+
+		_averageScores = averageScores;
+		_errorMessage = errorMessage;
+		_pagesErrored = pagesErrored;
+		_pagesScanned = pagesScanned;
+		_pagesTotal = pagesTotal;
+		_status = status;
+	}
+
+	public PageSpeedScores getAverageScores() {
+		return _averageScores;
+	}
+
+	public String getErrorMessage() {
+		return _errorMessage;
+	}
+
+	public int getPagesErrored() {
+		return _pagesErrored;
+	}
+
+	public int getPagesScanned() {
+		return _pagesScanned;
+	}
+
+	public int getPagesTotal() {
+		return _pagesTotal;
+	}
+
+	public String getStatus() {
+		return _status;
+	}
+
+	private final PageSpeedScores _averageScores;
+	private final String _errorMessage;
+	private final int _pagesErrored;
+	private final int _pagesScanned;
+	private final int _pagesTotal;
+	private final String _status;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScanner.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScanner.java
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScanner {
+
+	public PageSpeedScanResult scan(
+			String apiKey, String authToken, String portalURL, String strategy)
+		throws Exception {
+
+		LiferayHeadlessClient liferayHeadlessClient = new LiferayHeadlessClient(
+			authToken, portalURL);
+
+		List<String> urls = liferayHeadlessClient.getPageURLs(_PAGE_LIMIT);
+
+		if (urls.isEmpty()) {
+			return new PageSpeedScanResult(
+				new PageSpeedScores(0, 0, 0, 0), null, 0, 0, 0,
+				PageSpeedScanResult.STATUS_COMPLETED);
+		}
+
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider(apiKey, strategy);
+
+		if (!pageSpeedScoreProvider.isValidConnection()) {
+			return new PageSpeedScanResult(
+				null, "Google PageSpeed API key is not configured", 0, 0, 0,
+				PageSpeedScanResult.STATUS_FAILED);
+		}
+
+		return _scanURLs(pageSpeedScoreProvider, urls);
+	}
+
+	private PageSpeedScores _computeAverageScores(
+		int count, int totalAccessibility, int totalBestPractices,
+		int totalPerformance, int totalSeo) {
+
+		if (count == 0) {
+			return new PageSpeedScores(0, 0, 0, 0);
+		}
+
+		return new PageSpeedScores(
+			Math.round((float)totalAccessibility / count),
+			Math.round((float)totalBestPractices / count),
+			Math.round((float)totalPerformance / count),
+			Math.round((float)totalSeo / count));
+	}
+
+	private PageSpeedScanResult _scanURLs(
+		PageSpeedScoreProvider pageSpeedScoreProvider, List<String> urls) {
+
+		int pagesTotal = urls.size();
+
+		AtomicBoolean quotaExceeded = new AtomicBoolean(false);
+		AtomicInteger pagesErrored = new AtomicInteger(0);
+		AtomicInteger pagesScanned = new AtomicInteger(0);
+		AtomicInteger totalAccessibility = new AtomicInteger(0);
+		AtomicInteger totalBestPractices = new AtomicInteger(0);
+		AtomicInteger totalPerformance = new AtomicInteger(0);
+		AtomicInteger totalSeo = new AtomicInteger(0);
+
+		ExecutorService executorService = Executors.newFixedThreadPool(
+			_WORKER_COUNT);
+
+		List<Future<?>> futures = new ArrayList<>();
+
+		for (String url : urls) {
+			futures.add(
+				executorService.submit(
+					() -> {
+						if (quotaExceeded.get()) {
+							return;
+						}
+
+						try {
+							PageSpeedScores pageSpeedScores =
+								pageSpeedScoreProvider.getScores(url);
+
+							totalAccessibility.addAndGet(
+								pageSpeedScores.getAccessibility());
+							totalBestPractices.addAndGet(
+								pageSpeedScores.getBestPractices());
+							totalPerformance.addAndGet(
+								pageSpeedScores.getPerformance());
+							totalSeo.addAndGet(pageSpeedScores.getSeo());
+
+							pagesScanned.incrementAndGet();
+						}
+						catch (PageSpeedScoreProvider.
+									PageSpeedScoreProviderException
+										pageSpeedScoreProviderException) {
+
+							if (pageSpeedScoreProviderException.
+									isQuotaExceeded()) {
+
+								quotaExceeded.set(true);
+							}
+							else {
+								pagesErrored.incrementAndGet();
+
+								if (_log.isDebugEnabled()) {
+									_log.debug(
+										"Unable to get PageSpeed scores for " +
+											url,
+										pageSpeedScoreProviderException);
+								}
+							}
+						}
+					}));
+		}
+
+		executorService.shutdown();
+
+		for (Future<?> future : futures) {
+			try {
+				future.get();
+			}
+			catch (Exception exception) {
+				pagesErrored.incrementAndGet();
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to complete PageSpeed scan task", exception);
+				}
+			}
+		}
+
+		String errorMessage = null;
+		String status = PageSpeedScanResult.STATUS_COMPLETED;
+
+		int scanned = pagesScanned.get();
+
+		if (quotaExceeded.get()) {
+			errorMessage = StringBundler.concat(
+				"Google PageSpeed API quota exceeded after scanning ", scanned,
+				" of ", pagesTotal, " pages");
+		}
+
+		if ((scanned == 0) && (pagesErrored.get() > 0)) {
+			errorMessage = "All pages failed to scan";
+			status = PageSpeedScanResult.STATUS_FAILED;
+		}
+
+		return new PageSpeedScanResult(
+			_computeAverageScores(
+				scanned, totalAccessibility.get(), totalBestPractices.get(),
+				totalPerformance.get(), totalSeo.get()),
+			errorMessage, pagesErrored.get(), scanned, pagesTotal, status);
+	}
+
+	private static final int _PAGE_LIMIT = 100;
+
+	private static final int _WORKER_COUNT = 5;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PageSpeedScanner.class);
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProvider.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProvider.java
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.net.HttpURLConnection;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProvider {
+
+	public PageSpeedScoreProvider(String apiKey, String strategy) {
+		_apiKey = apiKey;
+		_strategy = strategy;
+	}
+
+	public PageSpeedScores getScores(String url)
+		throws PageSpeedScoreProviderException {
+
+		try {
+			return _getScores(url);
+		}
+		catch (PageSpeedScoreProviderException
+					pageSpeedScoreProviderException) {
+
+			throw pageSpeedScoreProviderException;
+		}
+		catch (Exception exception) {
+			throw new PageSpeedScoreProviderException(exception);
+		}
+	}
+
+	public boolean isValidConnection() {
+		return Validator.isNotNull(_apiKey);
+	}
+
+	public static class PageSpeedScoreProviderException
+		extends PortalException {
+
+		public PageSpeedScoreProviderException(Exception exception) {
+			super(exception);
+		}
+
+		public PageSpeedScoreProviderException(
+			JSONObject googlePageSpeedErrorJSONObject, String message) {
+
+			super(message);
+
+			_googlePageSpeedErrorJSONObject = googlePageSpeedErrorJSONObject;
+		}
+
+		public PageSpeedScoreProviderException(String message) {
+			super(message);
+		}
+
+		public JSONObject getGooglePageSpeedErrorJSONObject() {
+			return _googlePageSpeedErrorJSONObject;
+		}
+
+		public boolean isQuotaExceeded() {
+			JSONObject errorJSONObject = _googlePageSpeedErrorJSONObject;
+
+			if (errorJSONObject == null) {
+				return false;
+			}
+
+			JSONObject errorDetailJSONObject = errorJSONObject.getJSONObject(
+				"error");
+
+			if (errorDetailJSONObject == null) {
+				return false;
+			}
+
+			if (errorDetailJSONObject.getInt("code", -1) == 429) {
+				return true;
+			}
+
+			return false;
+		}
+
+		private JSONObject _googlePageSpeedErrorJSONObject;
+
+	}
+
+	private String _buildGooglePageSpeedURL(String url) {
+		String googlePageSpeedURL =
+			"https://content-pagespeedonline.googleapis.com/pagespeedonline" +
+				"/v5/runPagespeed";
+
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "ACCESSIBILITY");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "BEST_PRACTICES");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "PERFORMANCE");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "SEO");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "fields",
+			"lighthouseResult/categories/*/score");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "key", _apiKey);
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "strategy", _strategy);
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "url", url);
+
+		return googlePageSpeedURL;
+	}
+
+	private int _getScore(JSONObject categoriesJSONObject, String category) {
+		JSONObject categoryJSONObject = categoriesJSONObject.getJSONObject(
+			category);
+
+		if (categoryJSONObject == null) {
+			return 0;
+		}
+
+		double score = categoryJSONObject.getDouble("score", 0);
+
+		return (int)Math.round(score * 100);
+	}
+
+	private PageSpeedScores _getScores(String url) throws Exception {
+		if (!isValidConnection()) {
+			throw new PageSpeedScoreProviderException("Invalid Connection");
+		}
+
+		Http.Options options = new Http.Options();
+
+		String googlePageSpeedURL = _buildGooglePageSpeedURL(url);
+
+		options.setLocation(googlePageSpeedURL);
+
+		options.setTimeout(120000);
+
+		String responseJSON = HttpUtil.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		int responseCode = response.getResponseCode();
+
+		if (responseCode != HttpURLConnection.HTTP_OK) {
+			JSONObject errorJSONObject = null;
+
+			try {
+				errorJSONObject = JSONFactoryUtil.createJSONObject(
+					responseJSON);
+			}
+			catch (JSONException jsonException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to parse error response as JSON",
+						jsonException);
+				}
+			}
+
+			throw new PageSpeedScoreProviderException(
+				errorJSONObject,
+				StringBundler.concat(
+					"Response code ", responseCode, ": ", responseJSON));
+		}
+
+		return _parseScores(responseJSON);
+	}
+
+	private PageSpeedScores _parseScores(String responseJSON) throws Exception {
+		JSONObject responseJSONObject = JSONFactoryUtil.createJSONObject(
+			responseJSON);
+
+		JSONObject lighthouseResultJSONObject =
+			responseJSONObject.getJSONObject("lighthouseResult");
+
+		if (lighthouseResultJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"lighthouseResult\" in response");
+		}
+
+		JSONObject categoriesJSONObject =
+			lighthouseResultJSONObject.getJSONObject("categories");
+
+		if (categoriesJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"categories\" in \"lighthouseResult\"");
+		}
+
+		return new PageSpeedScores(
+			_getScore(categoriesJSONObject, "accessibility"),
+			_getScore(categoriesJSONObject, "best-practices"),
+			_getScore(categoriesJSONObject, "performance"),
+			_getScore(categoriesJSONObject, "seo"));
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PageSpeedScoreProvider.class);
+
+	private final String _apiKey;
+	private final String _strategy;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScores.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScores.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScores {
+
+	public PageSpeedScores(
+		int accessibility, int bestPractices, int performance, int seo) {
+
+		_accessibility = accessibility;
+		_bestPractices = bestPractices;
+		_performance = performance;
+		_seo = seo;
+	}
+
+	public int getAccessibility() {
+		return _accessibility;
+	}
+
+	public int getBestPractices() {
+		return _bestPractices;
+	}
+
+	public int getPerformance() {
+		return _performance;
+	}
+
+	public int getSeo() {
+		return _seo;
+	}
+
+	private final int _accessibility;
+	private final int _bestPractices;
+	private final int _performance;
+	private final int _seo;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/LiferayHeadlessClientTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/LiferayHeadlessClientTest.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.xml.SAXReaderImpl;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Kiana Suetani
+ */
+public class LiferayHeadlessClientTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
+
+		saxReaderUtil.setSAXReader(new SAXReaderImpl());
+	}
+
+	@Before
+	public void setUp() {
+		_httpUtilMockedStatic = Mockito.mockStatic(HttpUtil.class);
+	}
+
+	@After
+	public void tearDown() {
+		_httpUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testGetPageURLs() throws Exception {
+		String virtualHostsJSON =
+			"{\"items\":[{\"virtualHost\":\"example.com\"}],\"totalCount\":1}";
+
+		String sitemapXML = StringBundler.concat(
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?><urlset xmlns=",
+			"\"http://www.sitemaps.org/schemas/sitemap/0.9\">",
+			"<url><loc>https://example.com/home</loc></url>",
+			"<url><loc>https://example.com/about</loc></url></urlset>");
+
+		Http.Response httpResponse = Mockito.mock(Http.Response.class);
+
+		Mockito.when(
+			httpResponse.getResponseCode()
+		).thenReturn(
+			200
+		);
+
+		_httpUtilMockedStatic.when(
+			() -> HttpUtil.URLtoString(Mockito.any(Http.Options.class))
+		).thenAnswer(
+			invocation -> {
+				Http.Options options = invocation.getArgument(0);
+
+				options.setResponse(httpResponse);
+
+				String location = options.getLocation();
+
+				if (location.contains("portal-instances")) {
+					return virtualHostsJSON;
+				}
+
+				return sitemapXML;
+			}
+		);
+
+		LiferayHeadlessClient liferayHeadlessClient = new LiferayHeadlessClient(
+			null, "https://portal.example.com");
+
+		List<String> urls = liferayHeadlessClient.getPageURLs(0);
+
+		Assert.assertEquals(urls.toString(), 2, urls.size());
+		Assert.assertEquals("https://example.com/home", urls.get(0));
+		Assert.assertEquals("https://example.com/about", urls.get(1));
+	}
+
+	private MockedStatic<HttpUtil> _httpUtilMockedStatic;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScannerTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScannerTest.java
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScannerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testScanURLsWithAllPagesFailed() throws Exception {
+		PageSpeedScoreProvider pageSpeedScoreProvider = Mockito.mock(
+			PageSpeedScoreProvider.class);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores(Mockito.anyString())
+		).thenThrow(
+			new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+				"Connection error")
+		);
+
+		PageSpeedScanResult pageSpeedScanResult = _scanURLs(
+			pageSpeedScoreProvider, _createURLs(3));
+
+		Assert.assertEquals(
+			PageSpeedScanResult.STATUS_FAILED, pageSpeedScanResult.getStatus());
+		Assert.assertEquals(0, pageSpeedScanResult.getPagesScanned());
+		Assert.assertEquals(3, pageSpeedScanResult.getPagesErrored());
+		Assert.assertEquals(
+			"All pages failed to scan", pageSpeedScanResult.getErrorMessage());
+	}
+
+	@Test
+	public void testScanURLsWithMixedResults() throws Exception {
+		PageSpeedScoreProvider pageSpeedScoreProvider = Mockito.mock(
+			PageSpeedScoreProvider.class);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores("https://example.com/page1")
+		).thenReturn(
+			new PageSpeedScores(80, 90, 70, 60)
+		);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores("https://example.com/page2")
+		).thenThrow(
+			new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+				"Connection error")
+		);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores("https://example.com/page3")
+		).thenReturn(
+			new PageSpeedScores(90, 80, 80, 80)
+		);
+
+		PageSpeedScanResult pageSpeedScanResult = _scanURLs(
+			pageSpeedScoreProvider, _createURLs(3));
+
+		Assert.assertEquals(
+			PageSpeedScanResult.STATUS_COMPLETED,
+			pageSpeedScanResult.getStatus());
+		Assert.assertEquals(2, pageSpeedScanResult.getPagesScanned());
+		Assert.assertEquals(1, pageSpeedScanResult.getPagesErrored());
+		Assert.assertNull(pageSpeedScanResult.getErrorMessage());
+
+		PageSpeedScores pageSpeedScores =
+			pageSpeedScanResult.getAverageScores();
+
+		Assert.assertEquals(85, pageSpeedScores.getAccessibility());
+		Assert.assertEquals(85, pageSpeedScores.getBestPractices());
+		Assert.assertEquals(75, pageSpeedScores.getPerformance());
+		Assert.assertEquals(70, pageSpeedScores.getSeo());
+	}
+
+	@Test
+	public void testScanURLsWithQuotaExceeded() throws Exception {
+		PageSpeedScoreProvider pageSpeedScoreProvider = Mockito.mock(
+			PageSpeedScoreProvider.class);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores("https://example.com/page1")
+		).thenReturn(
+			new PageSpeedScores(80, 90, 70, 60)
+		);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores("https://example.com/page2")
+		).thenThrow(
+			new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+				JSONUtil.put("error", JSONUtil.put("code", 429)),
+				"Quota exceeded")
+		);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores("https://example.com/page3")
+		).thenReturn(
+			new PageSpeedScores(90, 80, 80, 80)
+		);
+
+		PageSpeedScanResult pageSpeedScanResult = _scanURLs(
+			pageSpeedScoreProvider, _createURLs(3));
+
+		Assert.assertEquals(
+			PageSpeedScanResult.STATUS_COMPLETED,
+			pageSpeedScanResult.getStatus());
+		Assert.assertTrue(
+			pageSpeedScanResult.getErrorMessage(
+			).contains(
+				"quota exceeded"
+			));
+	}
+
+	@Test
+	public void testScanURLsWithSuccessfulScan() throws Exception {
+		PageSpeedScoreProvider pageSpeedScoreProvider = Mockito.mock(
+			PageSpeedScoreProvider.class);
+
+		Mockito.when(
+			pageSpeedScoreProvider.getScores(Mockito.anyString())
+		).thenReturn(
+			new PageSpeedScores(80, 90, 70, 60)
+		);
+
+		PageSpeedScanResult pageSpeedScanResult = _scanURLs(
+			pageSpeedScoreProvider, _createURLs(5));
+
+		Assert.assertEquals(
+			PageSpeedScanResult.STATUS_COMPLETED,
+			pageSpeedScanResult.getStatus());
+		Assert.assertEquals(5, pageSpeedScanResult.getPagesScanned());
+		Assert.assertEquals(5, pageSpeedScanResult.getPagesTotal());
+		Assert.assertEquals(0, pageSpeedScanResult.getPagesErrored());
+		Assert.assertNull(pageSpeedScanResult.getErrorMessage());
+
+		PageSpeedScores pageSpeedScores =
+			pageSpeedScanResult.getAverageScores();
+
+		Assert.assertEquals(80, pageSpeedScores.getAccessibility());
+		Assert.assertEquals(90, pageSpeedScores.getBestPractices());
+		Assert.assertEquals(70, pageSpeedScores.getPerformance());
+		Assert.assertEquals(60, pageSpeedScores.getSeo());
+	}
+
+	private List<String> _createURLs(int count) {
+		List<String> urls = new ArrayList<>();
+
+		for (int i = 1; i <= count; i++) {
+			urls.add("https://example.com/page" + i);
+		}
+
+		return urls;
+	}
+
+	private PageSpeedScanResult _scanURLs(
+			PageSpeedScoreProvider pageSpeedScoreProvider, List<String> urls)
+		throws Exception {
+
+		PageSpeedScanner pageSpeedScanner = new PageSpeedScanner();
+
+		Method method = PageSpeedScanner.class.getDeclaredMethod(
+			"_scanURLs", PageSpeedScoreProvider.class, List.class);
+
+		method.setAccessible(true);
+
+		return (PageSpeedScanResult)method.invoke(
+			pageSpeedScanner, pageSpeedScoreProvider, urls);
+	}
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProviderTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProviderTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testIsValidConnection() {
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider("apiKey", "DESKTOP");
+
+		Assert.assertTrue(pageSpeedScoreProvider.isValidConnection());
+	}
+
+	@Test
+	public void testIsValidConnectionWithEmptyAPIKey() {
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider("", "DESKTOP");
+
+		Assert.assertFalse(pageSpeedScoreProvider.isValidConnection());
+	}
+
+	@Test
+	public void testIsValidConnectionWithNullAPIKey() {
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider(null, "DESKTOP");
+
+		Assert.assertFalse(pageSpeedScoreProvider.isValidConnection());
+	}
+
+	@Test
+	public void testQuotaExceededExceptionWithErrorJSON() throws Exception {
+		JSONObject errorJSONObject = JSONUtil.put(
+			"error",
+			JSONUtil.put(
+				"code", 429
+			).put(
+				"message", "Quota exceeded"
+			));
+
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					errorJSONObject, "Quota exceeded");
+
+		Assert.assertTrue(pageSpeedScoreProviderException.isQuotaExceeded());
+		Assert.assertEquals(
+			errorJSONObject,
+			pageSpeedScoreProviderException.
+				getGooglePageSpeedErrorJSONObject());
+	}
+
+	@Test
+	public void testQuotaExceededExceptionWithNonquotaError() throws Exception {
+		JSONObject errorJSONObject = JSONUtil.put(
+			"error",
+			JSONUtil.put(
+				"code", 403
+			).put(
+				"message", "Forbidden"
+			));
+
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					errorJSONObject, "Forbidden");
+
+		Assert.assertFalse(pageSpeedScoreProviderException.isQuotaExceeded());
+	}
+
+	@Test
+	public void testQuotaExceededExceptionWithNullJSON() {
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					"Some error");
+
+		Assert.assertFalse(pageSpeedScoreProviderException.isQuotaExceeded());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

  ### Summary                                                                                                                                                                                                                                            
  - Add seo-studio-pagespeed module for scanning pages via the Google PageSpeed Insights API                                       
  - PageSpeedScoreProvider calls the Google PageSpeed API for a single URL and returns 4 category scores. Handles HTTP 429 quota exceeded detection via error JSON. Uses the fields parameter for thin API responses (~95% smaller)                                                                                                       
  - LiferayHeadlessClient discovers all virtual hosts via the portal-instances API, fetches each domain's sitemap XML, and parses page URLs. Handles both PAGE_LAYOUT and ASSET_TYPE sitemap index modes by following all child sitemaps. Includes recursion depth limit of 3 and early termination when the page limit is reached                                                                
  - PageSpeedScanner orchestrates the scan: gets URLs from the client (capped at 100 pages), runs a 5-thread worker pool against PageSpeedScoreProvider, accumulates scores via AtomicInteger totals, and computes arithmetic mean averages excluding errored pages. Stops all workers on 429 quota exceeded                                                                                 
  - PageSpeedScanResult stores averaged scores, pages scanned/errored/total, error message, and status. The pagesTotal field enables crash detection by consumers (if pagesScanned < pagesTotal with a stale modifiedDate, the scan crashed with results) 

### How it will work with future tasks
The next task will implement the REST endpoint, the consumer, the listener, and the new object. The consumer will update the object with a running average of the scores as pages are scanned using the endpoint. The UI will poll the object to show live scan progress. Currently the Scanner just returns an average once it finishes, since the consumer won't be used without the API.