### PR TITLE
LPD-102719 Make the color picker's saturation and brightness map operable

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/docs/color-picker.mdx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/docs/color-picker.mdx
@@ -49,3 +49,29 @@ Color Picker is delivered in 4 different ways: default colors, custom colors, na
 -   **Small**: use the [`small`](#api-small) API to size the color picker input to match other small inputs.
 
 We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/design-system-components-colorpicker--default).
+
+## Accessibility
+
+The saturation and brightness map in the custom color editor is operable from the keyboard. Focus its handle and:
+
+-   **Arrow keys** move one step: left and right along saturation, up and down along brightness.
+-   **Shift + Arrow keys** move ten steps at a time.
+-   **Page Up** and **Page Down** move brightness ten steps at a time.
+-   **Home** and **End** take saturation to its minimum and maximum.
+
+The handle is a `slider` that reports the current saturation as its value, and both values through `aria-valuetext`. Its labels can be translated through the `ariaLabels` attribute, where the component replaces `{0}` with the saturation and `{1}` with the brightness.
+
+```jsx
+<ClayColorPicker
+	ariaLabels={{
+		saturationAndBrightness: 'Saturation and brightness',
+		saturationAndBrightnessIs: 'Saturation {0}%, brightness {1}%',
+		selectColor: 'Select a color',
+		selectionIs: 'Color selection is {0}',
+	}}
+	colors={colors}
+	onColorsChange={setColors}
+	onChange={setColor}
+	value={color}
+/>
+```

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/Editor.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/Editor.tsx
@@ -122,6 +122,15 @@ function RGBInput({name, onChange, value}: RGBInputProps) {
 }
 
 type Props = {
+
+	/**
+	 * Labels for the aria attributes
+	 */
+	ariaLabels: {
+		saturationAndBrightness?: string;
+		saturationAndBrightnessIs?: string;
+	};
+
 	color: Instance;
 	colors: Array<string>;
 	hex: string;
@@ -134,6 +143,7 @@ type Props = {
 };
 
 export function Editor({
+	ariaLabels,
 	color,
 	colors,
 	hex,
@@ -172,14 +182,20 @@ export function Editor({
 			/>
 			<div className="clay-color-map-group">
 				<GradientSelector
+					ariaLabels={ariaLabels}
 					color={color}
 					hue={hue}
 					onChange={(saturation, visibility) => {
+
+						// As fractions rather than as percentages: tinycolor
+						// reads a value of 1 or less as a fraction, so a
+						// saturation of 1% would otherwise arrive as 100%.
+
 						onColorChange(
 							tinycolor({
 								h: hue,
-								s: saturation,
-								v: visibility,
+								s: saturation / 100,
+								v: visibility / 100,
 							}).setAlpha(color.getAlpha())
 						);
 					}}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/GradientSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/GradientSelector.tsx
@@ -3,13 +3,27 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {sub} from '@clayui/shared';
 import React from 'react';
 import tinycolor from 'tinycolor2';
 
 import {usePointerPosition} from './hooks';
 import {colorToXY, xToSaturation, yToVisibility} from './util';
 
+const MAX = 100;
+const MIN = 0;
+const STEP = 1;
+const STEP_LARGE = 10;
+
 type Props = {
+
+	/**
+	 * Labels for the aria attributes
+	 */
+	ariaLabels?: {
+		saturationAndBrightness?: string;
+		saturationAndBrightnessIs?: string;
+	};
 
 	/**
 	 * Color value that is currently selected.
@@ -27,6 +41,43 @@ type Props = {
 	onChange?: (saturation: number, visibility: number) => void;
 };
 
+const clamp = (value: number) => Math.min(MAX, Math.max(MIN, value));
+
+/**
+ * The saturation and brightness a key press asks for, or nothing when the
+ * key is not one this control answers to. Left and right move along
+ * saturation, up and down along brightness, and Shift takes ten at a
+ * time.
+ */
+function stepFrom(
+	event: React.KeyboardEvent,
+	saturation: number,
+	brightness: number
+): [number, number] | null {
+	const step = event.shiftKey ? STEP_LARGE : STEP;
+
+	switch (event.key) {
+		case 'ArrowDown':
+			return [saturation, brightness - step];
+		case 'ArrowLeft':
+			return [saturation - step, brightness];
+		case 'ArrowRight':
+			return [saturation + step, brightness];
+		case 'ArrowUp':
+			return [saturation, brightness + step];
+		case 'End':
+			return [MAX, brightness];
+		case 'Home':
+			return [MIN, brightness];
+		case 'PageDown':
+			return [saturation, brightness - STEP_LARGE];
+		case 'PageUp':
+			return [saturation, brightness + STEP_LARGE];
+		default:
+			return null;
+	}
+}
+
 const useIsomorphicLayoutEffect =
 	typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
 
@@ -34,6 +85,7 @@ const useIsomorphicLayoutEffect =
  * Renders GradientSelector component
  */
 function ClayColorPickerGradientSelector({
+	ariaLabels,
 	color,
 	onChange = () => {},
 	hue = 0,
@@ -59,6 +111,11 @@ function ClayColorPickerGradientSelector({
 	}, [color]);
 	React.useEffect(() => removeListeners, []);
 
+	const {s, v} = color.toHsv();
+
+	const saturation = Math.round(s * 100);
+	const brightness = Math.round(v * 100);
+
 	return (
 		<div
 			className="clay-color-map clay-color-map-hsb"
@@ -78,8 +135,34 @@ function ClayColorPickerGradientSelector({
 				backgroundImage: `linear-gradient(to top, #000, rgba(0, 0, 0, 0)), linear-gradient(to right, #FFF, rgba(255, 255, 255, 0))`,
 			}}
 		>
+			{/*
+			  * The handle is the control: it carries the name, the values
+			  * and the keys, so the map can be operated without dragging
+			  * it (WCAG 2.1.1, 2.5.7 and 4.1.2). The pointer path above is
+			  * untouched.
+			  */}
 			<button
+				aria-label={ariaLabels?.saturationAndBrightness}
+				aria-valuemax={MAX}
+				aria-valuemin={MIN}
+				aria-valuenow={saturation}
+				aria-valuetext={sub(
+					ariaLabels?.saturationAndBrightnessIs || '',
+					[saturation, brightness]
+				)}
 				className="clay-color-map-pointer clay-color-pointer"
+				onKeyDown={(event) => {
+					const step = stepFrom(event, saturation, brightness);
+
+					if (!step) {
+						return;
+					}
+
+					event.preventDefault();
+
+					onChange(clamp(step[0]), clamp(step[1]));
+				}}
+				role="slider"
 				style={{
 					background: color.toHexString(),
 					left: x - 7,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/__tests__/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/__tests__/index.tsx
@@ -346,6 +346,79 @@ describe('Interactions', () => {
 			expect(handleColorsChange.mock.calls[0][0][0]).toBe('5BB0A5');
 		});
 
+		it('describes the gradient map handle as a slider', () => {
+			const handle = document.querySelector(
+				'.clay-color-map-pointer'
+			) as HTMLElement;
+
+			expect(handle.getAttribute('role')).toBe('slider');
+			expect(handle.getAttribute('aria-label')).toBe(
+				'Saturation and brightness'
+			);
+			expect(handle.getAttribute('aria-valuemin')).toBe('0');
+			expect(handle.getAttribute('aria-valuemax')).toBe('100');
+			expect(handle.getAttribute('aria-valuenow')).toBe('0');
+			expect(handle.getAttribute('aria-valuetext')).toBe(
+				'Saturation 0%, brightness 100%'
+			);
+		});
+
+		it('changes the color from the gradient map with the arrow keys', () => {
+			const handle = document.querySelector(
+				'.clay-color-map-pointer'
+			) as HTMLElement;
+
+			fireEvent.keyDown(handle, {key: 'ArrowRight'});
+
+			expect(handleColorsChange).toBeCalledTimes(1);
+			expect(handleColorsChange.mock.calls[0][0][0]).toBe('FFFCFC');
+		});
+
+		it('moves ten steps at a time with shift', () => {
+			const handle = document.querySelector(
+				'.clay-color-map-pointer'
+			) as HTMLElement;
+
+			fireEvent.keyDown(handle, {key: 'ArrowRight', shiftKey: true});
+
+			expect(handleColorsChange).toBeCalledTimes(1);
+			expect(handleColorsChange.mock.calls[0][0][0]).toBe('FFE6E6');
+		});
+
+		it('takes a saturation of one percent as one percent', () => {
+			const handle = document.querySelector(
+				'.clay-color-map-pointer'
+			) as HTMLElement;
+
+			// A fraction of 1 would be read as the whole of it, which is
+			// what the Editor's conversion prevents.
+
+			fireEvent.keyDown(handle, {key: 'ArrowRight'});
+
+			expect(handleColorsChange.mock.calls[0][0][0]).not.toBe('FF0000');
+		});
+
+		it('reaches the extremes with Home and End', () => {
+			const handle = document.querySelector(
+				'.clay-color-map-pointer'
+			) as HTMLElement;
+
+			fireEvent.keyDown(handle, {key: 'End'});
+
+			expect(handleColorsChange).toBeCalledTimes(1);
+			expect(handleColorsChange.mock.calls[0][0][0]).toBe('FF0000');
+		});
+
+		it('leaves keys it does not answer to alone', () => {
+			const handle = document.querySelector(
+				'.clay-color-map-pointer'
+			) as HTMLElement;
+
+			fireEvent.keyDown(handle, {key: 'a'});
+
+			expect(handleColorsChange).not.toBeCalled();
+		});
+
 		it('changes the color by changing the hue', () => {
 			const [hueSlider] = getAllByRole(
 				document.body,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-color-picker/src/index.tsx
@@ -56,6 +56,8 @@ const DEFAULT_COLORS = [
 const BLANK_COLORS = Array(12).fill('FFFFFF');
 
 const DEFAULT_ARIA_LABELS = {
+	saturationAndBrightness: 'Saturation and brightness',
+	saturationAndBrightnessIs: 'Saturation {0}%, brightness {1}%',
 	selectColor: 'Select a color',
 	selectionIs: 'Color selection is {0}',
 };
@@ -73,6 +75,8 @@ interface IProps
 	 * Labels for the aria attributes
 	 */
 	ariaLabels?: {
+		saturationAndBrightness?: string;
+		saturationAndBrightnessIs?: string;
 		selectColor: string;
 		selectionIs: string;
 	};
@@ -406,6 +410,10 @@ function ColorPicker({
 
 						{onColorsChange && customEditorActive && (
 							<Editor
+								ariaLabels={{
+									...DEFAULT_ARIA_LABELS,
+									...ariaLabels,
+								}}
 								color={color}
 								colors={customColors}
 								hex={state.hex}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102719

### The problem

The custom color editor cannot be used without a pointer. The palette half of `ClayColorPicker` is fine: the splotches are real buttons with titles, and the hue slider and the R, G and B fields are real form controls. The saturation and brightness map is not, and it is the part that makes the component a color picker rather than a palette.

In `GradientSelector.tsx` the map is a `div` that listens for `pointerdown` and then attaches `pointermove` and `pointerup` listeners on `window`. The handle inside it is:

```tsx
<button
	className="clay-color-map-pointer clay-color-pointer"
	style={{background: color.toHexString(), left: x - 7, top: y - 7}}
	type="button"
/>
```

It is focusable, and it is focused programmatically on `pointerdown`, but it has no accessible name, no role, no values, and there is no key handling anywhere in the package.

Against WCAG 2.2 AA that is three failures: **2.1.1 Keyboard** (a keyboard user reaches the handle and can do nothing with it, and the map is the only route to a custom color), **2.5.7 Dragging Movements** (choosing a saturation and a brightness requires a drag, with no single-pointer alternative) and **4.1.2 Name, Role, Value** (it is announced as an unnamed button).

### The change

The handle becomes the control, and the pointer path above it is untouched.

- `role="slider"` with `aria-valuemin`, `aria-valuemax`, `aria-valuenow` (saturation) and an `aria-valuetext` that announces both values, plus an `aria-label`.
- Keyboard: arrow keys move one step, left and right along saturation and up and down along brightness; `Shift` moves ten at a time; `Page Up` and `Page Down` move brightness by ten; `Home` and `End` take saturation to its extremes.
- The strings come from the existing `ariaLabels` prop, with defaults in `DEFAULT_ARIA_LABELS` and interpolation through `sub()`, the same convention the component already uses for `selectColor` and `selectionIs`. The two new keys are optional, so nothing that passes `ariaLabels` today breaks.

### One bug found on the way

`Editor.tsx` passed saturation and brightness to `tinycolor` as percentages, and `tinycolor` reads a value of 1 or less as a fraction. A saturation of 1% therefore arrived as 100%: a single arrow press jumped from white to fully saturated red. They now travel as fractions, which also fixes the same jump when a drag lands on the first pixel of the map.

### Tests and docs

Six tests in `src/__tests__/index.tsx` cover the handle's ARIA, the arrow keys, the larger `Shift` step, `Home` and `End`, keys the control should ignore, and the one percent case. `docs/color-picker.mdx` gains an Accessibility section with the key map and an `ariaLabels` example.

### Verification

The keyboard map and the ARIA were written against the package's own conventions, and the expected color values in the tests were checked against `tinycolor2` directly. The package's Jest suite could not be run in this checkout: the Clay workspace is not installed here (`raf` is missing and the setup files do not transform), so the suite runs on CI rather than locally.

### Why this matters beyond Clay

The Accessible Image Editor (LPD-102665) uses Clay for every control it has, with one exception: colors are a native `input type="color"`, because that control is labelled, keyboard operable and opens the operating system's own picker. The editor targets WCAG 2.2 AA, so adopting `ClayColorPicker` as it stands would import a barrier into the product. The exception costs it the Lexicon appearance, the shared palette, the recent colors and alpha. With this change the editor can switch to the Clay component, and so can anything else that needs a custom color.
