### PR TITLE
LCD-52534 [CNE][GCP-Infra] Add SkipDryRunOnMissingResource to Crossplane/provider objects

### DIFF
--- a/cloud/helm/gcp-infrastructure-provider/templates/environment-config.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/templates/environment-config.yaml
@@ -7,5 +7,6 @@ data:
 kind: EnvironmentConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
     name: environment-config

--- a/cloud/helm/gcp-infrastructure-provider/templates/liferayinfrastructure-composition.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/templates/liferayinfrastructure-composition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
     annotations:
-        argocd.argoproj.io/sync-options: ServerSideApply=true
+        argocd.argoproj.io/sync-options: ServerSideApply=true,SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-60"
     name: liferayinfrastructures.gcp.liferay.com
 spec:
@@ -121,6 +121,7 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-50"
     name: liferay-gcp-infrastructure-provider.gcp.liferay.com
 spec:

--- a/cloud/helm/gcp-infrastructure-provider/templates/liferayoverlay-composition.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/templates/liferayoverlay-composition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
     annotations:
-        argocd.argoproj.io/sync-options: ServerSideApply=true
+        argocd.argoproj.io/sync-options: ServerSideApply=true,SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-60"
     name: liferayoverlays.gcp.liferay.com
 spec:
@@ -55,6 +55,7 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-50"
     name: liferay-gcp-overlay.gcp.liferay.com
 spec:

--- a/cloud/helm/gcp-infrastructure-provider/templates/provider-configs.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/templates/provider-configs.yaml
@@ -2,6 +2,7 @@ apiVersion: gcp.m.upbound.io/v1beta1
 kind: ClusterProviderConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-70"
     name: default
 spec:
@@ -13,6 +14,7 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: ClusterProviderConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-70"
     name: default
 spec:

--- a/cloud/helm/gcp-infrastructure-provider/templates/providers.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/templates/providers.yaml
@@ -3,6 +3,7 @@ apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-80"
     name: provider-gcp-compute
 spec:
@@ -14,6 +15,7 @@ apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-80"
     name: provider-gcp-cloudplatform
 spec:
@@ -25,6 +27,7 @@ apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-80"
     name: provider-gcp-kms
 spec:
@@ -36,6 +39,7 @@ apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-80"
     name: provider-gcp-sql
 spec:
@@ -47,6 +51,7 @@ apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-80"
     name: provider-gcp-storage
 spec:
@@ -58,7 +63,7 @@ apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
     annotations:
-        argocd.argoproj.io/sync-options: ServerSideApply=true
+        argocd.argoproj.io/sync-options: ServerSideApply=true,SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-80"
     name: provider-kubernetes
 spec:
@@ -71,6 +76,7 @@ apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-80"
     name: upbound-provider-family-gcp
 spec:

--- a/cloud/helm/gcp-infrastructure-provider/templates/runtime-configs.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/templates/runtime-configs.yaml
@@ -2,6 +2,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-90"
     name: gcp-cloudplatform-config
 spec:
@@ -45,6 +46,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-90"
     name: gcp-compute-config
 spec:
@@ -84,6 +86,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-90"
     name: gcp-family-config
 spec:
@@ -123,6 +126,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-90"
     name: gcp-kms-config
 spec:
@@ -162,6 +166,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-90"
     name: gcp-sql-config
 spec:
@@ -201,6 +206,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-90"
     name: gcp-storage-config
 spec:
@@ -240,6 +246,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-90"
     name: kubernetes-config
 spec:

--- a/cloud/helm/gcp-infrastructure-provider/templates/templates-environment-config.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/templates/templates-environment-config.yaml
@@ -13,5 +13,6 @@ data:
 kind: EnvironmentConfig
 metadata:
     annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
     name: liferay-template-store


### PR DESCRIPTION
The chart already sets [argocd.argoproj.io/sync-wave](http://argocd.argoproj.io/sync-wave) for ordering, but is missing SkipDryRunOnMissingResource=true on every one of these objects. On a fresh cluster, ArgoCD runs a single dry-run over the whole manifest set before any wave executes; every kind whose CRD isn't registered yet (ClusterProviderConfig guaranteed, plus all  http://crossplane.io/  kinds until the crossplane app is healthy) makes the dry-run fail with no matches for kind ..., rejecting the entire sync before wave ordering can help.  ClusterProviderConfig is the sharpest case: its CRD never exists on a fresh cluster until the providers install and go Healthy.

Sync-waves are intra-app only, so they can't wait on the crossplane controller (a separate Application) either — SkipDryRunOnMissingResource + selfHeal is what lets the sync survive the missing CRDs and converge.