### PR TITLE
LPD-95785 Enable Match Phrase Prefix queries for CMS/Object Entry titles

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
@@ -28,7 +28,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rodrigo Paulino
  */
 @Component(
-	property = {"description.fields=description", "title.fields=name|title"},
+	property = {
+		"description.fields=description",
+		"title.fields=name|title|objectEntryTitle"
+	},
 	service = FieldQueryBuilderFactory.class
 )
 public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
@@ -85,6 +88,6 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	private volatile Collection<String> _descriptionFieldNames =
 		Collections.singleton("description");
 	private volatile Collection<String> _titleFieldNames = new HashSet<>(
-		Arrays.asList("name", "title"));
+		Arrays.asList("name", "title", "objectEntryTitle"));
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImpl.java
@@ -28,7 +28,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"description.fields=content|description", "title.fields=name|title"
+		"description.fields=content|description",
+		"title.fields=name|title|objectEntryTitle"
 	},
 	service = FieldQueryBuilderFactory.class
 )
@@ -86,6 +87,6 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	private volatile Collection<String> _descriptionFieldNames = Arrays.asList(
 		"content", "description");
 	private volatile Collection<String> _titleFieldNames = new HashSet<>(
-		Arrays.asList("name", "title"));
+		Arrays.asList("name", "title", "objectEntryTitle"));
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95785

The motivation is to match the search behavior of Classic CMS Web Content Article titles. Even though it’s not the best way of searching either (refer to the notes about the usage of Match Phrase Prefix query for autocomplete purposes at https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase-prefix)), we should aim for consistency at this point, as long as the Classic CMS is around as people will likely compare the behaviors.