### PR TITLE
LCD-52972: restrict argocd-system ingress (default-deny + explicit allows)

### DIFF
--- a/cloud/terraform/gcp/gitops/platform/argocd.tf
+++ b/cloud/terraform/gcp/gitops/platform/argocd.tf
@@ -12,12 +12,6 @@ resource "helm_release" "argocd" {
 		yamlencode(
 			{
 				applicationSet={
-					metrics={
-						enabled=true
-					}
-					networkPolicy={
-						create=true
-					}
 					resources={
 						limits={
 							memory="768Mi"
@@ -104,6 +98,86 @@ resource "helm_release" "argocd" {
 							labels=merge(
 								local.common_labels,
 								{
+									"app.kubernetes.io/name"="argocd-applicationset-controller"
+								})
+							name="argocd-applicationset-controller-ingress"
+						}
+						spec={
+							ingress=[
+								{
+									from=[
+										{
+											namespaceSelector={
+												matchLabels={
+													"kubernetes.io/metadata.name"=var.observability_namespace
+												}
+											}
+										},
+									]
+									ports=[
+										{
+											port="metrics"
+											protocol="TCP"
+										},
+									]
+								},
+							]
+							podSelector={
+								matchLabels={
+									"app.kubernetes.io/instance"="argocd"
+									"app.kubernetes.io/name"="argocd-applicationset-controller"
+								}
+							}
+							policyTypes=["Ingress"]
+						}
+					},
+					{
+						apiVersion="networking.k8s.io/v1"
+						kind="NetworkPolicy"
+						metadata={
+							labels=merge(
+								local.common_labels,
+								{
+									"app.kubernetes.io/name"="argocd-notifications-controller"
+								})
+							name="argocd-notifications-controller-ingress"
+						}
+						spec={
+							ingress=[
+								{
+									from=[
+										{
+											namespaceSelector={
+												matchLabels={
+													"kubernetes.io/metadata.name"=var.observability_namespace
+												}
+											}
+										},
+									]
+									ports=[
+										{
+											port="metrics"
+											protocol="TCP"
+										},
+									]
+								},
+							]
+							podSelector={
+								matchLabels={
+									"app.kubernetes.io/instance"="argocd"
+									"app.kubernetes.io/name"="argocd-notifications-controller"
+								}
+							}
+							policyTypes=["Ingress"]
+						}
+					},
+					{
+						apiVersion="networking.k8s.io/v1"
+						kind="NetworkPolicy"
+						metadata={
+							labels=merge(
+								local.common_labels,
+								{
 									"app.kubernetes.io/name"="argocd-server"
 								})
 							name="argocd-server-ingress"
@@ -168,9 +242,9 @@ resource "helm_release" "argocd" {
 							labels=merge(
 								local.common_labels,
 								{
-									"app.kubernetes.io/name"="argocd-namespace-default-deny"
+									"app.kubernetes.io/name"="default-deny-ingress"
 								})
-							name="argocd-namespace-default-deny"
+							name="default-deny-ingress"
 						}
 						spec={
 							podSelector={}
@@ -180,12 +254,6 @@ resource "helm_release" "argocd" {
 				]
 				installCRDs=true
 				notifications={
-					metrics={
-						enabled=true
-					}
-					networkPolicy={
-						create=true
-					}
 					resources={
 						limits={
 							memory="256Mi"

--- a/cloud/terraform/gcp/gitops/platform/argocd.tf
+++ b/cloud/terraform/gcp/gitops/platform/argocd.tf
@@ -12,6 +12,12 @@ resource "helm_release" "argocd" {
 		yamlencode(
 			{
 				applicationSet={
+					metrics={
+						enabled=true
+					}
+					networkPolicy={
+						create=true
+					}
 					resources={
 						limits={
 							memory="768Mi"
@@ -63,6 +69,9 @@ resource "helm_release" "argocd" {
 					}
 				}
 				controller={
+					networkPolicy={
+						create=true
+					}
 					resources={
 						limits={
 							memory="8Gi"
@@ -74,6 +83,9 @@ resource "helm_release" "argocd" {
 					}
 				}
 				dex={
+					networkPolicy={
+						create=true
+					}
 					resources={
 						limits={
 							memory="768Mi"
@@ -84,8 +96,96 @@ resource "helm_release" "argocd" {
 						}
 					}
 				}
+				extraObjects=[
+					{
+						apiVersion="networking.k8s.io/v1"
+						kind="NetworkPolicy"
+						metadata={
+							labels=merge(
+								local.common_labels,
+								{
+									"app.kubernetes.io/name"="argocd-server"
+								})
+							name="argocd-server-ingress"
+						}
+						spec={
+							ingress=[
+								{
+									from=[
+										{
+											namespaceSelector={
+												matchLabels={
+													"kubernetes.io/metadata.name"=var.gateway_namespace
+												}
+											}
+											podSelector={
+												matchLabels={
+													"app.kubernetes.io/managed-by"="envoy-gateway"
+													"app.kubernetes.io/name"="envoy"
+													"gateway.envoyproxy.io/owning-gateway-namespace"=var.argocd_namespace
+												}
+											}
+										},
+									]
+									ports=[
+										{
+											port="server"
+											protocol="TCP"
+										},
+									]
+								},
+								{
+									from=[
+										{
+											namespaceSelector={
+												matchLabels={
+													"kubernetes.io/metadata.name"=var.observability_namespace
+												}
+											}
+										},
+									]
+									ports=[
+										{
+											port="metrics"
+											protocol="TCP"
+										},
+									]
+								},
+							]
+							podSelector={
+								matchLabels={
+									"app.kubernetes.io/instance"="argocd"
+									"app.kubernetes.io/name"="argocd-server"
+								}
+							}
+							policyTypes=["Ingress"]
+						}
+					},
+					{
+						apiVersion="networking.k8s.io/v1"
+						kind="NetworkPolicy"
+						metadata={
+							labels=merge(
+								local.common_labels,
+								{
+									"app.kubernetes.io/name"="argocd-namespace-default-deny"
+								})
+							name="argocd-namespace-default-deny"
+						}
+						spec={
+							podSelector={}
+							policyTypes=["Ingress"]
+						}
+					},
+				]
 				installCRDs=true
 				notifications={
+					metrics={
+						enabled=true
+					}
+					networkPolicy={
+						create=true
+					}
 					resources={
 						limits={
 							memory="256Mi"
@@ -97,6 +197,9 @@ resource "helm_release" "argocd" {
 					}
 				}
 				redis={
+					networkPolicy={
+						create=true
+					}
 					resources={
 						limits={
 							memory="256Mi"
@@ -112,6 +215,9 @@ resource "helm_release" "argocd" {
 						failureThreshold=6
 						periodSeconds=15
 						timeoutSeconds=10
+					}
+					networkPolicy={
+						create=true
 					}
 					readinessProbe={
 						periodSeconds=15
@@ -131,6 +237,9 @@ resource "helm_release" "argocd" {
 					livenessProbe={
 						initialDelaySeconds=90
 						timeoutSeconds=5
+					}
+					networkPolicy={
+						create=false
 					}
 					readinessProbe={
 						initialDelaySeconds=60

--- a/cloud/terraform/gcp/gitops/platform/tests/argocd.tftest.hcl
+++ b/cloud/terraform/gcp/gitops/platform/tests/argocd.tftest.hcl
@@ -72,66 +72,90 @@ run "should_enable_per_component_network_policies_without_the_global_toggle" {
 		error_message="dex.networkPolicy.create must be true so the chart renders its scoped NetworkPolicy"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).applicationSet.networkPolicy.create == true && yamldecode(helm_release.argocd.values[0]).applicationSet.metrics.enabled == true
-		error_message="applicationSet needs both networkPolicy.create and metrics.enabled — the chart's template ANDs (create OR global.create) with (metrics.enabled OR ingress.enabled), so metrics.enabled alone or networkPolicy.create alone is not enough"
-	}
-	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).notifications.networkPolicy.create == true && yamldecode(helm_release.argocd.values[0]).notifications.metrics.enabled == true
-		error_message="notifications needs both networkPolicy.create and metrics.enabled — same AND condition as applicationSet"
-	}
-	assert {
 		condition=yamldecode(helm_release.argocd.values[0]).server.networkPolicy.create == false
 		error_message="server.networkPolicy.create must stay false — the chart's own argocd-server NetworkPolicy is unconditionally ingress: [{}] (allow from anywhere); the manual extraObjects policy is the only thing that should govern this pod's ingress"
 	}
+	assert {
+		condition=!contains(keys(yamldecode(helm_release.argocd.values[0]).applicationSet), "metrics") && !contains(keys(yamldecode(helm_release.argocd.values[0]).applicationSet), "networkPolicy")
+		error_message="applicationSet.metrics.enabled must stay untouched (chart default is false) — turning it on to get a chart-native NetworkPolicy also turns on the chart's Prometheus metrics server as a side effect. The applicationset-controller's ingress is covered by a manual extraObjects policy instead, so networkPolicy.create here would be a no-op anyway"
+	}
+	assert {
+		condition=!contains(keys(yamldecode(helm_release.argocd.values[0]).notifications), "metrics") && !contains(keys(yamldecode(helm_release.argocd.values[0]).notifications), "networkPolicy")
+		error_message="notifications.metrics.enabled must stay untouched (chart default is false) — same reasoning as applicationSet: the manual extraObjects policy covers its ingress instead"
+	}
 	command=plan
 }
-run "should_scope_the_manual_argocd_server_networkpolicy_correctly" {
+run "should_scope_the_manual_network_policies_correctly" {
 	assert {
-		condition=length(yamldecode(helm_release.argocd.values[0]).extraObjects) == 2
-		error_message="Two extra manifests are expected: the scoped argocd-server policy and the namespace-wide default-deny that replaces the chart's own (unusable) global.defaultDenyIngress"
+		condition=length(yamldecode(helm_release.argocd.values[0]).extraObjects) == 4
+		error_message="Four extra manifests are expected: scoped ingress policies for argocd-server, argocd-applicationset-controller, argocd-notifications-controller, plus the namespace-wide default-deny"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].kind == "NetworkPolicy"
-		error_message="The first extraObjects entry must be a NetworkPolicy"
+		condition=alltrue([for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o.kind == "NetworkPolicy"])
+		error_message="Every extraObjects entry must be a NetworkPolicy"
 	}
 	assert {
-		condition=!contains(keys(yamldecode(helm_release.argocd.values[0]).extraObjects[0].metadata), "namespace")
-		error_message="The extraObjects NetworkPolicy must omit metadata.namespace so it inherits the Helm release namespace"
+		condition=alltrue([for o in yamldecode(helm_release.argocd.values[0]).extraObjects : !contains(keys(o.metadata), "namespace")])
+		error_message="Every extraObjects NetworkPolicy must omit metadata.namespace so it inherits the Helm release namespace"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.podSelector.matchLabels["app.kubernetes.io/name"] == "argocd-server"
-		error_message="The first NetworkPolicy must select the argocd-server pods"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-server-ingress"][0].spec.podSelector.matchLabels["app.kubernetes.io/name"] == "argocd-server"
+		error_message="argocd-server-ingress must select the argocd-server pods"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.gateway_namespace
-		error_message="The first ingress rule must allow only the configured gateway namespace"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-server-ingress"][0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.gateway_namespace
+		error_message="argocd-server-ingress's first rule must allow only the configured gateway namespace"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[0].from[0].podSelector.matchLabels["gateway.envoyproxy.io/owning-gateway-namespace"] == var.argocd_namespace
-		error_message="The Gateway ingress rule must scope to the Envoy proxy that owns this namespace's Gateway, not any proxy in envoy-gateway-system"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-server-ingress"][0].spec.ingress[0].from[0].podSelector.matchLabels["gateway.envoyproxy.io/owning-gateway-namespace"] == var.argocd_namespace
+		error_message="argocd-server-ingress's Gateway rule must scope to the Envoy proxy that owns this namespace's Gateway, not any proxy in envoy-gateway-system"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.observability_namespace
-		error_message="The second ingress rule must allow only the observability namespace for metrics scraping"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-server-ingress"][0].spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.observability_namespace
+		error_message="argocd-server-ingress's second rule must allow only the observability namespace for metrics scraping"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[1].kind == "NetworkPolicy" && yamldecode(helm_release.argocd.values[0]).extraObjects[1].spec.podSelector == {}
-		error_message="The second extraObjects entry must be a namespace-wide default-deny (empty podSelector matches every pod in the namespace)"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-applicationset-controller-ingress"][0].spec.podSelector.matchLabels["app.kubernetes.io/name"] == "argocd-applicationset-controller"
+		error_message="argocd-applicationset-controller-ingress must select the argocd-applicationset-controller pods"
 	}
 	assert {
-		condition=!contains(keys(yamldecode(helm_release.argocd.values[0]).extraObjects[1].spec), "ingress")
-		error_message="The default-deny policy must declare zero ingress rules — any ingress key at all would allow something"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-applicationset-controller-ingress"][0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.observability_namespace && [for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-applicationset-controller-ingress"][0].spec.ingress[0].ports[0].port == "metrics"
+		error_message="argocd-applicationset-controller-ingress must allow only the observability namespace, only on the metrics port"
+	}
+	assert {
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-notifications-controller-ingress"][0].spec.podSelector.matchLabels["app.kubernetes.io/name"] == "argocd-notifications-controller"
+		error_message="argocd-notifications-controller-ingress must select the argocd-notifications-controller pods"
+	}
+	assert {
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-notifications-controller-ingress"][0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.observability_namespace && [for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-notifications-controller-ingress"][0].spec.ingress[0].ports[0].port == "metrics"
+		error_message="argocd-notifications-controller-ingress must allow only the observability namespace, only on the metrics port"
+	}
+	assert {
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "default-deny-ingress"][0].spec.podSelector == {}
+		error_message="default-deny-ingress must have an empty podSelector (matches every pod in the namespace)"
+	}
+	assert {
+		condition=!contains(keys([for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "default-deny-ingress"][0].spec), "ingress")
+		error_message="default-deny-ingress must declare zero ingress rules — any ingress key at all would allow something"
 	}
 	command=plan
 }
 run "should_honor_custom_gateway_and_observability_namespaces" {
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-gateway"
-		error_message="A custom gateway_namespace must flow into the argocd-server NetworkPolicy"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-server-ingress"][0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-gateway"
+		error_message="A custom gateway_namespace must flow into argocd-server-ingress"
 	}
 	assert {
-		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-observability"
-		error_message="A custom observability_namespace must flow into the argocd-server NetworkPolicy"
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-server-ingress"][0].spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-observability"
+		error_message="A custom observability_namespace must flow into argocd-server-ingress"
+	}
+	assert {
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-applicationset-controller-ingress"][0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-observability"
+		error_message="A custom observability_namespace must also flow into argocd-applicationset-controller-ingress"
+	}
+	assert {
+		condition=[for o in yamldecode(helm_release.argocd.values[0]).extraObjects : o if o.metadata.name == "argocd-notifications-controller-ingress"][0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-observability"
+		error_message="A custom observability_namespace must also flow into argocd-notifications-controller-ingress"
 	}
 	command=plan
 	variables {

--- a/cloud/terraform/gcp/gitops/platform/tests/argocd.tftest.hcl
+++ b/cloud/terraform/gcp/gitops/platform/tests/argocd.tftest.hcl
@@ -50,6 +50,95 @@ run "should_honor_a_custom_argocd_namespace" {
 		argocd_namespace="gitops"
 	}
 }
+run "should_enable_per_component_network_policies_without_the_global_toggle" {
+	assert {
+		condition=!contains(keys(yamldecode(helm_release.argocd.values[0])), "global")
+		error_message="global.networkPolicy.create must NOT be used — the argo-cd 9.5.16 chart ORs it with server.networkPolicy.create (see argocd-server/networkpolicy.yaml), so there is no values combination that both enables the chart-wide default-deny and suppresses argocd-server's own allow-all rule. Each component must be toggled individually instead"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).controller.networkPolicy.create == true
+		error_message="controller.networkPolicy.create must be true so the chart renders its scoped NetworkPolicy"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).repoServer.networkPolicy.create == true
+		error_message="repoServer.networkPolicy.create must be true so the chart renders its scoped NetworkPolicy"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).redis.networkPolicy.create == true
+		error_message="redis.networkPolicy.create must be true so the chart renders its scoped NetworkPolicy"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).dex.networkPolicy.create == true
+		error_message="dex.networkPolicy.create must be true so the chart renders its scoped NetworkPolicy"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).applicationSet.networkPolicy.create == true && yamldecode(helm_release.argocd.values[0]).applicationSet.metrics.enabled == true
+		error_message="applicationSet needs both networkPolicy.create and metrics.enabled — the chart's template ANDs (create OR global.create) with (metrics.enabled OR ingress.enabled), so metrics.enabled alone or networkPolicy.create alone is not enough"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).notifications.networkPolicy.create == true && yamldecode(helm_release.argocd.values[0]).notifications.metrics.enabled == true
+		error_message="notifications needs both networkPolicy.create and metrics.enabled — same AND condition as applicationSet"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).server.networkPolicy.create == false
+		error_message="server.networkPolicy.create must stay false — the chart's own argocd-server NetworkPolicy is unconditionally ingress: [{}] (allow from anywhere); the manual extraObjects policy is the only thing that should govern this pod's ingress"
+	}
+	command=plan
+}
+run "should_scope_the_manual_argocd_server_networkpolicy_correctly" {
+	assert {
+		condition=length(yamldecode(helm_release.argocd.values[0]).extraObjects) == 2
+		error_message="Two extra manifests are expected: the scoped argocd-server policy and the namespace-wide default-deny that replaces the chart's own (unusable) global.defaultDenyIngress"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].kind == "NetworkPolicy"
+		error_message="The first extraObjects entry must be a NetworkPolicy"
+	}
+	assert {
+		condition=!contains(keys(yamldecode(helm_release.argocd.values[0]).extraObjects[0].metadata), "namespace")
+		error_message="The extraObjects NetworkPolicy must omit metadata.namespace so it inherits the Helm release namespace"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.podSelector.matchLabels["app.kubernetes.io/name"] == "argocd-server"
+		error_message="The first NetworkPolicy must select the argocd-server pods"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.gateway_namespace
+		error_message="The first ingress rule must allow only the configured gateway namespace"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[0].from[0].podSelector.matchLabels["gateway.envoyproxy.io/owning-gateway-namespace"] == var.argocd_namespace
+		error_message="The Gateway ingress rule must scope to the Envoy proxy that owns this namespace's Gateway, not any proxy in envoy-gateway-system"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == var.observability_namespace
+		error_message="The second ingress rule must allow only the observability namespace for metrics scraping"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[1].kind == "NetworkPolicy" && yamldecode(helm_release.argocd.values[0]).extraObjects[1].spec.podSelector == {}
+		error_message="The second extraObjects entry must be a namespace-wide default-deny (empty podSelector matches every pod in the namespace)"
+	}
+	assert {
+		condition=!contains(keys(yamldecode(helm_release.argocd.values[0]).extraObjects[1].spec), "ingress")
+		error_message="The default-deny policy must declare zero ingress rules — any ingress key at all would allow something"
+	}
+	command=plan
+}
+run "should_honor_custom_gateway_and_observability_namespaces" {
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-gateway"
+		error_message="A custom gateway_namespace must flow into the argocd-server NetworkPolicy"
+	}
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).extraObjects[0].spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"] == "custom-observability"
+		error_message="A custom observability_namespace must flow into the argocd-server NetworkPolicy"
+	}
+	command=plan
+	variables {
+		gateway_namespace="custom-gateway"
+		observability_namespace="custom-observability"
+	}
+}
 variables {
 	argo_workflows_helm_chart_version="1.0.10"
 	argocd_helm_chart_version="9.5.16"

--- a/cloud/terraform/gcp/gitops/platform/variables.tf
+++ b/cloud/terraform/gcp/gitops/platform/variables.tf
@@ -29,6 +29,10 @@ variable "external_secrets_namespace" {
 	default="external-secrets-system"
 	type=string
 }
+variable "gateway_namespace" {
+	default="envoy-gateway-system"
+	type=string
+}
 variable "keda_enabled" {
 	default=false
 	type=bool
@@ -38,6 +42,10 @@ variable "keda_helm_chart_version" {
 }
 variable "keda_namespace" {
 	default="keda-system"
+	type=string
+}
+variable "observability_namespace" {
+	default="observability"
 	type=string
 }
 variable "project_id" {


### PR DESCRIPTION
## Summary
- Enables per-component NetworkPolicy on the `argo-cd` chart (controller, repo-server, redis, dex) via `networkPolicy.create=true` instead of the `global.networkPolicy` toggle — that toggle ORs with `server.networkPolicy.create` in this chart version with no override, so it unconditionally renders an allow-all `argocd-server` policy once enabled (verified by rendering the chart with `helm template`).
- Adds four NetworkPolicy manifests via the chart's `extraObjects` (same Helm release, no separate Terraform resource): `argocd-server-ingress` (scoped to the envoy-gateway-system Gateway proxy + observability namespace), `argocd-applicationset-controller-ingress` and `argocd-notifications-controller-ingress` (scoped to observability on the metrics port, without flipping `metrics.enabled` — that flag also turns on the chart's Prometheus metrics server as a side effect), and `default-deny-ingress` (namespace-wide default-deny, since the chart's own default-deny requires the unusable `global` toggle).
- Adds `gateway_namespace` and `observability_namespace` variables to `gitops/platform/variables.tf`, matching the existing defaults in the sibling `gitops/resources` module.

## Test plan
- [x] `terraform validate`
- [x] `terraform test` (6 cases covering the new behavior, 16/16 passing across the module)
- [x] `helm template` against the real `argo-cd` 9.5.16 chart — confirms 8 NetworkPolicy objects, no permissive rule for `argocd-server`
- [x] Applied live to a sandbox cluster (`infosec-rafapdemelo`) via `helm upgrade` — all 7 ArgoCD pods stayed `Running`/`0 restarts`
- [x] Live connectivity test from the `liferay-default-dev` namespace against `argocd-server` — connection now times out (previously succeeded per the InfoSec audit finding)