### PR TITLE
LRCI-7767 Report UNSTABLE downstream builds as passed in Testray

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/DownstreamBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/DownstreamBatchBuildTestrayCaseResult.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.testray;
+
+import com.liferay.jenkins.results.parser.BuildReport;
+import com.liferay.jenkins.results.parser.TopLevelBuildReport;
+import com.liferay.jenkins.results.parser.test.clazz.TestClass;
+import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
+import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
+
+import java.util.Objects;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class DownstreamBatchBuildTestrayCaseResult
+	extends BatchBuildTestrayCaseResult<TestClass, TestClassMethod> {
+
+	public DownstreamBatchBuildTestrayCaseResult(
+		AxisTestClassGroup axisTestClassGroup, TestrayBuild testrayBuild,
+		TopLevelBuildReport topLevelBuildReport) {
+
+		super(axisTestClassGroup, testrayBuild, topLevelBuildReport);
+	}
+
+	@Override
+	public String getErrors() {
+		Status status = getStatus();
+
+		if (status == Status.PASSED) {
+			return null;
+		}
+
+		return super.getErrors();
+	}
+
+	@Override
+	public Status getStatus() {
+		BuildReport buildReport = getBuildReport();
+
+		if ((buildReport != null) &&
+			Objects.equals(buildReport.getResult(), "UNSTABLE")) {
+
+			return Status.PASSED;
+		}
+
+		return super.getStatus();
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -100,7 +100,7 @@ public class TestrayFactory {
 				axisTestClassGroup, testrayBuild, topLevelBuildReport);
 		}
 
-		return new BatchBuildTestrayCaseResult<>(
+		return new DownstreamBatchBuildTestrayCaseResult(
 			axisTestClassGroup, testrayBuild, topLevelBuildReport);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7767

**What is being fixed:** When a downstream build finishes UNSTABLE, its
per-downstream-build Testray case result was reported as FAILED. That is
misleading — an UNSTABLE downstream build has technically passed at the
build level, and the actual test failures that caused the instability are
already captured individually by the related per-test-class case results.
The build-level result being marked FAILED double-counts those failures.

**How it is being fixed:** Introduces a dedicated
DownstreamBatchBuildTestrayCaseResult subclass of BatchBuildTestrayCaseResult
to hold downstream-build-specific reporting logic, and routes the axis-level
(per-downstream-build) factory path in TestrayFactory to it. The new class
overrides getStatus so an UNSTABLE build report resolves to PASSED rather than
FAILED, delegating all other results to the existing logic, and overrides
getErrors to return no error string once the result is treated as passed.