### PR TITLE
LPD-93606 Fix locators for staging publish content range radio buttons

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
@@ -220,12 +220,12 @@
 </tr>
 <tr>
 	<td>CONTENT_LAST</td>
-	<td>//span[contains(.,'Last...')]</td>
+	<td>//label[.//input[contains(@id,'rangeLast') and @type='radio']]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>CONTENT_ALL</td>
-	<td>//span[contains(.,'All')]</td>
+	<td>//label[.//input[contains(@id,'rangeAll') and @type='radio']]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
## What

Update the `CONTENT_ALL` and `CONTENT_LAST` XPath locators in `StagingPublishToLive.path` to target label elements wrapping the radio inputs by their `id` attributes (`rangeAll`, `rangeLast`) instead of span elements by text content.

## Why

The old span-based locators stopped matching the rendered HTML, causing the following functional tests to fail:

- `LocalFile.RemoteStaging#ViewWarningMessageWhenChooseALL`
- `LocalFile.RemoteStaging#ViewWarningMessageWhenPublishFromStagingAdmin`
- `LocalFile.StagingUsecase#ViewWarningMessageWhenChooseALL`
- `LocalFile.StagingUsecase#ViewWarningMessageWhenPublishFromStagingAdmin`
- `LocalFile.StagingUpgrade#ViewWarningMessageAfterUpgrade73101`
- `LocalFile.StagingUpgrade#ViewWarningMessageWhenPublishFromStagingAdminAfterUpgrade73101`

## Test plan

- [x] Run `LocalFile.StagingUsecase#ViewWarningMessageWhenChooseALL`
- [x] Run `LocalFile.StagingUsecase#ViewWarningMessageWhenPublishFromStagingAdmin`
- [ ] Run `LocalFile.RemoteStaging#ViewWarningMessageWhenChooseALL`
- [ ] Run `LocalFile.RemoteStaging#ViewWarningMessageWhenPublishFromStagingAdmin`
- [ ] Run `LocalFile.StagingUpgrade#ViewWarningMessageAfterUpgrade73101`
- [ ] Run `LocalFile.StagingUpgrade#ViewWarningMessageWhenPublishFromStagingAdminAfterUpgrade73101`