### PR TITLE
LPD-91697 Fix IDOR in workflow task assignment across virtual instances

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
@@ -124,6 +124,15 @@ public class WorkflowTaskManagerImpl implements WorkflowTaskManager {
 				ActionKeys.VIEW);
 		}
 
+		User assigneeUser = _userLocalService.fetchUser(assigneeUserId);
+
+		if ((assigneeUser == null) ||
+			(assigneeUser.getCompanyId() != companyId)) {
+
+			throw new PrincipalException.MustHavePermission(
+				userId, User.class.getName(), assigneeUserId, ActionKeys.VIEW);
+		}
+
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setCompanyId(companyId);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermission.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermission.java
@@ -65,6 +65,12 @@ public class KaleoTaskModelResourcePermission
 			KaleoTaskInstanceToken kaleoTaskInstanceToken, String actionId)
 		throws PortalException {
 
+		if (kaleoTaskInstanceToken.getCompanyId() !=
+				permissionChecker.getCompanyId()) {
+
+			return false;
+		}
+
 		WorkflowTask workflowTask = _kaleoWorkflowModelConverter.toWorkflowTask(
 			kaleoTaskInstanceToken,
 			WorkflowContextUtil.convert(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.runtime.integration.internal;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.permission.SimplePermissionChecker;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Roselaine Marques
+ */
+public class WorkflowTaskManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_userLocalService = Mockito.mock(UserLocalService.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_workflowTaskManagerImpl, "_userLocalService", _userLocalService);
+
+		PermissionThreadLocal.setPermissionChecker(
+			_mockPermissionChecker(_USER_ID));
+	}
+
+	@After
+	public void tearDown() {
+		PermissionThreadLocal.setPermissionChecker(null);
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserBelongsToDifferentVirtualInstance()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+		long assigneeUserId = RandomTestUtil.randomLong();
+
+		User assigneeUser = Mockito.mock(User.class);
+
+		Mockito.when(
+			assigneeUser.getCompanyId()
+		).thenReturn(
+			companyId + 1
+		);
+
+		Mockito.when(
+			_userLocalService.fetchUser(assigneeUserId)
+		).thenReturn(
+			assigneeUser
+		);
+
+		_workflowTaskManagerImpl.assignWorkflowTaskToUser(
+			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId,
+			null, null, null);
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserDoesNotExist()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+
+		long assigneeUserId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_userLocalService.fetchUser(assigneeUserId)
+		).thenReturn(
+			null
+		);
+
+		_workflowTaskManagerImpl.assignWorkflowTaskToUser(
+			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId,
+			null, null, null);
+	}
+
+	private PermissionChecker _mockPermissionChecker(long userId) {
+		return new SimplePermissionChecker() {
+
+			@Override
+			public long getUserId() {
+				return userId;
+			}
+
+		};
+	}
+
+	private static final long _USER_ID = RandomTestUtil.randomLong();
+
+	private UserLocalService _userLocalService;
+	private final WorkflowTaskManagerImpl _workflowTaskManagerImpl =
+		new WorkflowTaskManagerImpl();
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.runtime.integration.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.permission.SimplePermissionChecker;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Roselaine Marques
+ */
+public class KaleoTaskModelResourcePermissionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContainsFalseWhenKaleoTaskInstanceTokenBelongsToDifferentVirtualInstance()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken = Mockito.mock(
+			KaleoTaskInstanceToken.class);
+
+		Mockito.when(
+			kaleoTaskInstanceToken.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Assert.assertFalse(
+			_kaleoTaskModelResourcePermission.contains(
+				_mockPermissionChecker(companyId + 1), kaleoTaskInstanceToken,
+				null));
+	}
+
+	private PermissionChecker _mockPermissionChecker(long companyId) {
+		return new SimplePermissionChecker() {
+
+			@Override
+			public long getCompanyId() {
+				return companyId;
+			}
+
+			@Override
+			public User getUser() {
+				return _user;
+			}
+
+		};
+	}
+
+	private static final User _user = Mockito.mock(User.class);
+
+	private final KaleoTaskModelResourcePermission
+		_kaleoTaskModelResourcePermission =
+			new KaleoTaskModelResourcePermission();
+
+}


### PR DESCRIPTION
## Summary

- `KaleoTaskModelResourcePermission.contains()` now rejects tasks whose `companyId` does not match the requesting user's virtual instance, closing an IDOR that let a cross-instance admin pass the permission check.
- `WorkflowTaskManagerImpl.assignWorkflowTaskToUser()` now validates that the assignee user exists and belongs to the same company as the task, closing an IDOR that allowed assigning tasks to users from foreign virtual instances.
- Tests cover both rejection paths (different company, non-existent user) and the same-company pass-through for each fix.

## Test plan

- [ ] `KaleoTaskModelResourcePermissionTest` — `testContainsFalseWhenKaleoTaskInstanceTokenBelongsToDifferentVirtualInstance`, `testContainsTrueWhenKaleoTaskInstanceTokenBelongsToSameVirtualInstance`
- [ ] `WorkflowTaskManagerImplTest` — `testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserBelongsToDifferentVirtualInstance`, `testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserDoesNotExist`, `testAssignWorkflowTaskToUserWhenAssigneeUserBelongsToSameVirtualInstance`