### PR TITLE
LPD-91470 Localize time separator in Date & Time field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePickerBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePickerBase.tsx
@@ -14,7 +14,7 @@ import {dateUtils} from 'frontend-js-web';
 // @ts-ignore
 
 import moment from 'moment/min/moment-with-locales';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createTextMaskInputElement} from 'text-mask-core';
 
 import {getTooltipTitle} from '../util/tooltip';
@@ -100,6 +100,16 @@ export default function DatePickerBase({
 
 	const [{formattedDate, rawDate, years}, setDate] = useState(date);
 
+	const timeSeparator = useMemo(
+		() => (isDateTime ? datetimeUtils.getTimeSeparator(momentFormat) : ':'),
+		[isDateTime, momentFormat]
+	);
+
+	const localizeTimeSeparator = (value: string) =>
+		isDateTime && timeSeparator !== ':'
+			? value.replace(/(\d{2}):(\d{2})$/, `$1${timeSeparator}$2`)
+			: value;
+
 	/**
 	 * Updates the rawDate state whenever the prop value or localizedValue changes,
 	 * but it keep user's input case theres no language change.
@@ -149,7 +159,7 @@ export default function DatePickerBase({
 			isDateTime,
 			momentFormat,
 			serverFormat,
-			value: dateValue,
+			value: localizeTimeSeparator(dateValue),
 		});
 
 		setDate((previousState) => ({...previousState, ...nextState}));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
@@ -152,6 +152,19 @@ describe('DatePicker', () => {
 		);
 	});
 
+	it('displays the time with the locale separator for a date_time field in Finnish', () => {
+		render(
+			<DatePicker
+				locale="fi_FI"
+				onChange={() => {}}
+				type="date_time"
+				value="2026-05-27 14:30"
+			/>
+		);
+
+		expect(screen.getByRole('textbox')).toHaveValue('27.05.2026 14.30');
+	});
+
 	it('fills the input with the date selected on Date Picker', () => {
 		const {getByLabelText} = render(<DatePicker onChange={() => {}} />);
 

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/tests/utils/datetime.spec.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/tests/utils/datetime.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getTimeSeparator} from '../../utils/datetime';
+
+describe('getTimeSeparator', () => {
+	it('returns "." for locale formats that use period as the time separator', () => {
+		expect(getTimeSeparator('DD.MM.YYYY HH.mm')).toBe('.');
+	});
+
+	it('returns ":" for locale formats that use colon as the time separator', () => {
+		expect(getTimeSeparator('MM/DD/YYYY HH:mm')).toBe(':');
+	});
+
+	it('returns ":" for 12-hour formats', () => {
+		expect(getTimeSeparator('MM/DD/YYYY h:mm A')).toBe(':');
+	});
+
+	it('returns ":" when the format has no time portion', () => {
+		expect(getTimeSeparator('MM/DD/YYYY')).toBe(':');
+	});
+
+	it('returns ":" for an empty format', () => {
+		expect(getTimeSeparator('')).toBe(':');
+	});
+});

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/datetime.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/datetime.ts
@@ -109,6 +109,13 @@ export function generateDateConfigurations({
 	};
 }
 
+export function getTimeSeparator(momentFormat: string): string {
+	const timePart = momentFormat.split(' ').slice(1).join(' ');
+	const match = timePart.match(/H+([^\w])/i);
+
+	return match?.[1] ?? ':';
+}
+
 export function generateDate({
 	isDateTime,
 	momentFormat,


### PR DESCRIPTION
# What is this trying to solve?
Ticket: https://liferay.atlassian.net/browse/LPD-91470.

When a site's default language uses a non-colon time separator (e.g. Finnish, which formats time as `14.30`), picking a date and time on a web content's Date & Time field leaves the input with 14:30 and the field reports `"Please enter a valid date"`. The only workaround is to manually replace the `:` with `.`

# How am I fixing it?
The bug comes from two layers:
- `ClayDatePicker` hardcodes its time as `HH:mm` and has no `timeFormat` prop, so its output is always colon-separated.
- `DatePickerBase.tsx` validates against a locale-aware `momentFormat` for Finnish that's `DD.MM.YYYY HH.mm`. Clay returns `14:30`, the validator expects `14.30`, the parse fails, and `handleBlur` shows `"Please enter a valid date"`.

The fix -
1. Added `getTimeSeparator(momentFormat)` in `object-js-components-web/utils/datetime.ts`, this pulls the separator out of `momentFormat`, defaults to `:`.
2. In `handleValueChange`, ran Clay's value through `fromClayValue` before `datetimeUtils.generateDate`, so the validator sees the locale separator.
3. Kept `formattedDate` wired directly to Clay's `value` prop so the input shows `27.05.2026 14.30`.

Considered adding a `timeFormat` prop to `ClayDatePicker`. Skipped it because Clay is used in `Object`, `Forms`, `Workflow`, `dispatch`, and elsewhere, so the change is much wider than this, one issue. If a Clay-level fix lands later, this can just be deleted.

`rawDate` (the hidden input that gets submitted) is already in `SERVER_DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm'`, so nothing changes for the server.

# How can you verify that it works?
Run the included automated tests.