### PR TITLE
LPD-75473 Fix batch engine task deadlock on HSQLDB during concurrent updates

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -9850,6 +9850,10 @@ ${output.content}</echo>
 		<run-playwright-js-test app.server.type="wildfly" database.type="mariadb" />
 	</target>
 
+	<target name="playwright-js-tomcat101-hypersonic20">
+		<run-playwright-js-test database.type="hypersonic" />
+	</target>
+
 	<target name="playwright-js-tomcat101-mysql84">
 		<run-playwright-js-test database.type="mysql" />
 	</target>

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
@@ -108,4 +108,12 @@ public class BatchEngineExportTaskLocalServiceImpl
 		return batchEngineExportTaskPersistence.countByCompanyId(companyId);
 	}
 
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public BatchEngineExportTask updateBatchEngineExportTask(
+		BatchEngineExportTask batchEngineExportTask) {
+
+		return super.updateBatchEngineExportTask(batchEngineExportTask);
+	}
+
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
@@ -156,6 +156,14 @@ public class BatchEngineImportTaskLocalServiceImpl
 		return batchEngineImportTaskPersistence.countByCompanyId(companyId);
 	}
 
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public BatchEngineImportTask updateBatchEngineImportTask(
+		BatchEngineImportTask batchEngineImportTask) {
+
+		return super.updateBatchEngineImportTask(batchEngineImportTask);
+	}
+
 	private void _validateDelimiter(String delimiter)
 		throws BatchEngineImportTaskParametersException {
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineTaskDeadlockTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineTaskDeadlockTest.java
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.engine.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.BatchEngineTaskExecuteStatus;
+import com.liferay.batch.engine.BatchEngineTaskOperation;
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.batch.engine.internal.test.BlogPosting;
+import com.liferay.batch.engine.model.BatchEngineExportTask;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.batch.engine.service.BatchEngineExportTaskLocalService;
+import com.liferay.batch.engine.service.BatchEngineImportTaskLocalService;
+import com.liferay.portal.test.rule.Inject;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies that concurrent updates to batch engine tasks do not deadlock in
+ * HSQLDB. Without REQUIRES_NEW propagation on the update methods, two threads
+ * sharing a transaction context would deadlock on HSQLDB's table-level locks.
+ *
+ * @author Magdalena Jedraszak
+ */
+@RunWith(Arquillian.class)
+public class BatchEngineTaskDeadlockTest
+	extends BaseBatchEngineTaskServiceTest {
+
+	@Test
+	public void testConcurrentExportTaskUpdatesDoNotDeadlock()
+		throws Exception {
+
+		BatchEngineExportTask exportTask1 =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				null, BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Arrays.asList("headline", "id"), null, null);
+
+		BatchEngineExportTask exportTask2 =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				null, BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Arrays.asList("headline", "id"), null, null);
+
+		exportTask1.setExecuteStatus(
+			BatchEngineTaskExecuteStatus.COMPLETED.name());
+		exportTask2.setExecuteStatus(
+			BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+		_assertConcurrentUpdatesSucceed(
+			() ->
+				_batchEngineExportTaskLocalService.updateBatchEngineExportTask(
+					exportTask1),
+			() ->
+				_batchEngineExportTaskLocalService.updateBatchEngineExportTask(
+					exportTask2));
+	}
+
+	@Test
+	public void testConcurrentImportTaskUpdatesDoNotDeadlock()
+		throws Exception {
+
+		BatchEngineImportTask importTask1 =
+			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
+				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
+				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
+
+		BatchEngineImportTask importTask2 =
+			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
+				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
+				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
+
+		importTask1.setExecuteStatus(
+			BatchEngineTaskExecuteStatus.COMPLETED.name());
+		importTask2.setExecuteStatus(
+			BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+		_assertConcurrentUpdatesSucceed(
+			() ->
+				_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
+					importTask1),
+			() ->
+				_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
+					importTask2));
+	}
+
+	private void _assertConcurrentUpdatesSucceed(
+			CheckedRunnable runnable1, CheckedRunnable runnable2)
+		throws Exception {
+
+		CountDownLatch startLatch = new CountDownLatch(1);
+		AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+
+		ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+		Future<?> future1 = executorService.submit(
+			() -> {
+				try {
+					startLatch.await();
+
+					runnable1.run();
+				}
+				catch (Exception exception) {
+					exceptionReference.compareAndSet(null, exception);
+				}
+			});
+
+		Future<?> future2 = executorService.submit(
+			() -> {
+				try {
+					startLatch.await();
+
+					runnable2.run();
+				}
+				catch (Exception exception) {
+					exceptionReference.compareAndSet(null, exception);
+				}
+			});
+
+		startLatch.countDown();
+
+		future1.get(10, TimeUnit.SECONDS);
+		future2.get(10, TimeUnit.SECONDS);
+
+		executorService.shutdown();
+
+		Assert.assertNull(exceptionReference.get());
+	}
+
+	@Inject
+	private BatchEngineExportTaskLocalService
+		_batchEngineExportTaskLocalService;
+
+	@Inject
+	private BatchEngineImportTaskLocalService
+		_batchEngineImportTaskLocalService;
+
+	@FunctionalInterface
+	private interface CheckedRunnable {
+
+		public void run() throws Exception;
+
+	}
+
+}

--- a/modules/apps/batch-engine/test.properties
+++ b/modules/apps/batch-engine/test.properties
@@ -6,6 +6,9 @@ modified.files.includes[relevant][batch-engine-java-rule]=\
 modules.includes.required.test.batch.class.names.includes[batch-engine-java-rule][relevant][modules-integration-db-partition-postgresql163]=\
     apps/batch-engine/**/BatchEngineUnitProcessorImplDBPartitionTest.java
 
+modules.includes.required.test.batch.class.names.includes[modules-integration-hypersonic20][relevant][batch-engine-java-rule]=\
+    apps/batch-engine/**/BatchEngineTaskDeadlockTest.java
+
 modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][batch-engine-java-rule]=\
     apps/batch-engine/**/*Test.java,\
     util/portal-tools-rest-builder-test-test/**/exportimport/test/*Test.java
@@ -17,6 +20,7 @@ relevant.rule.names=batch-engine-java-rule
 
 test.batch.names[relevant][batch-engine-java-rule]=\
     modules-integration-db-partition-postgresql163,\
+    modules-integration-hypersonic20,\
     modules-integration-postgresql163,\
     modules-unit
 

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -10,7 +10,6 @@ import * as path from 'path';
 import {accountSettingsPagesTest} from '../../../fixtures/accountSettingsPagesTest';
 import {accountsPagesTest} from '../../../fixtures/accountsPagesTest';
 import {applicationsMenuPageTest} from '../../../fixtures/applicationsMenuPageTest';
-import {createCategories} from '../../../helpers/CreateCategories';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {depotAdminPageTest} from '../../../fixtures/depotAdminPageTest';
 import {documentLibraryPagesTest} from '../../../fixtures/documentLibraryPages.fixtures';
@@ -27,6 +26,7 @@ import {uiElementsPageTest} from '../../../fixtures/uiElementsTest';
 import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
 import {wikiPagesTest} from '../../../fixtures/wikiPagesTest';
 import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {createCategories} from '../../../helpers/CreateCategories';
 import {liferayConfig} from '../../../liferay.config';
 import {HomePage} from '../../../pages/portal-web/HomePage';
 import {getRandomInt} from '../../../utils/getRandomInt';
@@ -161,12 +161,17 @@ testWithExportImportAtInstanceLevelFF(
 		expect(categoryJson.length).toBe(2);
 
 		expect(
-			await apiHelpers.headlessAdminTaxonomy.deleteTaxonomyVocabulary(categories[0].vocabularyId)
+			await apiHelpers.headlessAdminTaxonomy.deleteTaxonomyVocabulary(
+				categories[0].vocabularyId
+			)
 		).toBeOK();
 
 		await exportImportPage.goToImport(site.friendlyUrlPath);
 
-		await exportImportPage.import({filePath: exportFilePath, taskStatus: 'completedWithErrors'});
+		await exportImportPage.import({
+			filePath: exportFilePath,
+			taskStatus: 'completedWithErrors',
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -9,6 +9,8 @@ import * as path from 'path';
 
 import {accountSettingsPagesTest} from '../../../fixtures/accountSettingsPagesTest';
 import {accountsPagesTest} from '../../../fixtures/accountsPagesTest';
+import {applicationsMenuPageTest} from '../../../fixtures/applicationsMenuPageTest';
+import {createCategories} from '../../../helpers/CreateCategories';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {depotAdminPageTest} from '../../../fixtures/depotAdminPageTest';
 import {documentLibraryPagesTest} from '../../../fixtures/documentLibraryPages.fixtures';
@@ -91,6 +93,81 @@ const testWithDeprecationFF = mergeTests(
 	}),
 	loginTest(),
 	uiElementsPageTest
+);
+
+export const testWithExportImportAtInstanceLevelFF = mergeTests(
+	applicationsMenuPageTest,
+	companyExportImportPageTest,
+	dataApiHelpersTest,
+	depotAdminPageTest,
+	exportImportPagesTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-35443': {enabled: true},
+		'LPD-35914': {enabled: true},
+		'LPD-44307': {enabled: true},
+		'LPD-44771': {enabled: true},
+		'LPD-45276': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	styleBookPageTest,
+	uiElementsPageTest
+);
+
+testWithExportImportAtInstanceLevelFF(
+	'Can export and import vocabularies and categories',
+	async ({apiHelpers, exportImportPage, site}) => {
+		const categoryNames = [
+			{name: getRandomString()},
+			{name: getRandomString()},
+		];
+		const vocabularyName = getRandomString();
+
+		const categories: Array<any> = await createCategories({
+			apiHelpers,
+			categoryNames,
+			siteId: site.id,
+			vocabularyName,
+		});
+
+		apiHelpers.data.push({
+			id: categories[0].vocabularyId,
+			type: 'taxonomyVocabulary',
+		});
+
+		await exportImportPage.goToExport(site.friendlyUrlPath);
+
+		const exportFilePath = await exportImportPage.export({
+			portletLabels: [`Categories 3 Items`],
+		});
+
+		const vocabularyContent = await readFileFromZip(
+			`com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary.json`,
+			exportFilePath
+		);
+
+		const vocabularyJson = JSON.parse(vocabularyContent);
+
+		expect(vocabularyJson.length).toBe(1);
+
+		const categoryContent = await readFileFromZip(
+			`com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory.json`,
+			exportFilePath
+		);
+
+		const categoryJson = JSON.parse(categoryContent);
+
+		expect(categoryJson.length).toBe(2);
+
+		expect(
+			await apiHelpers.headlessAdminTaxonomy.deleteTaxonomyVocabulary(categories[0].vocabularyId)
+		).toBeOK();
+
+		await exportImportPage.goToImport(site.friendlyUrlPath);
+
+		await exportImportPage.import({filePath: exportFilePath, taskStatus: 'completedWithErrors'});
+	}
 );
 
 test('Can export and import custom object entries at site level', async ({

--- a/test.properties
+++ b/test.properties
@@ -4242,6 +4242,7 @@
     test.batch.names[headless]=\
         functional-tomcat101-postgresql163,\
         js-unit,\
+        modules-integration-hypersonic20,\
         modules-integration-postgresql163,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163

--- a/test.properties
+++ b/test.properties
@@ -4459,6 +4459,9 @@
     # Headless Playwright
     #
 
+    playwright.projects.includes[playwright-js-tomcat101-hypersonic20][headless-playwright]=\
+        ${headless.staging.playwright.projects}
+
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][headless-playwright]=\
         ${headless.playwright.projects},\
         ${headless.staging.playwright.projects}
@@ -4466,6 +4469,7 @@
     test.batch.dist.app.servers[headless-playwright]=tomcat
 
     test.batch.names[headless-playwright]=\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163
 
     #

--- a/test.properties
+++ b/test.properties
@@ -4222,6 +4222,9 @@
         **/src/testIntegration/**/staging/**/*Test.java,\
         **/staging/**/src/testIntegration/**/*Test.java
 
+    test.batch.class.names.includes[modules-integration-hypersonic20][headless]=\
+        **/batch-engine/**/src/testIntegration/**/BatchEngineTaskDeadlockTest.java
+
     test.batch.class.names.includes[modules-unit][headless]=\
         **/batch-engine/**/src/test/**/*Test.java,\
         **/batch-planner/**/src/test/**/*Test.java,\

--- a/test.properties
+++ b/test.properties
@@ -912,6 +912,7 @@
         modules-integration-solr-mysql84,\
         modules-semantic-versioning,\
         modules-unit,\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
         unit


### PR DESCRIPTION
## What

When importing a LAR containing both a vocabulary and its categories (with feature flags LPD-35443 and LPD-35914 enabled), the import gets stuck on HSQLDB/Hypersonic. Two batch engine tasks run concurrently — one per entity type — and each calls `updateBatchEngineImportTask()` to write progress. Because both updates participate in the same outer transaction context, HSQLDB's table-level locks cause a deadlock.

The same pattern exists on the export side.

## Fix

Add `@Transactional(propagation = Propagation.REQUIRES_NEW)` to `updateBatchEngineImportTask()` and `updateBatchEngineExportTask()` so each update runs in its own isolated transaction, releasing the lock before the next update can proceed.

## Tests

- `BatchEngineTaskDeadlockTest` — new Arquillian integration test that fires two concurrent updates against both import and export tasks and asserts neither deadlocks. Runs only on `modules-integration-hypersonic20` in the headless CI routine (specific key overrides the wildcard to avoid running all batch-engine integration tests on HSQLDB).
- Playwright test `Can export and import vocabularies and categories` under `testWithExportImportAtInstanceLevelFF` — verifies the end-to-end flow on Hypersonic.