### PR TITLE
LPD-98152 Fix image alignment not applying outside the editor

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_rich_editor.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_rich_editor.scss
@@ -1,3 +1,28 @@
 img.image_resized {
 	height: auto;
 }
+
+figure.image {
+	display: table;
+	margin: 0.9em auto;
+}
+
+figure.image img {
+	display: block;
+	max-width: 100%;
+}
+
+figure.image.image-style-block-align-left {
+	margin-left: 0;
+	margin-right: auto;
+}
+
+figure.image.image-style-block-align-right {
+	margin-left: auto;
+	margin-right: 0;
+}
+
+figure.image.image-style-side {
+	float: right;
+	max-width: 50%;
+}


### PR DESCRIPTION
# What is this trying to solve?

[LPD-98152](https://liferay.atlassian.net/browse/LPD-98152)

After enabling Enhanced Rich Text Editor, aligning an image (center, left, or right) in the Web Content CKEditor 5 field is not reflected when the article renders outside the editor, for example previewing through a Display Page Template's mapped Content field.

# How am I fixing it?


CKEditor 5 renders alignment using CSS classes (`image-style-block-align-left`, `image-style-block-align-right`, `image-style-side`, and the default centered `image` wrapper) that only exist inside the editor's own bundled stylesheet, scoped to `.ck-content`. Outside the editor, those classes have no meaning, so alignment is dropped.

`_rich_editor.scss` (frontend-theme-styled) — Added `figure.image`, `figure.image img`, `figure.image.image-style-block-align-left`, `figure.image.image-style-block-align-right`, and `figure.image.image-style-side` rules, scoped to the `figure` tag. This file loads on every themed page, so alignment now applies wherever rich text renders.


# How can you verify that it works?

1. Create a Web Content article using the Rich Text field, insert an image, and align it center, left, and right
2. Create a Display Page Template for Basic Web Content mapping the Content field, and preview the article through it
3. Confirm the image alignment matches what was set in the editor

[LPD-98152]: https://liferay.atlassian.net/browse/LPD-98152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ