### PR TITLE
LPD-97230 Resolve string scope keys for the object entry folders page

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -308,7 +308,7 @@ public class ObjectEntryFolderResourceImpl
 						booleanQuery.getPreBooleanFilter();
 
 					booleanFilter.add(
-						new TermFilter(Field.GROUP_ID, scopeKey),
+						new TermFilter(Field.GROUP_ID, String.valueOf(groupId)),
 						BooleanClauseOccur.MUST);
 				}
 			},

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -137,6 +137,14 @@ public class ObjectEntryFolderResourceTest
 
 	@Override
 	@Test
+	public void testGetScopeScopeKeyObjectEntryFoldersPage() throws Exception {
+		super.testGetScopeScopeKeyObjectEntryFoldersPage();
+
+		_testGetScopeScopeKeyObjectEntryFoldersPageWithGroupKey();
+	}
+
+	@Override
+	@Test
 	public void testGetScopeScopeKeyObjectEntryFoldersPageWithFilterDateTimeEquals()
 		throws Exception {
 
@@ -1183,6 +1191,27 @@ public class ObjectEntryFolderResourceTest
 		assertEquals(
 			Collections.singletonList(objectEntryFolder2),
 			(List<ObjectEntryFolder>)page.getItems());
+	}
+
+	@TestInfo("LPD-97230")
+	private void _testGetScopeScopeKeyObjectEntryFoldersPageWithGroupKey()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			testGetScopeScopeKeyObjectEntryFoldersPage_addObjectEntryFolder(
+				String.valueOf(_testDepotEntry.getGroupId()),
+				randomObjectEntryFolder());
+
+		Page<ObjectEntryFolder> page =
+			objectEntryFolderResource.getScopeScopeKeyObjectEntryFoldersPage(
+				_testDepotEntryGroup.getGroupKey(), null, null, null, null,
+				Pagination.of(1, 10), null);
+
+		assertContains(
+			objectEntryFolder, (List<ObjectEntryFolder>)page.getItems());
+
+		objectEntryFolderResource.deleteObjectEntryFolder(
+			objectEntryFolder.getId());
 	}
 
 	private void _testPatchScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithGroupKey()


### PR DESCRIPTION
# What is this trying to solve?

Ticket: https://liferay.atlassian.net/browse/LPD-97230.

The Headless Object API endpoint `GET /o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders` resolved the `{scopeKey}` inconsistently. Given the numeric group ID it returned the Space's Object Entry Folders as expected, but given a string-based scope key — the asset library key, group key, or external reference code — the request succeeded yet returned an empty collection, even though folders existed in the Space. This was inconsistent with the other `/scopes/{scopeKey}/` endpoints, which resolve string scope keys correctly.

# How am I fixing it?

The endpoint is `ObjectEntryFolderResourceImpl.getScopeScopeKeyObjectEntryFoldersPage`. It already resolves the scope key to a numeric `groupId` via `_getGroupId(scopeKey)` and uses that for the permission check and `searchContext.setGroupIds(...)` — but the search pre-filter built its `GROUP_ID` term filter from the raw `scopeKey` string instead:

```java
new TermFilter(Field.GROUP_ID, scopeKey)                  // before
new TermFilter(Field.GROUP_ID, String.valueOf(groupId))   // after
```

A numeric scope key happened to match the indexed `GROUP_ID` value, so it worked; a string key matched nothing, so the result came back empty. The one-line fix builds the term filter from the already-resolved `groupId`, so every scope key form returns the same folders. This filter is only applied when `flatten` is false, which is why passing `flatten=true` was an accidental workaround.

# How can you verify that it works?

Run the included automated test: `ObjectEntryFolderResourceTest.testGetScopeScopeKeyObjectEntryFoldersPage` now also creates a folder via the numeric scope key and fetches the page by the Space's string group key, asserting the folder is returned.

Manually, against a CMS Space that has Object Entry Folders (feature flag `LPD-17564` enabled):

1. Look up the Space's identifiers, and note its `siteId` (numeric group ID) and `assetLibraryKey` / `externalReferenceCode` (string keys):
   ```
   GET /o/headless-asset-library/v1.0/asset-libraries?pageSize=100
   ```
2. Query by the numeric ID — folders are returned:
   ```
   GET /o/headless-object/v1.0/scopes/{siteId}/object-entry-folders
   ```
3. Query by the string key — before the fix this returned an empty collection; now it returns the same folders:
   ```
   GET /o/headless-object/v1.0/scopes/{assetLibraryKey}/object-entry-folders