### PR TITLE
LRCI-6956 Resolve the top level build URL from the build description

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser.testray;
 
 import com.liferay.jenkins.results.parser.BuildReportFactory;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.MultiPattern;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
 
 import java.io.IOException;
@@ -401,18 +402,48 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	}
 
 	public URL getTopLevelBuildURL() {
-		Matcher matcher = _getTestrayAttachmentURLMatcher();
+		String topLevelMasterHostname = null;
+		String topLevelJobName = null;
+		String topLevelBuildNumber = null;
 
-		if (matcher == null) {
+		String description = getDescription();
+
+		Matcher descriptionMatcher = null;
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(description)) {
+			descriptionMatcher = _descriptionPattern.matches(description);
+		}
+
+		if (descriptionMatcher != null) {
+			topLevelMasterHostname = descriptionMatcher.group(
+				"topLevelMasterHostname");
+			topLevelJobName = descriptionMatcher.group("topLevelJobName");
+			topLevelBuildNumber = descriptionMatcher.group(
+				"topLevelBuildNumber");
+		}
+		else {
+			Matcher testrayAttachmentURLMatcher =
+				_getTestrayAttachmentURLMatcher();
+
+			if (testrayAttachmentURLMatcher != null) {
+				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
+					"topLevelMasterHostname");
+				topLevelJobName = testrayAttachmentURLMatcher.group(
+					"topLevelJobName");
+				topLevelBuildNumber = testrayAttachmentURLMatcher.group(
+					"topLevelBuildNumber");
+			}
+		}
+
+		if (topLevelMasterHostname == null) {
 			return null;
 		}
 
 		try {
 			return new URL(
 				JenkinsResultsParserUtil.combine(
-					"https://", matcher.group("topLevelMasterHostname"),
-					".liferay.com/job/", matcher.group("topLevelJobName"), "/",
-					matcher.group("topLevelBuildNumber"), "/"));
+					"https://", topLevelMasterHostname, ".liferay.com/job/",
+					topLevelJobName, "/", topLevelBuildNumber, "/"));
 		}
 		catch (MalformedURLException malformedURLException) {
 			throw new RuntimeException(malformedURLException);
@@ -548,6 +579,16 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		return null;
 	}
 
+	private static final MultiPattern _descriptionPattern = new MultiPattern(
+		JenkinsResultsParserUtil.combine(
+			".*<a href=\"https://(?<topLevelMasterHostname>test-\\d+-\\d+)",
+			"\\.liferay\\.com/userContent/jobs/(?<topLevelJobName>[^/]+)/",
+			"builds/(?<topLevelBuildNumber>\\d+)/jenkins-report\\.html\">",
+			"Jenkins Report</a>.*"),
+		JenkinsResultsParserUtil.combine(
+			".*<a href=\".+/testray-results/\\d{4}-\\d{2}/",
+			"(?<topLevelMasterHostname>test-\\d+-\\d+)/",
+			"(?<topLevelJobName>[^/]+)/(?<topLevelBuildNumber>[^/]+)/.+"));
 	private static final Pattern _portalBranchPattern = Pattern.compile(
 		"Portal Branch: (?<portalBranch>[^;]+);");
 	private static final Pattern _testrayAttachmentURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -42,6 +42,8 @@ import com.liferay.jenkins.results.parser.test.clazz.group.PlaywrightAxisTestCla
 import java.io.File;
 import java.io.IOException;
 
+import java.net.URL;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -385,7 +387,19 @@ public class TestrayImporter {
 		}
 
 		sb.append("<a href=\"");
-		sb.append(_topLevelBuildReport.getJenkinsReportURL());
+
+		URL jenkinsReportTestrayAttachmentURL =
+			_topLevelBuildReport.getTestrayAttachmentURLBySuffix(
+				"jenkins-report.html.gz");
+
+		if (jenkinsReportTestrayAttachmentURL != null) {
+			sb.append(jenkinsReportTestrayAttachmentURL);
+			sb.append("?authuser=0");
+		}
+		else {
+			sb.append(_topLevelBuildReport.getJenkinsReportURL());
+		}
+
 		sb.append("\">Jenkins Report</a>");
 		sb.append("; ");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6956

## What Is Being Fixed

The top level build URL for a Testray build was resolved only from the Testray attachment URL pattern. That left builds whose top level coordinates are recorded in the build description without a resolvable top level build URL.

## How It Is Being Fixed

TestrayBuild#getTopLevelBuildURL now first parses the build description with a MultiPattern that recognizes both the Jenkins Report anchor and the testray-results URL, extracting the master hostname, job name, and build number, and falls back to the existing Testray attachment URL matcher. TestrayImporter now writes the Jenkins Report link into the description using the Testray attachment URL for jenkins-report.html.gz (with ?authuser=0) when one is available, falling back to the Jenkins report URL. Together these let the top level build URL be recovered directly from the description.

## Why Are There No Tests?

jenkins-results-parser is CI tooling without a unit test harness for this code path; the change is verified by CI runs.