### PR TITLE
LPD-90363 Preserve custom friendly URL when layout omits the field

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -9121,7 +9121,11 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testPatchObjectEntryWithFriendlyURL() throws Exception {
+	public void testPatchObjectEntryWithFriendlyURLCustomizationEnabled()
+		throws Exception {
+
+		// With friendly URL
+
 		_objectDefinition1.setEnableFriendlyURLCustomization(true);
 
 		_objectDefinition1 =
@@ -9147,6 +9151,34 @@ public class ObjectEntryResourceTest {
 
 		Assert.assertEquals(
 			"test-url", jsonObject.getString("friendlyUrlPath"));
+
+		// Without friendly URL
+
+		String friendlyURL = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+		String objectFieldValue = RandomTestUtil.randomString();
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, objectFieldValue
+			).put(
+				"friendlyUrlPath_i18n",
+				HashMapBuilder.put(
+					"en_US", friendlyURL
+				).build()
+			).toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, objectFieldValue
+			).toString(),
+			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
+				jsonObject.getString("id"),
+			Http.Method.PATCH);
+
+		Assert.assertEquals(
+			friendlyURL, jsonObject.getString("friendlyUrlPath"));
 	}
 
 	@Test

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
@@ -355,7 +355,7 @@ if (ParamUtil.getBoolean(request, "showHeader", true)) {
 								'[data-field-name="friendlyURL"]'
 							);
 
-							if (friendlyURLInputs) {
+							if (friendlyURLInputs.length > 0) {
 								const friendlyURLValues = {};
 
 								friendlyURLInputs.forEach((input) => {

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -6234,3 +6234,121 @@ test.describe('Manage object entries through Workflow', () => {
 		}
 	);
 });
+
+test.describe('Manage object entries with custom Object Layout', () => {
+	test(
+		'verify that friendly URL is preserved when updating an entry through a custom layout without the Friendly URL field',
+		{tag: ['@LPD-90363']},
+		async ({
+			apiHelpers,
+			objectLayoutsPage,
+			page,
+			viewObjectEntriesPage,
+		}) => {
+			test.slow();
+
+			const objectDefinitionLabel =
+				'ObjectDefinitionLabel' + getRandomInt();
+			const objectDefinitionName =
+				'ObjectDefinitionName' + getRandomInt();
+
+			const objectFields = generateObjectFields({
+				objectFieldBusinessTypes: ['Text'],
+			});
+
+			const objectField = objectFields[0];
+
+			const objectDefinitionAPIClient =
+				await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+			const {body: objectDefinition} =
+				await objectDefinitionAPIClient.postObjectDefinition({
+					active: true,
+					enableFriendlyURLCustomization: true,
+					label: {
+						en_US: objectDefinitionLabel,
+					},
+					name: objectDefinitionName,
+					objectFields,
+					pluralLabel: {
+						en_US: objectDefinitionLabel,
+					},
+					portlet: true,
+					scope: 'company',
+					status: {
+						code: 0,
+					},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			const applicationName =
+				'c/' + objectDefinition.name.toLowerCase() + 's';
+
+			const preservedURL = 'preserved-url';
+
+			const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{friendlyUrlPath: preservedURL},
+				applicationName
+			);
+
+			await objectLayoutsPage.goto(objectDefinitionLabel);
+
+			const objectLayoutName = getRandomString();
+
+			await objectLayoutsPage.createObjectLayout(objectLayoutName);
+
+			await page.getByRole('link', {name: objectLayoutName}).click();
+
+			await objectLayoutsPage.markAsDefaultButton.check();
+
+			await objectLayoutsPage.layoutTab.click();
+
+			await objectLayoutsPage.createObjectLayoutTab(getRandomString());
+
+			await objectLayoutsPage.createObjectLayoutBlock({
+				objectLayoutRegularBlockName: getRandomString(),
+			});
+
+			await objectLayoutsPage.openObjectLayoutObjectField();
+
+			await objectLayoutsPage.iframeLocator
+				.getByRole('option', {name: objectField.label.en_US})
+				.click();
+
+			await objectLayoutsPage.saveAddFieldButton.click();
+
+			await objectLayoutsPage.saveUpdateLayoutButton.click();
+
+			await viewObjectEntriesPage.goto(objectDefinition.className);
+
+			await page
+				.getByRole('link', {name: String(objectEntry.id)})
+				.click();
+
+			await expect(page.getByLabel('Friendly URL')).not.toBeVisible();
+
+			await page
+				.getByLabel(objectField.label.en_US)
+				.fill('updated value');
+
+			await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
+
+			const updatedEntry =
+				await apiHelpers.objectEntry.getObjectEntryByExternalReferenceCode(
+					{
+						applicationName,
+						externalReferenceCode:
+							objectEntry.externalReferenceCode,
+					}
+				);
+
+			expect(updatedEntry.friendlyUrlPath).toBe(preservedURL);
+		}
+	);
+});


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPP-64051

## Summary

- Fix `form.jsp` so the entry update payload omits `friendlyUrlPath_i18n` when the active Object Layout does not render the Friendly URL field. Without this, `document.querySelectorAll(...)` returns an empty NodeList (still truthy), so the payload included `friendlyUrlPath_i18n: {}` and the backend regenerated the URL from the ERC.
- Add an integration test (`testPatchObjectEntryWithFriendlyURLCustomizationEnabled`) and a Playwright test (`Manage object entries with custom Object Layout`) covering the friendly URL preservation behavior on PATCH and through a custom layout.

## Test plan

- [x] `cd modules/apps/object/object-rest-test && ../../../../gradlew testIntegration --tests com.liferay.object.rest.internal.resource.v1_0.test.ObjectEntryResourceTest.testPatchObjectEntryWithFriendlyURLCustomizationEnabled` passes
- [x] `cd modules/test/playwright && yarn test tests/object-web/entry/objectEntry.spec.ts -g "preserved when updating an entry through a custom layout"` passes
- [x] Manual: create an Object Definition with `enableFriendlyURLCustomization=true`, add an entry with a custom `friendlyUrlPath`, define a custom Object Layout without the Friendly URL field as default, edit the entry — the original `friendlyUrlPath` remains