### PR TITLE
LPD-98221 Assert AI Creator checkbox state before saving

### DIFF
--- a/modules/test/playwright/pages/product-navigation-applications-menu/AICreatorSettingsPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/AICreatorSettingsPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {waitForAlert} from '../../utils/waitForAlert';
 import {GlobalMenuPage} from './GlobalMenuPage';
@@ -23,10 +23,10 @@ export class AICreatorInstanceSettingsPage {
 		this.page = page;
 
 		this.apiKeyInput = this.page.getByLabel('API Key');
-		this.chatGPTCheckbox = this.page.getByText(
+		this.chatGPTCheckbox = this.page.getByLabel(
 			'Enable ChatGPT to Create Content'
 		);
-		this.dalleCheckbox = this.page.getByText(
+		this.dalleCheckbox = this.page.getByLabel(
 			'Enable DALL-E to Create Images'
 		);
 		this.globalMenuPage = new GlobalMenuPage(page);
@@ -44,6 +44,9 @@ export class AICreatorInstanceSettingsPage {
 		await this.goto();
 
 		await this.chatGPTCheckbox.uncheck();
+
+		await expect(this.chatGPTCheckbox).not.toBeChecked();
+
 		await this.saveButton.click();
 
 		await waitForAlert(this.page);
@@ -53,6 +56,9 @@ export class AICreatorInstanceSettingsPage {
 		await this.goto();
 
 		await this.chatGPTCheckbox.check();
+
+		await expect(this.chatGPTCheckbox).toBeChecked();
+
 		await this.saveButton.click();
 
 		await waitForAlert(this.page);
@@ -62,6 +68,9 @@ export class AICreatorInstanceSettingsPage {
 		await this.goto();
 
 		await this.dalleCheckbox.check();
+
+		await expect(this.dalleCheckbox).toBeChecked();
+
 		await this.saveButton.click();
 
 		await waitForAlert(this.page);
@@ -71,6 +80,9 @@ export class AICreatorInstanceSettingsPage {
 		await this.goto();
 
 		await this.dalleCheckbox.uncheck();
+
+		await expect(this.dalleCheckbox).not.toBeChecked();
+
 		await this.saveButton.click();
 
 		await waitForAlert(this.page);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98221

## What Is Being Fixed

The `AICreatorInstanceSettingsPage` Playwright page object located the "Enable ChatGPT to Create Content" and "Enable DALL-E to Create Images" checkboxes with `getByText(...)` and toggled them without verifying that the toggle took effect. `getByText` matches the label's text node rather than the input control, which is a fragile way to reach a checkbox, and because no assertion followed the `check()`/`uncheck()` calls, a toggle that silently failed to register would still let the test click Save and pass.

## How It Is Being Fixed

The two checkbox locators now use `getByLabel(...)`, which resolves the actual input associated with the visible label. Each of the four toggle methods asserts the resulting checkbox state with `expect(...).toBeChecked()` / `.not.toBeChecked()` immediately after the toggle and before clicking Save, so the page object fails fast at the toggle step instead of masking the problem downstream. `expect` was added to the `@playwright/test` import to support the assertions.

## Why Are There No Tests?

This change only hardens Playwright test infrastructure — a page object used by the AI Creator settings tests. It strengthens assertions on already-covered flows and introduces no product code, so there is no new behavior to cover with additional tests.

## PR Check

**pr-check: PASS** — tested on `8075c4206c0a0e7fe2077dad09407606b55f0ff3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "8075c4206c0a0e7fe2077dad09407606b55f0ff3"} -->
