### PR TITLE
LPD-102896 Search fieldset picker against the server instead of the local cache

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/FormBuilder.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/FormBuilder.js
@@ -67,7 +67,7 @@ export function FormBuilder() {
 			}
 
 			const groupFieldSetsPromise =
-				groupId === themeDisplay.getCompanyGroupId()
+				Number(groupId) === Number(themeDisplay.getCompanyGroupId())
 					? Promise.resolve({})
 					: getItem(
 							`/o/data-engine/v2.0/data-definitions/by-content-type/${contentType}?page=1&pageSize=250`

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-sets/FieldSetList.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-sets/FieldSetList.js
@@ -5,37 +5,30 @@
 
 import ClayButton from '@clayui/button';
 import ClayEmptyState from '@clayui/empty-state';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {
 	DRAG_TYPES,
 	EVENT_TYPES,
+	useConfig,
 	useForm,
 	useFormState,
 } from 'data-engine-js-components-web';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
+import {getItems} from '../../utils/client.es';
 import {getLocalizedValue, getPluralMessage, sub} from '../../utils/lang.es';
-import {getSearchRegex} from '../../utils/search.es';
 import FieldType from '../field-types/FieldType.es';
 import FieldSetModal from './FieldSetModal';
 import useDeleteFieldSet from './actions/useDeleteFieldSet.es';
 import usePropagateFieldSet from './actions/usePropagateFieldSet.es';
 
 function getSortedFieldsets(fieldsets) {
-	return fieldsets.sort((a, b) => {
+	return [...fieldsets].sort((a, b) => {
 		const localizedValueA = getLocalizedValue(a.defaultLanguageId, a.name);
 		const localizedValueB = getLocalizedValue(b.defaultLanguageId, b.name);
 
 		return localizedValueA.localeCompare(localizedValueB);
 	});
-}
-
-function getFilteredFieldsets(fieldsets, keywords) {
-	const regex = getSearchRegex(keywords);
-	const filteredFieldsets = fieldsets.filter(({defaultLanguageId, name}) =>
-		regex.test(getLocalizedValue(defaultLanguageId, name))
-	);
-
-	return getSortedFieldsets(filteredFieldsets);
 }
 
 export default function FieldSetList({searchTerm}) {
@@ -45,7 +38,88 @@ export default function FieldSetList({searchTerm}) {
 	const dispatch = useForm();
 	const deleteFieldSet = useDeleteFieldSet();
 	const propagateFieldSet = usePropagateFieldSet();
-	const filteredFieldsets = getFilteredFieldsets(fieldSets, searchTerm);
+
+	const {contentType, dataDefinitionId, groupId} = useConfig();
+	const [loading, setLoading] = useState(false);
+	const [searchResults, setSearchResults] = useState(null);
+
+	useEffect(() => {
+		if (!searchTerm) {
+			setLoading(false);
+			setSearchResults(null);
+
+			return;
+		}
+
+		const abortController = new AbortController();
+
+		const timeoutId = setTimeout(async () => {
+			setLoading(true);
+
+			try {
+				const {signal} = abortController;
+
+				const siteFieldSetsPromise = groupId
+					? getItems(
+							`/o/data-engine/v2.0/sites/${groupId}/data-definitions/by-content-type/${contentType}`,
+							searchTerm,
+							{signal}
+						)
+					: Promise.resolve([]);
+
+				const globalFieldSetsPromise =
+					Number(groupId) === Number(themeDisplay.getCompanyGroupId())
+						? Promise.resolve([])
+						: getItems(
+								`/o/data-engine/v2.0/data-definitions/by-content-type/${contentType}`,
+								searchTerm,
+								{signal}
+							);
+
+				const [siteFieldSets, globalFieldSets] = await Promise.all([
+					siteFieldSetsPromise,
+					globalFieldSetsPromise,
+				]);
+
+				if (!signal.aborted) {
+					setSearchResults(
+						[...siteFieldSets, ...globalFieldSets].filter(
+							({id}) => id !== parseInt(dataDefinitionId, 10)
+						)
+					);
+				}
+			}
+			catch (error) {
+				if (!abortController.signal.aborted) {
+					if (process.env.NODE_ENV === 'development') {
+						console.warn('[FieldSetList] search failed:', error);
+					}
+
+					setSearchResults([]);
+				}
+			}
+			finally {
+
+				// Skip when aborted: the next effect run (new search term) or
+				// the empty-term early return will reset loading correctly.
+
+				if (!abortController.signal.aborted) {
+					setLoading(false);
+				}
+			}
+		}, 300);
+
+		return () => {
+			abortController.abort();
+			clearTimeout(timeoutId);
+		};
+	}, [contentType, dataDefinitionId, groupId, searchTerm]);
+
+	const displayedFieldsets = getSortedFieldsets(
+		searchTerm ? searchResults ?? [] : fieldSets
+	);
+
+	const isPendingSearch = !!searchTerm && searchResults === null && !loading;
 
 	const fieldSetsInUse = new Set();
 	dataDefinition.dataDefinitionFields.forEach(
@@ -76,77 +150,83 @@ export default function FieldSetList({searchTerm}) {
 
 	return (
 		<>
-			{filteredFieldsets.length ? (
+			{!!displayedFieldsets.length || loading || isPendingSearch ? (
 				<>
 					<CreateNewFieldsetButton />
 
 					<div className="mt-3">
-						{filteredFieldsets.map((fieldSet) => {
-							const actions = [
-								{
-									action: () => toggleFieldSet(fieldSet),
-									name: Liferay.Language.get('edit'),
-								},
-								{
-									action: () =>
-										propagateFieldSet({
-											fieldSet,
-											isDeleteAction: true,
-											modal: {
-												actionMessage:
-													Liferay.Language.get(
-														'delete'
-													),
-												fieldSetMessage:
-													Liferay.Language.get(
-														'the-fieldset-will-be-deleted-permanently-from'
-													),
-												headerMessage:
-													Liferay.Language.get(
-														'delete'
-													),
-												status: 'danger',
-												warningMessage:
-													Liferay.Language.get(
-														'this-action-may-erase-data-permanently'
-													),
-											},
-											onPropagate: deleteFieldSet,
-										}),
-									name: Liferay.Language.get('delete'),
-								},
-							];
-							const description = getPluralMessage(
-								Liferay.Language.get('x-field'),
-								Liferay.Language.get('x-fields'),
-								fieldSet.dataDefinitionFields.length
-							);
-							const disabled = fieldSetsInUse.has(fieldSet.id);
-							const label = getLocalizedValue(
-								fieldSet.defaultLanguageId,
-								fieldSet.name
-							);
-							const onDoubleClick = () => {
-								dispatch({
-									payload: {fieldSet},
-									type: EVENT_TYPES.FIELD_SET.ADD,
-								});
-							};
+						{loading || isPendingSearch ? (
+							<ClayLoadingIndicator />
+						) : (
+							displayedFieldsets.map((fieldSet) => {
+								const actions = [
+									{
+										action: () => toggleFieldSet(fieldSet),
+										name: Liferay.Language.get('edit'),
+									},
+									{
+										action: () =>
+											propagateFieldSet({
+												fieldSet,
+												isDeleteAction: true,
+												modal: {
+													actionMessage:
+														Liferay.Language.get(
+															'delete'
+														),
+													fieldSetMessage:
+														Liferay.Language.get(
+															'the-fieldset-will-be-deleted-permanently-from'
+														),
+													headerMessage:
+														Liferay.Language.get(
+															'delete'
+														),
+													status: 'danger',
+													warningMessage:
+														Liferay.Language.get(
+															'this-action-may-erase-data-permanently'
+														),
+												},
+												onPropagate: deleteFieldSet,
+											}),
+										name: Liferay.Language.get('delete'),
+									},
+								];
+								const description = getPluralMessage(
+									Liferay.Language.get('x-field'),
+									Liferay.Language.get('x-fields'),
+									fieldSet.dataDefinitionFields.length
+								);
+								const disabled = fieldSetsInUse.has(
+									fieldSet.id
+								);
+								const label = getLocalizedValue(
+									fieldSet.defaultLanguageId,
+									fieldSet.name
+								);
+								const onDoubleClick = () => {
+									dispatch({
+										payload: {fieldSet},
+										type: EVENT_TYPES.FIELD_SET.ADD,
+									});
+								};
 
-							return (
-								<FieldType
-									actions={actions}
-									description={description}
-									disabled={disabled}
-									dragType={DRAG_TYPES.DRAG_FIELDSET_ADD}
-									fieldSet={fieldSet}
-									icon="forms"
-									key={fieldSet.dataDefinitionKey}
-									label={label}
-									onDoubleClick={onDoubleClick}
-								/>
-							);
-						})}
+								return (
+									<FieldType
+										actions={actions}
+										description={description}
+										disabled={disabled}
+										dragType={DRAG_TYPES.DRAG_FIELDSET_ADD}
+										fieldSet={fieldSet}
+										icon="forms"
+										key={fieldSet.dataDefinitionKey}
+										label={label}
+										onDoubleClick={onDoubleClick}
+									/>
+								);
+							})
+						)}
 					</div>
 				</>
 			) : (

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/utils/client.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/utils/client.es.js
@@ -98,11 +98,45 @@ export function request(endpoint, method = 'GET') {
 	});
 }
 
-export function getItem(endpoint) {
+export function getItem(endpoint, {signal} = {}) {
 	return fetch(getURL(endpoint), {
 		headers: HEADERS,
 		method: 'GET',
+		signal,
 	}).then((response) => response.json());
+}
+
+export async function getItems(
+	baseURL,
+	keywords = '',
+	{pageSize = 250, signal} = {}
+) {
+
+	// baseURL must not contain a query string
+
+	const encodedKeywords = encodeURIComponent(keywords);
+
+	const {items = [], totalCount = 0} = await getItem(
+		`${baseURL}?page=1&pageSize=${pageSize}&keywords=${encodedKeywords}`,
+		{signal}
+	);
+
+	if (totalCount <= pageSize) {
+		return items;
+	}
+
+	const pages = Math.ceil(totalCount / pageSize);
+
+	const rest = await Promise.all(
+		Array.from({length: pages - 1}, (_, i) =>
+			getItem(
+				`${baseURL}?page=${i + 2}&pageSize=${pageSize}&keywords=${encodedKeywords}`,
+				{signal}
+			)
+		)
+	);
+
+	return [...items, ...rest.flatMap(({items: pageItems = []}) => pageItems)];
 }
 
 export function updateItem(endpoint, item, params) {

--- a/modules/apps/data-engine/data-engine-taglib/test/js/components/field-sets/FieldSetList.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/test/js/components/field-sets/FieldSetList.es.js
@@ -1,0 +1,289 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, cleanup, render} from '@testing-library/react';
+import {useConfig, useForm, useFormState} from 'data-engine-js-components-web';
+import React from 'react';
+
+import FieldSetList from '../../../../src/main/resources/META-INF/resources/js/components/field-sets/FieldSetList';
+import {getItems} from '../../../../src/main/resources/META-INF/resources/js/utils/client.es';
+
+jest.mock('data-engine-js-components-web', () => ({
+	DRAG_TYPES: {DRAG_FIELDSET_ADD: 'DRAG_FIELDSET_ADD'},
+	EVENT_TYPES: {FIELD_SET: {ADD: 'FIELD_SET.ADD'}},
+	useConfig: jest.fn(),
+	useForm: jest.fn(),
+	useFormState: jest.fn(),
+}));
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/utils/client.es',
+	() => ({
+		getItems: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/components/field-types/FieldType.es',
+	() => {
+		const React = require('react');
+
+		return {
+			__esModule: true,
+			default: ({label}) =>
+				React.createElement(
+					'div',
+					{'data-testid': 'field-type'},
+					label
+				),
+		};
+	}
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/components/field-sets/FieldSetModal',
+	() => ({
+		__esModule: true,
+		default: () => null,
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/components/field-sets/actions/useDeleteFieldSet.es',
+	() => ({
+		__esModule: true,
+		default: () => jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/components/field-sets/actions/usePropagateFieldSet.es',
+	() => ({
+		__esModule: true,
+		default: () => jest.fn(),
+	})
+);
+
+function makeFieldSet(id, name) {
+	return {
+		dataDefinitionFields: [],
+		dataDefinitionKey: String(id),
+		defaultLanguageId: 'en_US',
+		id,
+		name: {en_US: name},
+	};
+}
+
+const defaultConfig = {
+	contentType: 'journal',
+	dataDefinitionId: '1',
+	groupId: '20120',
+};
+
+const defaultDefinition = {
+	dataDefinitionFields: [],
+};
+
+describe('FieldSetList — server-side search', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+
+		themeDisplay.getCompanyGroupId = jest.fn(() => defaultConfig.groupId);
+
+		useConfig.mockReturnValue(defaultConfig);
+		useForm.mockReturnValue(jest.fn());
+		useFormState.mockReturnValue({
+			dataDefinition: defaultDefinition,
+			fieldSets: [],
+		});
+
+		getItems.mockResolvedValue([]);
+	});
+
+	afterEach(() => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+		jest.clearAllMocks();
+		cleanup();
+	});
+
+	it('shows the empty state when there are no fieldsets and no search term', () => {
+		const {queryByText} = render(<FieldSetList searchTerm="" />);
+
+		expect(queryByText('there-are-no-fieldsets')).toBeTruthy();
+	});
+
+	it('renders local fieldsets when no search term is active', () => {
+		const fieldSets = [makeFieldSet(10, 'Alpha'), makeFieldSet(20, 'Beta')];
+
+		useFormState.mockReturnValue({
+			dataDefinition: defaultDefinition,
+			fieldSets,
+		});
+
+		const {getAllByTestId, queryByText} = render(
+			<FieldSetList searchTerm="" />
+		);
+
+		expect(getAllByTestId('field-type')).toHaveLength(2);
+		expect(queryByText('Alpha')).toBeTruthy();
+		expect(queryByText('Beta')).toBeTruthy();
+	});
+
+	it('shows a loading indicator during the debounce window before the fetch starts', () => {
+		const {container, queryByText} = render(
+			<FieldSetList searchTerm="alpha" />
+		);
+
+		expect(container.querySelector('.loading-animation')).toBeTruthy();
+		expect(queryByText('no-results-found')).toBeFalsy();
+		expect(queryByText('there-are-no-fieldsets')).toBeFalsy();
+	});
+
+	it('calls getItems with the search term after the debounce delay', async () => {
+		render(<FieldSetList searchTerm="alpha" />);
+
+		expect(getItems).not.toHaveBeenCalled();
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(getItems).toHaveBeenCalledWith(
+			expect.stringContaining('journal'),
+			'alpha',
+			expect.objectContaining({signal: expect.any(AbortSignal)})
+		);
+	});
+
+	it('displays search results returned by the server', async () => {
+		const results = [makeFieldSet(10, 'Alpha'), makeFieldSet(20, 'Beta')];
+
+		getItems.mockResolvedValue(results);
+
+		const {getAllByTestId, queryByText} = render(
+			<FieldSetList searchTerm="alpha" />
+		);
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(getAllByTestId('field-type')).toHaveLength(2);
+		expect(queryByText('Alpha')).toBeTruthy();
+		expect(queryByText('Beta')).toBeTruthy();
+	});
+
+	it('shows the "no results found" empty state when the server returns no matches', async () => {
+		getItems.mockResolvedValue([]);
+
+		const {queryByText} = render(<FieldSetList searchTerm="zzz" />);
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(queryByText('no-results-found')).toBeTruthy();
+	});
+
+	it('restores the local fieldset list when the search term is cleared', async () => {
+		const fieldSets = [makeFieldSet(10, 'Alpha')];
+
+		useFormState.mockReturnValue({
+			dataDefinition: defaultDefinition,
+			fieldSets,
+		});
+
+		getItems.mockResolvedValue([makeFieldSet(20, 'ServerResult')]);
+
+		const {getAllByTestId, queryByText, rerender} = render(
+			<FieldSetList searchTerm="alpha" />
+		);
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(queryByText('ServerResult')).toBeTruthy();
+
+		await act(async () => {
+			rerender(<FieldSetList searchTerm="" />);
+		});
+
+		expect(getAllByTestId('field-type')).toHaveLength(1);
+		expect(queryByText('Alpha')).toBeTruthy();
+		expect(queryByText('ServerResult')).toBeFalsy();
+	});
+
+	it('fetches both site and global fieldsets when groupId differs from companyGroupId', async () => {
+		useConfig.mockReturnValue({
+			...defaultConfig,
+			groupId: '99999',
+		});
+
+		const siteResult = makeFieldSet(10, 'Site');
+		const globalResult = makeFieldSet(20, 'Global');
+
+		getItems
+			.mockResolvedValueOnce([siteResult])
+			.mockResolvedValueOnce([globalResult]);
+
+		const {queryByText} = render(<FieldSetList searchTerm="test" />);
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(getItems).toHaveBeenCalledTimes(2);
+		expect(queryByText('Site')).toBeTruthy();
+		expect(queryByText('Global')).toBeTruthy();
+	});
+
+	it('excludes the current data definition from search results', async () => {
+		const self = makeFieldSet(1, 'Self');
+		const other = makeFieldSet(2, 'Other');
+
+		getItems.mockResolvedValue([self, other]);
+
+		const {queryByText} = render(<FieldSetList searchTerm="x" />);
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(queryByText('Self')).toBeFalsy();
+		expect(queryByText('Other')).toBeTruthy();
+	});
+
+	it('shows the "no results found" empty state when the fetch fails', async () => {
+		getItems.mockRejectedValue(new Error('network error'));
+
+		const {queryByText} = render(<FieldSetList searchTerm="alpha" />);
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(queryByText('no-results-found')).toBeTruthy();
+	});
+
+	it('fires only one request when the search term changes before the debounce fires', async () => {
+		const {rerender} = render(<FieldSetList searchTerm="a" />);
+
+		rerender(<FieldSetList searchTerm="ab" />);
+		rerender(<FieldSetList searchTerm="abc" />);
+
+		await act(async () => {
+			jest.advanceTimersByTime(300);
+		});
+
+		expect(getItems).toHaveBeenCalledTimes(1);
+		expect(getItems).toHaveBeenCalledWith(
+			expect.any(String),
+			'abc',
+			expect.any(Object)
+		);
+	});
+});

--- a/modules/apps/data-engine/data-engine-taglib/test/js/utils/client.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/test/js/utils/client.es.js
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+import {getItems} from '../../../src/main/resources/META-INF/resources/js/utils/client.es';
+
+jest.mock('frontend-js-web', () => ({
+	fetch: jest.fn(),
+}));
+
+function makeResponse(data) {
+	return {
+		json: () => Promise.resolve(data),
+	};
+}
+
+describe('getItems', () => {
+	beforeEach(() => {
+		fetch.mockReset();
+	});
+
+	it('returns all items when totalCount fits within a single page', async () => {
+		const items = [{id: 1}, {id: 2}];
+
+		fetch.mockResolvedValue(makeResponse({items, totalCount: 2}));
+
+		const result = await getItems('/o/data-engine/v2.0/test-api');
+
+		expect(result).toEqual(items);
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('fetches additional pages and concatenates items when totalCount exceeds pageSize', async () => {
+		const page1Items = [{id: 1}, {id: 2}];
+		const page2Items = [{id: 3}];
+
+		fetch
+			.mockResolvedValueOnce(
+				makeResponse({items: page1Items, totalCount: 3})
+			)
+			.mockResolvedValueOnce(
+				makeResponse({items: page2Items, totalCount: 3})
+			);
+
+		const result = await getItems('/o/data-engine/v2.0/test-api', '', {
+			pageSize: 2,
+		});
+
+		const [page1Url] = fetch.mock.calls[0];
+		const [page2Url] = fetch.mock.calls[1];
+
+		expect(page1Url).toContain('page=1');
+		expect(page2Url).toContain('page=2');
+		expect(result).toEqual([...page1Items, ...page2Items]);
+		expect(fetch).toHaveBeenCalledTimes(2);
+	});
+
+	it('defaults keywords to an empty string when the argument is omitted', async () => {
+		fetch.mockResolvedValue(makeResponse({items: [], totalCount: 0}));
+
+		await getItems('/o/data-engine/v2.0/test-api');
+
+		const [url] = fetch.mock.calls[0];
+
+		expect(url).toContain('keywords=');
+		expect(url).not.toContain('keywords=undefined');
+	});
+
+	it('threads the AbortSignal through to every fetch call', async () => {
+		const page1Items = [{id: 1}, {id: 2}];
+		const page2Items = [{id: 3}];
+
+		fetch
+			.mockResolvedValueOnce(
+				makeResponse({items: page1Items, totalCount: 3})
+			)
+			.mockResolvedValueOnce(
+				makeResponse({items: page2Items, totalCount: 3})
+			);
+
+		const controller = new AbortController();
+
+		await getItems('/o/data-engine/v2.0/test-api', '', {
+			pageSize: 2,
+			signal: controller.signal,
+		});
+
+		expect(fetch).toHaveBeenCalledTimes(2);
+
+		fetch.mock.calls.forEach(([, options]) => {
+			expect(options.signal).toBe(controller.signal);
+		});
+	});
+});


### PR DESCRIPTION
LPD-102896 Search fieldset picker against the server instead of the local cache

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-102896

The fieldset picker in the Web Content Structure builder only searched through the first 250 pre-loaded structures. Any structure beyond that initial page was invisible to search, so users could not find fieldsets that existed but were not in the first batch.

# How am I fixing it?

The picker now queries the Data Engine REST API directly with the user's search term instead of filtering the pre-fetched list client-side. A 300 ms debounce prevents a request on every keystroke, and an AbortController cancels any in-flight request when the term changes before the previous fetch completes. A shared `getItems` utility handles transparent pagination so all matching structures are returned regardless of how many pages they span. While the fetch is in flight (including during the debounce window), a loading indicator is shown so the UI never flashes a false "no results" state.

# How can you verify that it works?

Run the included automated tests.