### PR TITLE
LPD-92077

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/ActionUtilTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/ActionUtilTest.java
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.exception.NoSuchFolderException;
+import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.settings.ModifiableSettings;
+import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Ankita Malik
+ */
+@RunWith(Arquillian.class)
+public class ActionUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(ActionUtilTest.class);
+
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.document.library.web");
+
+		Class<?> actionUtilClass = bundle.loadClass(
+			"com.liferay.document.library.web.internal.portlet.action." +
+				"ActionUtil");
+
+		_getFolderMethod = actionUtilClass.getDeclaredMethod(
+			"getFolder", HttpServletRequest.class);
+
+		Class<?> dlPortletInstanceSettingsClass = bundle.loadClass(
+			"com.liferay.document.library.web.internal.settings." +
+				"DLPortletInstanceSettings");
+
+		_dlPortletInstanceSettingsConstructor =
+			dlPortletInstanceSettingsClass.getConstructor(Settings.class);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-92077")
+	public void testGetFolderRejectsFolderOutsideConfiguredRootFolder()
+		throws Exception {
+
+		Folder rootFolder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		Folder outsideFolder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"folderId", String.valueOf(outsideFolder.getFolderId()));
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _createThemeDisplay());
+
+		mockHttpServletRequest.setAttribute(
+			_DOCUMENT_LIBRARY_PORTLET_INSTANCE_SETTINGS_ATTRIBUTE,
+			_dlPortletInstanceSettingsConstructor.newInstance(
+				_createSettings(rootFolder.getExternalReferenceCode())));
+
+		try {
+			_getFolderMethod.invoke(null, mockHttpServletRequest);
+
+			Assert.fail(
+				"ActionUtil.getFolder should reject a folderId outside the " +
+					"configured root folder");
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			Throwable throwable = invocationTargetException.getCause();
+
+			Assert.assertTrue(
+				"Expected NoSuchFolderException but got " + throwable,
+				throwable instanceof NoSuchFolderException);
+		}
+	}
+
+	private Settings _createSettings(String rootFolderExternalReferenceCode) {
+		return new Settings() {
+
+			@Override
+			public ModifiableSettings getModifiableSettings() {
+				return null;
+			}
+
+			@Override
+			public Settings getParentSettings() {
+				return null;
+			}
+
+			@Override
+			public String getValue(String key, String defaultValue) {
+				if (key.equals("rootFolderExternalReferenceCode")) {
+					return rootFolderExternalReferenceCode;
+				}
+
+				return defaultValue;
+			}
+
+			@Override
+			public String[] getValues(String key, String[] defaultValue) {
+				return defaultValue;
+			}
+
+		};
+	}
+
+	private ThemeDisplay _createThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
+	private static final String
+		_DOCUMENT_LIBRARY_PORTLET_INSTANCE_SETTINGS_ATTRIBUTE =
+			"DOCUMENT_LIBRARY_PORTLET_INSTANCE_SETTINGS";
+
+	private static Constructor<?> _dlPortletInstanceSettingsConstructor;
+	private static Method _getFolderMethod;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
@@ -9,6 +9,7 @@ import com.liferay.document.library.constants.DLFileVersionPreviewConstants;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.exception.NoSuchFileShortcutException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.processor.RawMetadataProcessorUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.service.DLFileVersionPreviewLocalServiceUtil;
@@ -205,18 +206,20 @@ public class ActionUtil {
 		boolean ignoreRootFolder = ParamUtil.getBoolean(
 			httpServletRequest, "ignoreRootFolder");
 
+		long rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+				new DLPortletInstanceSettingsHelper(
+					new DLRequestHelper(httpServletRequest));
+
+			rootFolderId = dlPortletInstanceSettingsHelper.getRootFolderId();
+		}
+
 		if ((folderId <= 0) && !ignoreRootFolder) {
-			try (SafeCloseable safeCloseable =
-					CTCollectionThreadLocal.
-						setProductionModeWithSafeCloseable()) {
-
-				DLPortletInstanceSettingsHelper
-					dlPortletInstanceSettingsHelper =
-						new DLPortletInstanceSettingsHelper(
-							new DLRequestHelper(httpServletRequest));
-
-				folderId = dlPortletInstanceSettingsHelper.getRootFolderId();
-			}
+			folderId = rootFolderId;
 		}
 
 		if (folderId <= 0) {
@@ -228,6 +231,12 @@ public class ActionUtil {
 		}
 
 		Folder folder = DLAppServiceUtil.getFolder(folderId);
+
+		if ((rootFolderId > 0) && (folderId != rootFolderId) &&
+			!_isDescendantOfRootFolder(folder, rootFolderId)) {
+
+			throw new NoSuchFolderException("{folderId=" + folderId + "}");
+		}
 
 		DLFolderUtil.validateDepotFolder(
 			folderId, folder.getGroupId(), themeDisplay.getScopeGroupId());
@@ -310,6 +319,25 @@ public class ActionUtil {
 		throws PortalException {
 
 		return getRepository(PortalUtil.getHttpServletRequest(portletRequest));
+	}
+
+	private static boolean _isDescendantOfRootFolder(
+			Folder folder, long rootFolderId)
+		throws PortalException {
+
+		long parentFolderId = folder.getParentFolderId();
+
+		while (parentFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			if (parentFolderId == rootFolderId) {
+				return true;
+			}
+
+			Folder parentFolder = DLAppServiceUtil.getFolder(parentFolderId);
+
+			parentFolderId = parentFolder.getParentFolderId();
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(ActionUtil.class);


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-92077](https://liferay.atlassian.net/browse/LPD-92077)}

Restrict access so that only folders within the configured root folder can be accessed, and prevent requests from reaching folders outside that allowed hierarchy.

# How am I fixing it?

Capture the configured root folder upfront and validate that the requested folder belongs to the same folder tree before allowing access. If the folder falls outside the configured root hierarchy, treat it as inaccessible.

[LPD-92077]: https://liferay.atlassian.net/browse/LPD-92077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ