### PR TITLE
LPD-92475 Stop persisting "null" for nullable AS metadata URIs

### DIFF
--- a/modules/apps/oauth-client/oauth-client-persistence-service/bnd.bnd
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/bnd.bnd
@@ -13,7 +13,7 @@ Import-Package:\
 	!org.opensaml.*,\
 	\
 	*
-Liferay-Require-SchemaVersion: 1.5.2
+Liferay-Require-SchemaVersion: 1.5.3
 Liferay-Service: true
 -dsannotations-options: inherit
 -fixupmessages: Classes found in the wrong directory: ...;is:=ignore

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/internal/upgrade/registry/OAuthClientPersistenceServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/internal/upgrade/registry/OAuthClientPersistenceServiceUpgradeStepRegistrator.java
@@ -8,6 +8,7 @@ package com.liferay.oauth.client.persistence.internal.upgrade.registry;
 import com.liferay.oauth.client.persistence.internal.upgrade.v1_4_0.OAuthClientASLocalMetadataUpgradeProcess;
 import com.liferay.oauth.client.persistence.internal.upgrade.v1_4_1.OAuthClientEntryUpgradeProcess;
 import com.liferay.oauth.client.persistence.internal.upgrade.v1_5_2.OAuthClientASLocalMetadataIssuerUpgradeProcess;
+import com.liferay.oauth.client.persistence.internal.upgrade.v1_5_3.OAuthClientASLocalMetadataNullURIUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.BaseUuidUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
@@ -79,6 +80,10 @@ public class OAuthClientPersistenceServiceUpgradeStepRegistrator
 		registry.register(
 			"1.5.1", "1.5.2",
 			new OAuthClientASLocalMetadataIssuerUpgradeProcess());
+
+		registry.register(
+			"1.5.2", "1.5.3",
+			new OAuthClientASLocalMetadataNullURIUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/internal/upgrade/v1_5_3/OAuthClientASLocalMetadataNullURIUpgradeProcess.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/internal/upgrade/v1_5_3/OAuthClientASLocalMetadataNullURIUpgradeProcess.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.persistence.internal.upgrade.v1_5_3;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Validator;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import java.util.Objects;
+
+import net.minidev.json.JSONObject;
+
+/**
+ * @author Christian Moura
+ */
+public class OAuthClientASLocalMetadataNullURIUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update OAuthClientASLocalMetadata set metadataJSON = ?, " +
+						"oAuthASMetadataJSON = ? where " +
+							"oAuthClientASLocalMetadataId = ?");
+
+			Statement statement = connection.createStatement();
+
+			ResultSet resultSet = statement.executeQuery(
+				"select oAuthClientASLocalMetadataId, metadataJSON, " +
+					"oAuthASMetadataJSON from OAuthClientASLocalMetadata")) {
+
+			while (resultSet.next()) {
+				long oAuthClientASLocalMetadataId = resultSet.getLong(
+					"oAuthClientASLocalMetadataId");
+
+				String metadataJSON = resultSet.getString("metadataJSON");
+				String oAuthASMetadataJSON = resultSet.getString(
+					"oAuthASMetadataJSON");
+
+				String scrubbedMetadataJSON = _scrubLiteralNullEntries(
+					oAuthClientASLocalMetadataId, metadataJSON);
+				String scrubbedOAuthASMetadataJSON = _scrubLiteralNullEntries(
+					oAuthClientASLocalMetadataId, oAuthASMetadataJSON);
+
+				if (Objects.equals(metadataJSON, scrubbedMetadataJSON) &&
+					Objects.equals(
+						oAuthASMetadataJSON, scrubbedOAuthASMetadataJSON)) {
+
+					continue;
+				}
+
+				preparedStatement.setString(1, scrubbedMetadataJSON);
+				preparedStatement.setString(2, scrubbedOAuthASMetadataJSON);
+				preparedStatement.setLong(3, oAuthClientASLocalMetadataId);
+
+				preparedStatement.addBatch();
+			}
+
+			preparedStatement.executeBatch();
+		}
+	}
+
+	private String _scrubLiteralNullEntries(
+		long oAuthClientASLocalMetadataId, String json) {
+
+		if (Validator.isNull(json)) {
+			return json;
+		}
+
+		JSONObject jsonObject;
+
+		try {
+			jsonObject = JSONObjectUtils.parse(json);
+		}
+		catch (ParseException parseException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to parse JSON for OAuth 2 client authorization " +
+						"server local metadata " + oAuthClientASLocalMetadataId,
+					parseException);
+			}
+
+			return json;
+		}
+
+		if (jsonObject == null) {
+			return json;
+		}
+
+		boolean modified = jsonObject.entrySet(
+		).removeIf(
+			entry -> Objects.equals(entry.getValue(), "null")
+		);
+
+		if (!modified) {
+			return json;
+		}
+
+		return jsonObject.toString();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OAuthClientASLocalMetadataNullURIUpgradeProcess.class);
+
+}

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
@@ -67,12 +67,17 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 
 		return addOAuthClientASLocalMetadata(
 			null, userId,
-			String.valueOf(
-				authorizationServerMetadata.getAuthorizationEndpointURI()),
-			String.valueOf(authorizationServerMetadata.getIssuer()),
-			String.valueOf(authorizationServerMetadata.getJWKSetURI()), false,
-			String.valueOf(
-				authorizationServerMetadata.getRegistrationEndpointURI()),
+			Objects.toString(
+				authorizationServerMetadata.getAuthorizationEndpointURI(),
+				StringPool.BLANK),
+			Objects.toString(
+				authorizationServerMetadata.getIssuer(), StringPool.BLANK),
+			Objects.toString(
+				authorizationServerMetadata.getJWKSetURI(), StringPool.BLANK),
+			false,
+			Objects.toString(
+				authorizationServerMetadata.getRegistrationEndpointURI(),
+				StringPool.BLANK),
 			StringUtil.split(
 				StringUtil.merge(authorizationServerMetadata.getGrantTypes()),
 				StringPool.COMMA),
@@ -82,7 +87,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 			StringUtil.split(
 				_getSubjectTypes(authorizationServerMetadata),
 				StringPool.COMMA),
-			String.valueOf(authorizationServerMetadata.getTokenEndpointURI()),
+			Objects.toString(
+				authorizationServerMetadata.getTokenEndpointURI(),
+				StringPool.BLANK),
 			_getUserInfoEndpointURI(authorizationServerMetadata));
 	}
 
@@ -271,12 +278,17 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 
 		return updateOAuthClientASLocalMetadata(
 			oAuthClientASLocalMetadataId,
-			String.valueOf(
-				authorizationServerMetadata.getAuthorizationEndpointURI()),
-			String.valueOf(authorizationServerMetadata.getIssuer()),
-			String.valueOf(authorizationServerMetadata.getJWKSetURI()), false,
-			String.valueOf(
-				authorizationServerMetadata.getRegistrationEndpointURI()),
+			Objects.toString(
+				authorizationServerMetadata.getAuthorizationEndpointURI(),
+				StringPool.BLANK),
+			Objects.toString(
+				authorizationServerMetadata.getIssuer(), StringPool.BLANK),
+			Objects.toString(
+				authorizationServerMetadata.getJWKSetURI(), StringPool.BLANK),
+			false,
+			Objects.toString(
+				authorizationServerMetadata.getRegistrationEndpointURI(),
+				StringPool.BLANK),
 			StringUtil.split(
 				StringUtil.merge(authorizationServerMetadata.getGrantTypes()),
 				StringPool.COMMA),
@@ -286,7 +298,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 			StringUtil.split(
 				_getSubjectTypes(authorizationServerMetadata),
 				StringPool.COMMA),
-			String.valueOf(authorizationServerMetadata.getTokenEndpointURI()),
+			Objects.toString(
+				authorizationServerMetadata.getTokenEndpointURI(),
+				StringPool.BLANK),
 			_getUserInfoEndpointURI(authorizationServerMetadata));
 	}
 
@@ -352,17 +366,30 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 			AuthorizationServerMetadata authorizationServerMetadata =
 				new AuthorizationServerMetadata(new Issuer(issuer));
 
-			authorizationServerMetadata.setAuthorizationEndpointURI(
-				new URI(authorizationEndpoint));
+			if (Validator.isNotNull(authorizationEndpoint)) {
+				authorizationServerMetadata.setAuthorizationEndpointURI(
+					new URI(authorizationEndpoint));
+			}
+
 			authorizationServerMetadata.setGrantTypes(
 				TransformUtil.transformToList(
 					supportedGrantTypes, GrantType::parse));
-			authorizationServerMetadata.setJWKSetURI(new URI(jwksURI));
-			authorizationServerMetadata.setRegistrationEndpointURI(
-				new URI(registrationEndpoint));
+
+			if (Validator.isNotNull(jwksURI)) {
+				authorizationServerMetadata.setJWKSetURI(new URI(jwksURI));
+			}
+
+			if (Validator.isNotNull(registrationEndpoint)) {
+				authorizationServerMetadata.setRegistrationEndpointURI(
+					new URI(registrationEndpoint));
+			}
+
 			authorizationServerMetadata.setScopes(new Scope(supportedScopes));
-			authorizationServerMetadata.setTokenEndpointURI(
-				new URI(tokenEndpoint));
+
+			if (Validator.isNotNull(tokenEndpoint)) {
+				authorizationServerMetadata.setTokenEndpointURI(
+					new URI(tokenEndpoint));
+			}
 
 			return String.valueOf(authorizationServerMetadata.toJSONObject());
 		}
@@ -416,15 +443,25 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 						supportedSubjectTypes, SubjectType::parse),
 					new URI(jwksURI));
 
-			oidcProviderMetadata.setAuthorizationEndpointURI(
-				new URI(authorizationEndpoint));
+			if (Validator.isNotNull(authorizationEndpoint)) {
+				oidcProviderMetadata.setAuthorizationEndpointURI(
+					new URI(authorizationEndpoint));
+			}
+
 			oidcProviderMetadata.setGrantTypes(
 				TransformUtil.transformToList(
 					supportedGrantTypes, GrantType::parse));
 			oidcProviderMetadata.setScopes(new Scope(supportedScopes));
-			oidcProviderMetadata.setTokenEndpointURI(new URI(tokenEndpoint));
-			oidcProviderMetadata.setUserInfoEndpointURI(
-				new URI(userInfoEndpoint));
+
+			if (Validator.isNotNull(tokenEndpoint)) {
+				oidcProviderMetadata.setTokenEndpointURI(
+					new URI(tokenEndpoint));
+			}
+
+			if (Validator.isNotNull(userInfoEndpoint)) {
+				oidcProviderMetadata.setUserInfoEndpointURI(
+					new URI(userInfoEndpoint));
+			}
 
 			return String.valueOf(oidcProviderMetadata.toJSONObject());
 		}
@@ -452,8 +489,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 		if (authorizationServerMetadata instanceof
 				OIDCProviderMetadata oidcProviderMetadata) {
 
-			return String.valueOf(
-				oidcProviderMetadata.getUserInfoEndpointURI());
+			return Objects.toString(
+				oidcProviderMetadata.getUserInfoEndpointURI(),
+				StringPool.BLANK);
 		}
 
 		return StringPool.BLANK;

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/internal/upgrade/v1_5_3/test/OAuthClientASLocalMetadataNullURIUpgradeProcessTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/internal/upgrade/v1_5_3/test/OAuthClientASLocalMetadataNullURIUpgradeProcessTest.java
@@ -1,0 +1,217 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.persistence.internal.upgrade.v1_5_3.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.oauth.client.persistence.model.OAuthClientASLocalMetadata;
+import com.liferay.oauth.client.persistence.service.OAuthClientASLocalMetadataLocalService;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import com.nimbusds.oauth2.sdk.as.AuthorizationServerMetadata;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christian Moura
+ */
+@RunWith(Arquillian.class)
+public class OAuthClientASLocalMetadataNullURIUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testUpgrade() throws Exception {
+		JSONObject brokenMetadataJSONObject = _baseMetadataJSONObject(
+		).put(
+			"authorization_endpoint", "null"
+		).put(
+			"registration_endpoint", "null"
+		).put(
+			"token_endpoint", "null"
+		).put(
+			"userinfo_endpoint", "null"
+		);
+		JSONObject brokenOAuthASMetadataJSONObject =
+			_baseOAuthASMetadataJSONObject(
+			).put(
+				"authorization_endpoint", "null"
+			).put(
+				"jwks_uri", "null"
+			).put(
+				"registration_endpoint", "null"
+			).put(
+				"token_endpoint", "null"
+			);
+
+		OAuthClientASLocalMetadata brokenOAuthClientASLocalMetadata =
+			_persistOAuthClientASLocalMetadata(
+				brokenMetadataJSONObject.toString(),
+				brokenOAuthASMetadataJSONObject.toString());
+
+		JSONObject cleanMetadataJSONObject = _baseMetadataJSONObject(
+		).put(
+			"registration_endpoint",
+			_ISSUER + "/clients-registrations/openid-connect"
+		).put(
+			"userinfo_endpoint", _ISSUER + "/protocol/openid-connect/userinfo"
+		);
+		JSONObject cleanOAuthASMetadataJSONObject =
+			_baseOAuthASMetadataJSONObject().put(
+				"registration_endpoint",
+				_ISSUER + "/clients-registrations/openid-connect");
+
+		OAuthClientASLocalMetadata cleanOAuthClientASLocalMetadata =
+			_persistOAuthClientASLocalMetadata(
+				cleanMetadataJSONObject.toString(),
+				cleanOAuthASMetadataJSONObject.toString());
+
+		String cleanMetadataJSON =
+			cleanOAuthClientASLocalMetadata.getMetadataJSON();
+		String cleanOAuthASMetadataJSON =
+			cleanOAuthClientASLocalMetadata.getOAuthASMetadataJSON();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.ALL)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
+
+		brokenOAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				getOAuthClientASLocalMetadata(
+					brokenOAuthClientASLocalMetadata.
+						getOAuthClientASLocalMetadataId());
+
+		String upgradedMetadataJSON =
+			brokenOAuthClientASLocalMetadata.getMetadataJSON();
+
+		Assert.assertFalse(upgradedMetadataJSON.contains("\":\"null\""));
+
+		OIDCProviderMetadata oidcProviderMetadata = OIDCProviderMetadata.parse(
+			upgradedMetadataJSON);
+
+		Assert.assertNull(oidcProviderMetadata.getAuthorizationEndpointURI());
+		Assert.assertNull(oidcProviderMetadata.getRegistrationEndpointURI());
+		Assert.assertNull(oidcProviderMetadata.getTokenEndpointURI());
+		Assert.assertNull(oidcProviderMetadata.getUserInfoEndpointURI());
+
+		String upgradedOAuthASMetadataJSON =
+			brokenOAuthClientASLocalMetadata.getOAuthASMetadataJSON();
+
+		Assert.assertFalse(upgradedOAuthASMetadataJSON.contains("\":\"null\""));
+
+		AuthorizationServerMetadata authorizationServerMetadata =
+			AuthorizationServerMetadata.parse(upgradedOAuthASMetadataJSON);
+
+		Assert.assertNull(
+			authorizationServerMetadata.getAuthorizationEndpointURI());
+		Assert.assertNull(authorizationServerMetadata.getJWKSetURI());
+		Assert.assertNull(
+			authorizationServerMetadata.getRegistrationEndpointURI());
+		Assert.assertNull(authorizationServerMetadata.getTokenEndpointURI());
+
+		cleanOAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				getOAuthClientASLocalMetadata(
+					cleanOAuthClientASLocalMetadata.
+						getOAuthClientASLocalMetadataId());
+
+		Assert.assertEquals(
+			cleanMetadataJSON,
+			cleanOAuthClientASLocalMetadata.getMetadataJSON());
+		Assert.assertEquals(
+			cleanOAuthASMetadataJSON,
+			cleanOAuthClientASLocalMetadata.getOAuthASMetadataJSON());
+	}
+
+	private JSONObject _baseMetadataJSONObject() {
+		return JSONUtil.put(
+			"authorization_endpoint", _ISSUER + "/protocol/openid-connect/auth"
+		).put(
+			"issuer", _ISSUER
+		).put(
+			"jwks_uri", _ISSUER + "/protocol/openid-connect/certs"
+		).put(
+			"subject_types_supported", JSONUtil.putAll("public")
+		).put(
+			"token_endpoint", _ISSUER + "/protocol/openid-connect/token"
+		);
+	}
+
+	private JSONObject _baseOAuthASMetadataJSONObject() {
+		return JSONUtil.put(
+			"authorization_endpoint", _ISSUER + "/protocol/openid-connect/auth"
+		).put(
+			"issuer", _ISSUER
+		).put(
+			"jwks_uri", _ISSUER + "/protocol/openid-connect/certs"
+		).put(
+			"token_endpoint", _ISSUER + "/protocol/openid-connect/token"
+		);
+	}
+
+	private OAuthClientASLocalMetadata _persistOAuthClientASLocalMetadata(
+			String metadataJSON, String oAuthASMetadataJSON)
+		throws Exception {
+
+		OAuthClientASLocalMetadata oAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				createOAuthClientASLocalMetadata(
+					_counterLocalService.increment());
+
+		oAuthClientASLocalMetadata.setMetadataJSON(metadataJSON);
+		oAuthClientASLocalMetadata.setOAuthASMetadataJSON(oAuthASMetadataJSON);
+
+		return _oAuthClientASLocalMetadataLocalService.
+			updateOAuthClientASLocalMetadata(oAuthClientASLocalMetadata);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.oauth.client.persistence.internal.upgrade.v1_5_3." +
+			"OAuthClientASLocalMetadataNullURIUpgradeProcess";
+
+	private static final String _ISSUER =
+		"https://example.com/auth/realms/master";
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
+	private OAuthClientASLocalMetadataLocalService
+		_oAuthClientASLocalMetadataLocalService;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.oauth.client.persistence.internal.upgrade.registry.OAuthClientPersistenceServiceUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/test/OAuthClientASLocalMetadataLocalServiceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/test/OAuthClientASLocalMetadataLocalServiceTest.java
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.persistence.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth.client.persistence.model.OAuthClientASLocalMetadata;
+import com.liferay.oauth.client.persistence.service.OAuthClientASLocalMetadataLocalService;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christian Moura
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class OAuthClientASLocalMetadataLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@After
+	public void tearDown() throws Exception {
+		if (_oAuthClientASLocalMetadata != null) {
+			_oAuthClientASLocalMetadataLocalService.
+				deleteOAuthClientASLocalMetadata(_oAuthClientASLocalMetadata);
+		}
+	}
+
+	@Test
+	public void testAddOAuthClientASLocalMetadata() throws Exception {
+		_testAddOAuthClientASLocalMetadata(null);
+		_testAddOAuthClientASLocalMetadata("authorization_endpoint");
+		_testAddOAuthClientASLocalMetadata("registration_endpoint");
+		_testAddOAuthClientASLocalMetadata("token_endpoint");
+		_testAddOAuthClientASLocalMetadata("userinfo_endpoint");
+	}
+
+	@Test
+	public void testUpdateOAuthClientASLocalMetadataWhenUserInfoEndpointIsMissing()
+		throws Exception {
+
+		_oAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				addOAuthClientASLocalMetadata(
+					TestPropsValues.getUserId(),
+					_buildFullMetadataJSONObject().toString(),
+					"openid-configuration");
+
+		String updatedIssuer = _ISSUER + "/updated";
+
+		_oAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				updateOAuthClientASLocalMetadata(
+					_oAuthClientASLocalMetadata.
+						getOAuthClientASLocalMetadataId(),
+					JSONUtil.put(
+						"authorization_endpoint",
+						updatedIssuer + "/protocol/openid-connect/auth"
+					).put(
+						"issuer", updatedIssuer
+					).put(
+						"jwks_uri",
+						updatedIssuer + "/protocol/openid-connect/certs"
+					).put(
+						"subject_types_supported", JSONUtil.putAll("public")
+					).put(
+						"token_endpoint",
+						updatedIssuer + "/protocol/openid-connect/token"
+					).toString(),
+					"openid-configuration");
+
+		String storedMetadataJSON =
+			_oAuthClientASLocalMetadata.getMetadataJSON();
+
+		Assert.assertFalse(
+			storedMetadataJSON.contains("\"userinfo_endpoint\":\"null\""));
+
+		OIDCProviderMetadata oidcProviderMetadata = OIDCProviderMetadata.parse(
+			storedMetadataJSON);
+
+		Assert.assertNull(oidcProviderMetadata.getUserInfoEndpointURI());
+	}
+
+	private JSONObject _buildFullMetadataJSONObject() {
+		return JSONUtil.put(
+			"authorization_endpoint", _ISSUER + "/protocol/openid-connect/auth"
+		).put(
+			"issuer", _ISSUER
+		).put(
+			"jwks_uri", _ISSUER + "/protocol/openid-connect/certs"
+		).put(
+			"registration_endpoint",
+			_ISSUER + "/clients-registrations/openid-connect"
+		).put(
+			"subject_types_supported", JSONUtil.putAll("public")
+		).put(
+			"token_endpoint", _ISSUER + "/protocol/openid-connect/token"
+		).put(
+			"userinfo_endpoint", _ISSUER + "/protocol/openid-connect/userinfo"
+		);
+	}
+
+	private void _testAddOAuthClientASLocalMetadata(String missingKey)
+		throws Exception {
+
+		JSONObject metadataJSONObject = _buildFullMetadataJSONObject();
+
+		if (missingKey != null) {
+			metadataJSONObject.remove(missingKey);
+		}
+
+		_oAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				addOAuthClientASLocalMetadata(
+					TestPropsValues.getUserId(), metadataJSONObject.toString(),
+					"openid-configuration");
+
+		String storedMetadataJSON =
+			_oAuthClientASLocalMetadata.getMetadataJSON();
+
+		if (missingKey == null) {
+			OIDCProviderMetadata oidcProviderMetadata =
+				OIDCProviderMetadata.parse(storedMetadataJSON);
+
+			Assert.assertEquals(
+				_ISSUER + "/protocol/openid-connect/token",
+				String.valueOf(oidcProviderMetadata.getTokenEndpointURI()));
+			Assert.assertEquals(
+				_ISSUER + "/protocol/openid-connect/userinfo",
+				String.valueOf(oidcProviderMetadata.getUserInfoEndpointURI()));
+		}
+		else {
+			String literalNullEntry = "\"" + missingKey + "\":\"null\"";
+
+			Assert.assertFalse(storedMetadataJSON.contains(literalNullEntry));
+
+			String oAuthASMetadataJSON =
+				_oAuthClientASLocalMetadata.getOAuthASMetadataJSON();
+
+			Assert.assertFalse(oAuthASMetadataJSON.contains(literalNullEntry));
+		}
+
+		_oAuthClientASLocalMetadataLocalService.
+			deleteOAuthClientASLocalMetadata(_oAuthClientASLocalMetadata);
+
+		_oAuthClientASLocalMetadata = null;
+	}
+
+	private static final String _ISSUER =
+		"https://example.com/auth/realms/master";
+
+	private OAuthClientASLocalMetadata _oAuthClientASLocalMetadata;
+
+	@Inject
+	private OAuthClientASLocalMetadataLocalService
+		_oAuthClientASLocalMetadataLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92475

## What is being fixed

`OAuthClientASLocalMetadataLocalServiceImpl` reduced Nimbus URIs and identifiers back to `String` with `String.valueOf`, which returns the literal string `"null"` when the source URI is null. Nimbus then round-tripped that literal through `new URI("null")` and `toJSONObject()`, so the stored metadata JSON contained entries like `"userinfo_endpoint":"null"`. On the next login, `OIDCProviderMetadata.parse` rehydrated those as non-null relative URIs and the OIDC flow blew up with "URI is not absolute" when it tried to call `toURL` on them. Rows already saved before the fix carried the same corruption and kept failing OIDC login until an admin manually re-saved each provider.

## How it is being fixed

The first two commits stop new writes from creating the corruption. Every Nimbus URI and identifier is routed through `Objects.toString(..., StringPool.BLANK)` before persisting, and each `set*EndpointURI` call in `_generateAuthorizationServerMetadataJSON` and `_generateMetadataJSON` is gated on `Validator.isNotNull` so a stray literal `"null"` still cannot reach the stored JSON even if upstream sanitization is bypassed.

The next two commits handle rows already corrupted before the runtime fix landed. A new v1_5_3 upgrade streams every `OAuthClientASLocalMetadata` row, parses both `metadataJSON` and `oAuthASMetadataJSON` via Nimbus's `JSONObjectUtils.parse`, removes any top-level entry whose value is the literal string `"null"`, and writes the pair back in a single batched UPDATE only when modified — so clean rows are byte-for-byte preserved. `Liferay-Require-SchemaVersion` is bumped to `1.5.3` and the upgrade is registered alongside the existing v1_5_2 issuer-recovery process.