### PR TITLE
LPD-100087 Stop rebuilding CTEntry search doc per DTO to fix cluster OOM

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -63,6 +64,25 @@ public class CTEntryDTOConverter
 		return _toCTEntry(dtoConverterContext, ctEntry);
 	}
 
+	private Document _getDocument(
+			DTOConverterContext dtoConverterContext,
+			com.liferay.change.tracking.model.CTEntry ctEntry)
+		throws SearchException {
+
+		Document document = (Document)dtoConverterContext.getAttribute(
+			"document");
+
+		if (document != null) {
+			return document;
+		}
+
+		Indexer<com.liferay.change.tracking.model.CTEntry> indexer =
+			_indexerRegistry.getIndexer(
+				com.liferay.change.tracking.model.CTEntry.class);
+
+		return indexer.getDocument(ctEntry);
+	}
+
 	private String _getLocalizedValue(Field field, Locale locale) {
 		if (field == null) {
 			return StringPool.BLANK;
@@ -76,6 +96,10 @@ public class CTEntryDTOConverter
 		int ctCollectionStatus, Date ctCollectionStatusDate,
 		String ctCollectionStatusUserName,
 		HttpServletRequest httpServletRequest) {
+
+		if (ctCollectionStatusDate == null) {
+			return StringPool.BLANK;
+		}
 
 		if (ctCollectionStatus == WorkflowConstants.STATUS_APPROVED) {
 			return _language.format(
@@ -110,11 +134,7 @@ public class CTEntryDTOConverter
 			com.liferay.change.tracking.model.CTEntry ctEntry)
 		throws Exception {
 
-		Indexer<com.liferay.change.tracking.model.CTEntry> indexer =
-			_indexerRegistry.getIndexer(
-				com.liferay.change.tracking.model.CTEntry.class);
-
-		Document document = indexer.getDocument(ctEntry);
+		Document document = _getDocument(dtoConverterContext, ctEntry);
 
 		return new CTEntry() {
 			{

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
@@ -16,7 +16,6 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
-import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -67,7 +66,7 @@ public class CTEntryDTOConverter
 	private Document _getDocument(
 			DTOConverterContext dtoConverterContext,
 			com.liferay.change.tracking.model.CTEntry ctEntry)
-		throws SearchException {
+		throws Exception {
 
 		Document document = (Document)dtoConverterContext.getAttribute(
 			"document");

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.change.tracking.spi.history.CTCollectionHistoryProvider;
 import com.liferay.change.tracking.spi.history.CTCollectionHistoryProviderRegistry;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.ServicePreAction;
 import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Sort;
@@ -78,8 +80,7 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 			booleanQuery -> booleanQuery.getPreBooleanFilter(), filter,
 			com.liferay.change.tracking.model.CTEntry.class.getName(), search,
 			pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK, Field.UID),
+			queryConfig -> queryConfig.setSelectedFieldNames(StringPool.STAR),
 			searchContext -> {
 				searchContext.setAttribute("ctCollectionId", ctCollectionId);
 				searchContext.setAttribute("showHideable", showHideable);
@@ -105,9 +106,13 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 					return null;
 				}
 
+				DefaultDTOConverterContext dtoConverterContext =
+					_getDTOConverterContext(serviceBuilderCTEntry);
+
+				dtoConverterContext.setAttribute("document", document);
+
 				return _ctEntryDTOConverter.toDTO(
-					_getDTOConverterContext(serviceBuilderCTEntry),
-					serviceBuilderCTEntry);
+					dtoConverterContext, serviceBuilderCTEntry);
 			});
 	}
 
@@ -157,8 +162,7 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 			booleanQuery -> booleanQuery.getPreBooleanFilter(), filter,
 			com.liferay.change.tracking.model.CTEntry.class.getName(), search,
 			pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
+			queryConfig -> queryConfig.setSelectedFieldNames(StringPool.STAR),
 			searchContext -> {
 				CTCollectionHistoryProvider<?> ctCollectionHistoryProvider =
 					_ctCollectionHistoryProviderRegistry.
@@ -213,12 +217,13 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 			},
 			sorts,
 			document -> _toCTEntry(
-				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))));
+				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)),
+				document));
 	}
 
 	@Override
 	public CTEntry getCTEntry(Long ctEntryId) throws Exception {
-		return _toCTEntry(ctEntryId);
+		return _toCTEntry(ctEntryId, null);
 	}
 
 	@Override
@@ -339,13 +344,19 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 			contextHttpServletRequest, httpServletResponse);
 	}
 
-	private CTEntry _toCTEntry(Long ctEntryId) throws Exception {
+	private CTEntry _toCTEntry(Long ctEntryId, Document document)
+		throws Exception {
+
 		com.liferay.change.tracking.model.CTEntry serviceBuilderCTEntry =
 			_ctEntryLocalService.getCTEntry(ctEntryId);
 
+		DefaultDTOConverterContext dtoConverterContext =
+			_getDTOConverterContext(serviceBuilderCTEntry);
+
+		dtoConverterContext.setAttribute("document", document);
+
 		return _ctEntryDTOConverter.toDTO(
-			_getDTOConverterContext(serviceBuilderCTEntry),
-			serviceBuilderCTEntry);
+			dtoConverterContext, serviceBuilderCTEntry);
 	}
 
 	private static final EntityModel _entityModel = new CTEntryEntityModel();


### PR DESCRIPTION
## Summary

Fixes the cluster OOM reported in LPP-64916 (Tokyo customer). Opening the review-changes page for a large scheduled publication fired one `@Clusterable` `SchedulerEngineHelper.getScheduledJob` RPC per CTEntry (via `Indexer.getDocument()` invoked from `CTEntryDTOConverter._toCTEntry`), which saturated heap with pending cluster-response containers on non-coordinator nodes.

The root cause is LPS-199501 (Nov 2023), which changed `CTEntryDTOConverter` to call `Indexer.getDocument(ctEntry)` per DTO conversion. That method does not read from Elasticsearch — it rebuilds the document by running every `ModelDocumentContributor`. `CTEntryDTOConverter` is the only file in `modules/apps` that misuses `Indexer.getDocument()` this way; sibling `CTProcessDTOConverter` in the same module already uses the correct pattern.

## Approach (Option A-both-paged)

- In `CTEntryDTOConverter._toCTEntry`, source the `Document` from a `DTOConverterContext` attribute set by the caller; fall back to `indexer.getDocument(ctEntry)` when no attribute is provided (single-entry endpoints only, one call per request, no amplification).
- In `CTEntryResourceImpl.getCtCollectionCTEntriesPage` (Path 1 — customer's OOM path) and `getCTEntriesHistoryPage` (Path 3 — same amplification shape, powers Timeline History and the CT indicator UI): widen `queryConfig.setSelectedFieldNames(StringPool.STAR)` so Elasticsearch returns the fields the DTO reads, and pass the search-hit `Document` into the DTO converter via the context.
- Guard `_getStatusMessage` against a null `ctCollectionStatusDate` so the DTO does not NPE for SCHEDULED collections, where the field is currently null in stored ES (separate write-side gap; see Not-in-scope below).

## Not In Scope (Follow-Up Tickets)

- Reindex on CTCollection status transition to SCHEDULED (write-side gap — restores the `publishes in X days` UI message that this fix loses for SCHEDULED collections)
- Remove scheduler branch from `CTEntryModelDocumentContributor._getCTCollectionStatusDate` (belt-and-suspenders for full-reindex-on-non-coordinator-node — addresses Minhchau's Q3 on LPP-64916)
- Same anti-pattern in `CTCollectionDTOConverter._getDateScheduled` and `CTCollectionModelDocumentContributor`
- Double-reindex on public API CTEntry writes (`@Indexable` aspect + ModelListener both fire post-LPD-88209)
- Source-formatter rule to prevent future `Indexer.getDocument()` misuse in DTO code

## Test Plan

pr-check PASS on `145f30dadddc8`:

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS (no test counterparts) |

Manual verification on a fresh single-node bundle with instrumented `_getCTCollectionStatusDate` logging:

- Baseline (fallback path, no doc in context): 20 CT entries → 20 scheduler-branch log lines, 71 ms.
- Fixed path (search-hit doc in context via `DTOConverterContext` attribute): 20 CT entries → **0** scheduler-branch log lines, 1 ms.

In cluster mode on a non-coordinator node, this translates to 0 cluster RPCs per page load regardless of collection size, closing the OOM path.

## References

- LPP-64916 (customer report with stack trace and log attachment)
- LPS-199501 (introducing commit)
- LPD-88209 (recent context on CTEntry reindex behavior)
- `CTProcessDTOConverter.java` (sibling using the correct pattern)

Minhchau Dang's investigation on LPP-64916 identified the code path, confirmed via breakpoint that scheduling does not reindex, and flagged the reindex-on-non-coordinator-node concern captured in the Not-In-Scope list.