### PR TITLE
LPD-99391 Fix empty form label on FDS selectable-table row checkbox

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -237,10 +237,6 @@ const Row = ({
 							>
 								{!item.editable && (
 									<SelectionComponent
-										aria-label={sub(
-											Liferay.Language.get('select-x'),
-											accessibleName
-										)}
 										checked={active}
 										onChange={() =>
 											onItemSelectionChange(item)
@@ -249,7 +245,16 @@ const Row = ({
 											'select-item'
 										)}
 										value={id}
-									/>
+									>
+										<span className="sr-only">
+											{sub(
+												Liferay.Language.get(
+													'select-x'
+												),
+												accessibleName
+											)}
+										</span>
+									</SelectionComponent>
 								)}
 							</ClayTableCell>
 						);


### PR DESCRIPTION
## LPD-99391

WAVE reports an **"Empty form label"** accessibility error on the row-selection checkboxes of any Frontend Data Set (FDS) table with `selectionType="multiple"` (reported by a customer on Publications → Review Changes, LPP-64957).

### Root cause
In `frontend-data-set-web` `views/table/Table.tsx`, the row selection checkbox (`ClayCheckbox`/`ClayRadio`) was given only an `aria-label` prop with no children, so Clay renders an empty `<label>` (empty `.custom-control-label` span). WAVE's "Empty form label" check fires on the empty wrapping `<label>` regardless of `aria-label`.

### Fix
Render the selection label as an `sr-only` child of the checkbox instead of using `aria-label`, matching the existing `SelectionCheckbox.tsx` (Select-All) pattern already used in the same module. The accessible name is preserved ("Select X") and the wrapping `<label>` is no longer empty.

### Testing
Built and deployed `frontend-data-set-web` and verified live on the Publications → Review Changes tab: the row checkbox `<label>` now contains its label text and a full-page scan reports 0 empty form labels associated with controls (previously 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)