### PR TITLE
LPD-91368 Switch Time Viewed to days past 24h

### DIFF
--- a/modules/apps/site/site-dsr-site-initializer/src/main/resources/META-INF/resources/js/main_view/analytics/components/RoomStatistics.tsx
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/resources/META-INF/resources/js/main_view/analytics/components/RoomStatistics.tsx
@@ -27,8 +27,14 @@ const formatTime = (minutes?: number): string => {
 
 	const duration = moment.duration(minutes, 'minutes');
 
-	const hours = Math.floor(duration.asHours());
+	const days = Math.floor(duration.asDays());
+	const hours = duration.hours();
 	const mins = duration.minutes();
+
+	const daysLabel =
+		days === 1
+			? Liferay.Language.get('1-day').toLowerCase()
+			: sub(Liferay.Language.get('x-days'), [days]).toLowerCase();
 
 	const hoursLabel =
 		hours === 1
@@ -39,6 +45,14 @@ const formatTime = (minutes?: number): string => {
 		mins === 1
 			? Liferay.Language.get('1-minute').toLowerCase()
 			: sub(Liferay.Language.get('x-minutes'), [mins]).toLowerCase();
+
+	if (days > 0) {
+		if (hours === 0) {
+			return daysLabel;
+		}
+
+		return `${daysLabel} ${hoursLabel}`;
+	}
 
 	return `${hoursLabel} ${minutesLabel}`;
 };

--- a/modules/apps/site/site-dsr-site-initializer/test/js/components/RoomStatistics.spec.tsx
+++ b/modules/apps/site/site-dsr-site-initializer/test/js/components/RoomStatistics.spec.tsx
@@ -8,16 +8,25 @@ import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
 import RoomStatistics from '../../../src/main/resources/META-INF/resources/js/main_view/analytics/components/RoomStatistics';
+import {roomStatisticsDevEnvData} from '../fixtures/analyticsDevEnvData';
 
 const {Liferay: originalLiferay} = global.window;
 
 const mockLiferayLanguageGet = jest.fn((key: string) => {
+	if (key === '1-day') {
+		return '1 day';
+	}
+
 	if (key === '1-hour') {
 		return '1 hour';
 	}
 
 	if (key === '1-minute') {
 		return '1 minute';
+	}
+
+	if (key === 'x-days') {
+		return 'x days';
 	}
 
 	if (key === 'x-hours') {
@@ -56,23 +65,27 @@ jest.mock(
 	})
 );
 
+let mockAnalyticsResponse: any;
+
 jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/common/hooks/useAnalyticsQuery',
-	() => {
-		const {
-			roomStatisticsDevEnvData,
-		} = require('../fixtures/analyticsDevEnvData');
-
-		return {
-			__esModule: true,
-			default: jest.fn(() => ({
-				isLoading: false,
-				response: roomStatisticsDevEnvData,
-				sendRequest: jest.fn(),
-			})),
-		};
-	}
+	() => ({
+		__esModule: true,
+		default: jest.fn(() => ({
+			isLoading: false,
+			response: mockAnalyticsResponse,
+			sendRequest: jest.fn(),
+		})),
+	})
 );
+
+const withTotalSessionDuration = (totalSessionDuration: number) => ({
+	...roomStatisticsDevEnvData,
+	siteVisitorBehavior: {
+		...roomStatisticsDevEnvData.siteVisitorBehavior,
+		totalSessionDuration,
+	},
+});
 
 describe('RoomStatistics', () => {
 	beforeAll(() => {
@@ -127,6 +140,10 @@ describe('RoomStatistics', () => {
 		jest.resetAllMocks();
 	});
 
+	beforeEach(() => {
+		mockAnalyticsResponse = roomStatisticsDevEnvData;
+	});
+
 	it('matches snapshot', () => {
 		const {container} = render(<RoomStatistics />);
 
@@ -141,5 +158,37 @@ describe('RoomStatistics', () => {
 		expect(getByText('20')).toBeInTheDocument();
 		expect(getByText('10')).toBeInTheDocument();
 		expect(getByText('5')).toBeInTheDocument();
+	});
+
+	it('renders 1-day when totalSessionDuration is exactly 24h', () => {
+		mockAnalyticsResponse = withTotalSessionDuration(24 * 60);
+
+		const {getByText} = render(<RoomStatistics />);
+
+		expect(getByText('1-day')).toBeInTheDocument();
+	});
+
+	it('renders days and hours when totalSessionDuration is 25h30', () => {
+		mockAnalyticsResponse = withTotalSessionDuration(25 * 60 + 30);
+
+		const {getByText} = render(<RoomStatistics />);
+
+		expect(getByText('1-day 1-hour')).toBeInTheDocument();
+	});
+
+	it('renders days only when totalSessionDuration is exactly 48h', () => {
+		mockAnalyticsResponse = withTotalSessionDuration(48 * 60);
+
+		const {getByText} = render(<RoomStatistics />);
+
+		expect(getByText('2-days')).toBeInTheDocument();
+	});
+
+	it('renders days and hours when totalSessionDuration is 50h15', () => {
+		mockAnalyticsResponse = withTotalSessionDuration(50 * 60 + 15);
+
+		const {getByText} = render(<RoomStatistics />);
+
+		expect(getByText('2-days 2-hours')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Change `formatTime` in the DSR Room Statistics widget so that once the cumulative session duration reaches 24h the label switches from `X hours Y minutes` to `X days Y hours` (or `X days` when hours overflow is zero).
- Below 24h the existing output is unchanged. No new language keys (`1-day` and `x-days` already exist).

## Test plan

- [x] `yarn test components/RoomStatistics` — 6/6 pass, including 4 new cases covering 24h, 25h30, 48h, 50h15.
- [ ] Manual UI verification on a DSR-enabled bundle: seed AC so that the visible-range `totalSessionDuration >= 1440` minutes on a Room and confirm the Room Statistics widget renders the days-based label.