### PR TITLE
LCI-5246 [CNE][AI-Hub] Chart should disable the use of envoy and enable gateway-api

### DIFF
--- a/cloud/helm/default/templates/_statefulset.tpl
+++ b/cloud/helm/default/templates/_statefulset.tpl
@@ -278,14 +278,24 @@ spec:
         -   backendRefs:
                 -   name: {{ include "liferay.name" $ctx.root }}{{ $suffix }}
                     port: {{ $backendPort }}
+            {{- if $ctx.statefulset.network.hsts.enabled }}
+            filters:
+                -   type: ResponseHeaderModifier
+                    responseHeaderModifier:
+                        set:
+                            -   name: Strict-Transport-Security
+                                value: {{ $ctx.statefulset.network.hsts.value | quote }}
+            {{- end }}
             matches:
                 -   path:
                         type: PathPrefix
                         value: /
+            {{- if not $ctx.statefulset.network.gke.enabled }}
             {{- with $ctx.statefulset.network.timeouts }}
             timeouts:
                 backendRequest: {{ .backendRequest }}
                 request: {{ .request }}
+            {{- end }}
             {{- end }}
 {{- end }}
 {{- else }}
@@ -319,14 +329,24 @@ spec:
         -   backendRefs:
                 -   name: {{ include "liferay.name" .root }}{{ $suffix }}
                     port: {{ $backendPort }}
+            {{- if .statefulset.network.hsts.enabled }}
+            filters:
+                -   type: ResponseHeaderModifier
+                    responseHeaderModifier:
+                        set:
+                            -   name: Strict-Transport-Security
+                                value: {{ .statefulset.network.hsts.value | quote }}
+            {{- end }}
             matches:
                 -   path:
                         type: PathPrefix
                         value: /
+            {{- if not .statefulset.network.gke.enabled }}
             {{- with .statefulset.network.timeouts }}
             timeouts:
                 backendRequest: {{ .backendRequest }}
                 request: {{ .request }}
+            {{- end }}
             {{- end }}
         {{- with .statefulset.network.extraRules }}
         {{- toYaml . | nindent 8 }}

--- a/cloud/helm/default/templates/gcpbackendpolicy.yaml
+++ b/cloud/helm/default/templates/gcpbackendpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.network.gke.enabled }}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+    labels:
+        app: {{ include "liferay.name" . }}
+        {{- include "liferay.labels" . | nindent 8 }}
+    name: {{ include "liferay.name" . }}
+    namespace: {{ include "liferay.namespace" . }}
+spec:
+    default:
+        timeoutSec: {{ .Values.network.gke.backendConfig.timeoutSec }}
+    targetRef:
+        group: ""
+        kind: Service
+        name: {{ include "liferay.name" . }}
+{{- end }}

--- a/cloud/helm/default/templates/healthcheckpolicy.yaml
+++ b/cloud/helm/default/templates/healthcheckpolicy.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.network.gke.enabled }}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+    labels:
+        app: {{ include "liferay.name" . }}
+        {{- include "liferay.labels" . | nindent 8 }}
+    name: {{ include "liferay.name" . }}
+    namespace: {{ include "liferay.namespace" . }}
+spec:
+    default:
+        config:
+            type: HTTP
+            httpHealthCheck:
+                port: {{ .Values.network.gke.healthCheck.port }}
+                requestPath: {{ .Values.network.gke.healthCheck.path }}
+    targetRef:
+        group: ""
+        kind: Service
+        name: {{ include "liferay.name" . }}
+{{- end }}

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -298,7 +298,17 @@ network:
     extraRules: []
     forceHttpsRedirect: false
     gatewayName: ""
+    gke:
+        backendConfig:
+            timeoutSec: 300
+        enabled: false
+        healthCheck:
+            path: /c/portal/robots
+            port: 8080
     hostnames: []
+    hsts:
+        enabled: true
+        value: "max-age=31536000; includeSubDomains; preload"
     perHostnameRoutes: false
     securityPolicyAuthorizationSpec: {}
     timeouts: {}

--- a/cloud/helm/gcp-infrastructure/templates/_helpers.tpl
+++ b/cloud/helm/gcp-infrastructure/templates/_helpers.tpl
@@ -37,3 +37,9 @@
 {{- printf "liferay-licenses-%s" $trimmed -}}
 {{- end }}
 {{- end -}}
+
+{{- define "liferay.gateway.isEnvoy" -}}
+{{- if hasPrefix "envoy-gateway" (.Values.gateway.className | default "") -}}
+true
+{{- end -}}
+{{- end -}}

--- a/cloud/helm/gcp-infrastructure/templates/gateway.yaml
+++ b/cloud/helm/gcp-infrastructure/templates/gateway.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.enabled .Values.gateway.className .Values.gateway.name }}
+{{- if include "liferay.gateway.isEnvoy" . }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
@@ -21,6 +22,7 @@ spec:
             matchLabels:
                 name: {{ .Values.gateway.name }}
 ---
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:


### PR DESCRIPTION
Our current CNE chart should allow switching from using envoy to using gateway-api as an option.