### PR TITLE
LPD-97633 Add showFragmentNameInput prop to FragmentSetModal

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
@@ -29,6 +29,7 @@ export default function FragmentSetModal({
 	fragmentEntryIds = [],
 	onSubmitFragmentCollection,
 	portletNamespace,
+	showFragmentNameInput = false,
 }: {
 	addFragmentCollectionURL?: string;
 	contributedEntryKeys?: string[];
@@ -36,9 +37,11 @@ export default function FragmentSetModal({
 	fragmentCollections: FragmentSet[];
 	fragmentEntryIds?: string[];
 	onSubmitFragmentCollection?: (
-		fragmentCollectionId: number
+		fragmentCollectionId: number,
+		fragmentName?: string
 	) => Promise<void> | void;
 	portletNamespace: string;
+	showFragmentNameInput?: boolean;
 }) {
 	const [visible, setVisible] = useState(true);
 
@@ -47,6 +50,7 @@ export default function FragmentSetModal({
 	});
 
 	const [errors, setErrors] = useState<Errors>({});
+	const [fragmentName, setFragmentName] = useState('');
 	const [showFragmentSetForm, setShowFragmentSetForm] = useState(
 		!fragmentCollections.length
 	);
@@ -54,9 +58,20 @@ export default function FragmentSetModal({
 	const formId = `${portletNamespace}form`;
 
 	const submitFragmentCollection = (fragmentCollectionId: number) => {
+		if (showFragmentNameInput && !fragmentName) {
+			setErrors({
+				name: sub(
+					Liferay.Language.get('x-field-is-required'),
+					Liferay.Language.get('name')
+				),
+			});
+
+			return;
+		}
+
 		if (onSubmitFragmentCollection) {
 			onClose();
-			onSubmitFragmentCollection(fragmentCollectionId);
+			onSubmitFragmentCollection(fragmentCollectionId, fragmentName);
 
 			return;
 		}
@@ -128,9 +143,11 @@ export default function FragmentSetModal({
 			<ClayModal.Header
 				closeButtonAriaLabel={Liferay.Language.get('close')}
 			>
-				{showFragmentSetForm
-					? Liferay.Language.get('add-fragment-set')
-					: Liferay.Language.get('select-fragment-set')}
+				{showFragmentNameInput
+					? Liferay.Language.get('add-fragment')
+					: showFragmentSetForm
+						? Liferay.Language.get('add-fragment-set')
+						: Liferay.Language.get('select-fragment-set')}
 			</ClayModal.Header>
 
 			<ClayModal.Body>
@@ -141,6 +158,26 @@ export default function FragmentSetModal({
 					>
 						{errors.error}
 					</ClayAlert>
+				)}
+
+				{showFragmentNameInput && (
+					<FormField
+						error={errors.name}
+						id={`${portletNamespace}fragmentName`}
+						name={Liferay.Language.get('name')}
+						required
+					>
+						<ClayInput
+							id={`${portletNamespace}fragmentName`}
+							onChange={(event) => {
+								setErrors({...errors, name: null});
+								setFragmentName(event.target.value);
+							}}
+							required
+							type="text"
+							value={fragmentName}
+						/>
+					</FormField>
 				)}
 
 				{showFragmentSetForm ? (


### PR DESCRIPTION
## Summary

- Extend `FragmentSetModal` in `layout-js-components-web` with an optional prop `showFragmentNameInput` that renders a required fragment name input above the modal body and switches the header to `add-fragment`.
- Widen the `onSubmitFragmentCollection` callback signature to `(fragmentCollectionId, fragmentName?)` so the caller can persist the collected name on submit.
- Backwards compatible: without the new prop, the modal behaves exactly as today (both the header copy and the callback ignore the extra state).

Prepares the modal for reuse from the Design Library resources listing, where the same widget will drive the `Add Fragment` flow. The Design Library and fragment portlet pieces land in separate subtasks under LPD-97407.

## Test plan

- [ ] `<gradlew> formatSource` on `layout-js-components-web` passes.
- [ ] Existing `Add Fragment Set` flow in the Fragments admin portlet still renders and submits without regressions.
- [ ] Manual: opening the modal with `showFragmentNameInput={true}` shows the name input, requires it before submit, and forwards the value to `onSubmitFragmentCollection`.
- [ ] Manual: opening the modal without the new prop keeps the current header (`add-fragment-set` or `select-fragment-set`) and the current single-argument callback path.