### PR TITLE
LPD-89408 Use STANDARD cookie spec on OIDC HTTP calls

### DIFF
--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientEntryLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientEntryLocalServiceImpl.java
@@ -347,6 +347,7 @@ public class OAuthClientEntryLocalServiceImpl
 
 			Http.Options httpOptions = new Http.Options();
 
+			httpOptions.setCookieSpec(Http.CookieSpec.STANDARD);
 			httpOptions.setLocation(authServerWellKnownURI);
 
 			_http.URLtoString(httpOptions);

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/test/OAuthClientEntryLocalServiceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/test/OAuthClientEntryLocalServiceTest.java
@@ -18,8 +18,19 @@ import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.OutputStream;
+
+import java.net.InetSocketAddress;
+
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -146,12 +157,87 @@ public class OAuthClientEntryLocalServiceTest {
 				_tokenRequestParametersJSON));
 	}
 
+	@Test
+	public void testAddOAuthClientEntryWithMalformedDiscoveryCookie()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.apache.http.client.protocol.ResponseProcessCookies",
+				LoggerTestUtil.WARN)) {
+
+			HttpServer httpServer = HttpServer.create(
+				new InetSocketAddress("127.0.0.1", 0), 0);
+
+			try {
+				httpServer.createContext(
+					"/",
+					httpExchange -> {
+						httpExchange.getResponseHeaders(
+						).add(
+							"Content-Type", "application/json"
+						);
+
+						httpExchange.getResponseHeaders(
+						).add(
+							"Set-Cookie", _TRACER_COOKIE
+						);
+
+						byte[] bodyBytes = "{}".getBytes(
+							StandardCharsets.UTF_8);
+
+						httpExchange.sendResponseHeaders(200, bodyBytes.length);
+
+						try (OutputStream outputStream =
+								httpExchange.getResponseBody()) {
+
+							outputStream.write(bodyBytes);
+						}
+					});
+
+				httpServer.start();
+
+				int port = httpServer.getAddress(
+				).getPort();
+
+				_oAuthClientEntryLocalService.addOAuthClientEntry(
+					null, TestPropsValues.getUserId(),
+					_authRequestParametersJSON,
+					"http://127.0.0.1:" + port +
+						"/.well-known/openid-configuration",
+					_CUSTOM_CLAIMS_JSON, _infoJSON, "email",
+					OAuthClientEntryConstants.METADATA_CACHE_TIME_DEFAULT,
+					OAuthClientEntryConstants.OIDC_USER_INFO_MAPPER_JSON,
+					_tokenRequestParametersJSON);
+			}
+			finally {
+				httpServer.stop(0);
+			}
+
+			for (LogEntry logEntry : logCapture.getLogEntries()) {
+				String message = logEntry.getMessage();
+
+				if (message.contains("Invalid cookie header") &&
+					message.contains(_TRACER_COOKIE_NAME)) {
+
+					Assert.fail(message);
+				}
+			}
+		}
+	}
+
 	private static final String _AUTH_SERVER_WELL_KNOWN_URI =
 		"https://accounts.google.com/.well-known/openid-configuration";
 
 	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private static final String _CUSTOM_CLAIMS_JSON = "{}";
+
+	private static final String _TRACER_COOKIE =
+		"oauthcliententrylocalservicetest-tracer=1; expires=Fri, 15 May 2026 " +
+			"18:46:54 GMT; path=/; secure; samesite=none; httponly";
+
+	private static final String _TRACER_COOKIE_NAME =
+		"oauthcliententrylocalservicetest-tracer";
 
 	private String _authRequestParametersJSON;
 	private String _infoJSON;

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectHttpUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectHttpUtil.java
@@ -51,6 +51,8 @@ public class OpenIdConnectHttpUtil {
 	private static Http.Options _toHttpOptions(HTTPRequest httpRequest) {
 		Http.Options httpOptions = new Http.Options();
 
+		httpOptions.setCookieSpec(Http.CookieSpec.STANDARD);
+
 		Map<String, List<String>> headerMap = httpRequest.getHeaderMap();
 
 		if (headerMap != null) {

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectHttpUtilTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectHttpUtilTest.java
@@ -85,6 +85,8 @@ public class OpenIdConnectHttpUtilTest {
 
 		Assert.assertNull(httpOptions.getBody());
 		Assert.assertEquals(
+			Http.CookieSpec.STANDARD, httpOptions.getCookieSpec());
+		Assert.assertEquals(
 			authorization, httpOptions.getHeader("Authorization"));
 		Assert.assertEquals(userInfoURL.toString(), httpOptions.getLocation());
 		Assert.assertFalse(httpOptions.isPost());

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/internal/test/OpenIdConnectHttpUtilTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/internal/test/OpenIdConnectHttpUtilTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.OutputStream;
+
+import java.lang.reflect.Method;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Christian Moura
+ */
+@RunWith(Arquillian.class)
+public class OpenIdConnectHttpUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testSend() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.apache.http.client.protocol.ResponseProcessCookies",
+				LoggerTestUtil.WARN)) {
+
+			HttpServer httpServer = HttpServer.create(
+				new InetSocketAddress("127.0.0.1", 0), 0);
+
+			try {
+				httpServer.createContext(
+					"/",
+					httpExchange -> {
+						httpExchange.getResponseHeaders(
+						).add(
+							"Content-Type", "application/json"
+						);
+
+						httpExchange.getResponseHeaders(
+						).add(
+							"Set-Cookie", _TRACER_COOKIE
+						);
+
+						byte[] bodyBytes = "{}".getBytes(
+							StandardCharsets.UTF_8);
+
+						httpExchange.sendResponseHeaders(200, bodyBytes.length);
+
+						try (OutputStream outputStream =
+								httpExchange.getResponseBody()) {
+
+							outputStream.write(bodyBytes);
+						}
+					});
+
+				httpServer.start();
+
+				Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+				Bundle implBundle = null;
+
+				for (Bundle candidateBundle :
+						bundle.getBundleContext(
+						).getBundles()) {
+
+					if (Objects.equals(
+							_IMPL_BUNDLE_SYMBOLIC_NAME,
+							candidateBundle.getSymbolicName())) {
+
+						implBundle = candidateBundle;
+
+						break;
+					}
+				}
+
+				Assert.assertNotNull(
+					"Unable to locate the OpenID Connect impl bundle",
+					implBundle);
+
+				Class<?> openIdConnectHttpUtilClass = implBundle.loadClass(
+					"com.liferay.portal.security.sso.openid.connect.internal." +
+						"util.OpenIdConnectHttpUtil");
+
+				Method sendMethod = openIdConnectHttpUtilClass.getMethod(
+					"send", HTTPRequest.class);
+
+				int port = httpServer.getAddress(
+				).getPort();
+
+				sendMethod.invoke(
+					null,
+					new HTTPRequest(
+						HTTPRequest.Method.GET,
+						new URL("http://127.0.0.1:" + port + "/userinfo")));
+			}
+			finally {
+				httpServer.stop(0);
+			}
+
+			for (LogEntry logEntry : logCapture.getLogEntries()) {
+				String message = logEntry.getMessage();
+
+				if (message.contains("Invalid cookie header") &&
+					message.contains(_TRACER_COOKIE_NAME)) {
+
+					Assert.fail(message);
+				}
+			}
+		}
+	}
+
+	private static final String _IMPL_BUNDLE_SYMBOLIC_NAME =
+		"com.liferay.portal.security.sso.openid.connect.impl";
+
+	private static final String _TRACER_COOKIE =
+		"openidconnecthttputiltest-tracer=1; expires=Fri, 15 May 2026 " +
+			"18:46:54 GMT; path=/; secure; samesite=none; httponly";
+
+	private static final String _TRACER_COOKIE_NAME =
+		"openidconnecthttputiltest-tracer";
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89408

## What is being fixed

During portal startup, Apache HttpClient emits "Invalid cookie header" WARN entries when an Identity Provider returns a `Set-Cookie` header containing an RFC 1123 `Expires` attribute (the standard "Expires=Fri, 15 May 2026 18:46:54 GMT" form). The default Apache HttpClient cookie policy is strict about cookie date formats and rejects RFC 1123 as malformed, even though the rest of the world treats it as valid. The OIDC code paths in `OAuthClientEntryLocalServiceImpl` (discovery endpoint fetch) and `OpenIdConnectHttpUtil` (token and userinfo calls) inherit that strict default and surface the warning.

## How it is being fixed

Both OIDC HTTP code paths opt into `Http.CookieSpec.STANDARD`, which parses RFC 1123 `Expires` attributes silently. The fix is a one-line `setCookieSpec` call at the two call sites. Coverage is added at two levels: a one-assertion extension to the existing `OpenIdConnectHttpUtilTest` unit test pins the enum value, and two integration tests drive the real Apache HttpClient through an embedded HTTP server returning a tracer cookie with an RFC 1123 `Expires`, asserting via `LogCapture` that the `ResponseProcessCookies` logger emits no `Invalid cookie header` WARN tagged with the tracer cookie.