### PR TITLE
LPP-64828 - Fix AMD -> ESM bridge `...spread`

### DIFF
--- a/modules/frontend-sdk/node-scripts/util/amd/writeExportBridges.mjs
+++ b/modules/frontend-sdk/node-scripts/util/amd/writeExportBridges.mjs
@@ -105,9 +105,12 @@ Liferay.Loader.define(
 	['module'],
 	function (module) {
 		module.exports = {
-			__esModule: true,
-			default: ${hashedImportPath},
 			...${hashedImportPath},
+			__esModule: true,
+			default:
+				${hashedImportPath}.default !== undefined
+					? ${hashedImportPath}.default
+					: ${hashedImportPath},
 		};
 	}
 );


### PR DESCRIPTION
Spread the namespace first, then force `__esModule` and `default` so the spread cannot clobber them

ESM-packaged libraries (e.g. clay 3.14x) export `__esModule` as a named export whose value is `undefined`; if `...` came last it would overwrite the bridge's `__esModule: true`, breaking `_interopRequireDefault` in consumers (which then double-wrap the bridge and render an object -> React #130). `default` falls back to the namespace when there is no default export.